### PR TITLE
Add toast notifications and loading skeletons (#20)

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { api, getToken, setToken } from "@/lib/api";
+import { useToast } from "@/components/ToastProvider";
+import { SkeletonTableRow } from "@/components/Skeleton";
 
 type Tab = "materials" | "suppliers" | "pricing";
 
@@ -62,10 +64,20 @@ const tdStyle = {
 function MaterialsTab() {
   const [materials, setMaterials] = useState<Material[]>([]);
   const [filter, setFilter] = useState("");
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
 
   useEffect(() => {
-    api.getMaterials().then(setMaterials).catch(console.error);
-  }, []);
+    api.getMaterials()
+      .then((mats) => {
+        setMaterials(mats);
+        setLoading(false);
+      })
+      .catch((err) => {
+        toast(err instanceof Error ? err.message : "Materiaalien lataus epaonnistui / Failed to load materials", "error");
+        setLoading(false);
+      });
+  }, [toast]);
 
   const filtered = materials.filter(
     (m) =>
@@ -101,77 +113,83 @@ function MaterialsTab() {
             </tr>
           </thead>
           <tbody>
-            {filtered.map((m, i) => {
-              const primary = m.pricing?.find((p) => p.is_primary);
-              const altCount = (m.pricing?.length || 0) - (primary ? 1 : 0);
-              return (
-                <tr
-                  key={m.id}
-                  style={{
-                    animation: `fadeIn 0.2s ease-out ${i * 0.02}s both`,
-                    transition: "background 0.1s",
-                  }}
-                  onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
-                >
-                  <td style={{ ...tdStyle, padding: "6px 8px" }}>
-                    {m.image_url ? (
-                      <img
-                        src={m.image_url}
-                        alt={m.name}
-                        style={{
-                          width: 36,
-                          height: 36,
-                          borderRadius: 6,
-                          objectFit: "cover",
-                          display: "block",
-                        }}
-                      />
-                    ) : (
-                      <div
-                        style={{
-                          width: 36,
-                          height: 36,
-                          borderRadius: 6,
-                          background: "var(--bg-elevated)",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          color: "var(--text-muted)",
-                          fontSize: 10,
-                        }}
-                      >
-                        -
-                      </div>
-                    )}
-                  </td>
-                  <td style={{ ...tdStyle, fontWeight: 500 }}>{m.name}</td>
-                  <td style={{ ...tdStyle, color: "var(--text-secondary)" }}>{m.category_name}</td>
-                  <td style={{ ...tdStyle, fontFamily: "var(--font-mono)", fontSize: 12 }}>
-                    {((m.waste_factor - 1) * 100).toFixed(0)}%
-                  </td>
-                  <td style={tdStyle}>
-                    {primary ? (
-                      <span style={{ color: "var(--success)", fontFamily: "var(--font-mono)", fontWeight: 500, fontSize: 12 }}>
-                        {primary.unit_price.toFixed(2)} {primary.currency}/{primary.unit}
-                      </span>
-                    ) : (
-                      <span className="badge badge-danger">Ei hintaa</span>
-                    )}
-                  </td>
-                  <td style={{ ...tdStyle, color: "var(--text-muted)" }}>
-                    {primary?.supplier_name || "-"}
-                  </td>
-                  <td style={tdStyle}>
-                    {altCount > 0 ? (
-                      <span className="badge badge-amber">+{altCount}</span>
-                    ) : (
-                      <span style={{ color: "var(--text-muted)" }}>-</span>
-                    )}
-                  </td>
-                </tr>
-              );
-            })}
+            {loading ? (
+              Array.from({ length: 6 }).map((_, i) => (
+                <SkeletonTableRow key={i} columns={7} delay={i * 0.05} />
+              ))
+            ) : (
+              filtered.map((m, i) => {
+                const primary = m.pricing?.find((p) => p.is_primary);
+                const altCount = (m.pricing?.length || 0) - (primary ? 1 : 0);
+                return (
+                  <tr
+                    key={m.id}
+                    style={{
+                      animation: `fadeIn 0.2s ease-out ${i * 0.02}s both`,
+                      transition: "background 0.1s",
+                    }}
+                    onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+                  >
+                    <td style={{ ...tdStyle, padding: "6px 8px" }}>
+                      {m.image_url ? (
+                        <img
+                          src={m.image_url}
+                          alt={m.name}
+                          style={{
+                            width: 36,
+                            height: 36,
+                            borderRadius: 6,
+                            objectFit: "cover",
+                            display: "block",
+                          }}
+                        />
+                      ) : (
+                        <div
+                          style={{
+                            width: 36,
+                            height: 36,
+                            borderRadius: 6,
+                            background: "var(--bg-elevated)",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            color: "var(--text-muted)",
+                            fontSize: 10,
+                          }}
+                        >
+                          -
+                        </div>
+                      )}
+                    </td>
+                    <td style={{ ...tdStyle, fontWeight: 500 }}>{m.name}</td>
+                    <td style={{ ...tdStyle, color: "var(--text-secondary)" }}>{m.category_name}</td>
+                    <td style={{ ...tdStyle, fontFamily: "var(--font-mono)", fontSize: 12 }}>
+                      {((m.waste_factor - 1) * 100).toFixed(0)}%
+                    </td>
+                    <td style={tdStyle}>
+                      {primary ? (
+                        <span style={{ color: "var(--success)", fontFamily: "var(--font-mono)", fontWeight: 500, fontSize: 12 }}>
+                          {primary.unit_price.toFixed(2)} {primary.currency}/{primary.unit}
+                        </span>
+                      ) : (
+                        <span className="badge badge-danger">Ei hintaa</span>
+                      )}
+                    </td>
+                    <td style={{ ...tdStyle, color: "var(--text-muted)" }}>
+                      {primary?.supplier_name || "-"}
+                    </td>
+                    <td style={tdStyle}>
+                      {altCount > 0 ? (
+                        <span className="badge badge-amber">+{altCount}</span>
+                      ) : (
+                        <span style={{ color: "var(--text-muted)" }}>-</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
           </tbody>
         </table>
       </div>
@@ -181,10 +199,20 @@ function MaterialsTab() {
 
 function SuppliersTab() {
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
 
   useEffect(() => {
-    api.getSuppliers().then(setSuppliers).catch(console.error);
-  }, []);
+    api.getSuppliers()
+      .then((sups) => {
+        setSuppliers(sups);
+        setLoading(false);
+      })
+      .catch((err) => {
+        toast(err instanceof Error ? err.message : "Toimittajien lataus epaonnistui / Failed to load suppliers", "error");
+        setLoading(false);
+      });
+  }, [toast]);
 
   return (
     <div>
@@ -198,36 +226,42 @@ function SuppliersTab() {
           </tr>
         </thead>
         <tbody>
-          {suppliers.map((s, i) => (
-            <tr
-              key={s.id}
-              style={{ animation: `fadeIn 0.2s ease-out ${i * 0.04}s both`, transition: "background 0.1s" }}
-              onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; }}
-              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
-            >
-              <td style={{ ...tdStyle, fontWeight: 500 }}>{s.name}</td>
-              <td style={tdStyle}>
-                {s.website ? (
-                  <a
-                    href={s.website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    style={{ color: "var(--accent)", textDecoration: "none" }}
-                  >
-                    {new URL(s.website).hostname}
-                  </a>
-                ) : (
-                  <span style={{ color: "var(--text-muted)" }}>-</span>
-                )}
-              </td>
-              <td style={tdStyle}>
-                <span className="badge badge-amber">{s.product_count}</span>
-              </td>
-              <td style={{ ...tdStyle, color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: 12 }}>
-                {s.oldest_price ? new Date(s.oldest_price).toLocaleDateString() : "-"}
-              </td>
-            </tr>
-          ))}
+          {loading ? (
+            Array.from({ length: 4 }).map((_, i) => (
+              <SkeletonTableRow key={i} columns={4} delay={i * 0.05} />
+            ))
+          ) : (
+            suppliers.map((s, i) => (
+              <tr
+                key={s.id}
+                style={{ animation: `fadeIn 0.2s ease-out ${i * 0.04}s both`, transition: "background 0.1s" }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = "var(--bg-hover)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+              >
+                <td style={{ ...tdStyle, fontWeight: 500 }}>{s.name}</td>
+                <td style={tdStyle}>
+                  {s.website ? (
+                    <a
+                      href={s.website}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ color: "var(--accent)", textDecoration: "none" }}
+                    >
+                      {new URL(s.website).hostname}
+                    </a>
+                  ) : (
+                    <span style={{ color: "var(--text-muted)" }}>-</span>
+                  )}
+                </td>
+                <td style={tdStyle}>
+                  <span className="badge badge-amber">{s.product_count}</span>
+                </td>
+                <td style={{ ...tdStyle, color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: 12 }}>
+                  {s.oldest_price ? new Date(s.oldest_price).toLocaleDateString() : "-"}
+                </td>
+              </tr>
+            ))
+          )}
         </tbody>
       </table>
     </div>
@@ -236,10 +270,20 @@ function SuppliersTab() {
 
 function PricingTab() {
   const [stale, setStale] = useState<StalePrice[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
 
   useEffect(() => {
-    api.getStalePrices().then(setStale).catch(console.error);
-  }, []);
+    api.getStalePrices()
+      .then((prices) => {
+        setStale(prices);
+        setLoading(false);
+      })
+      .catch((err) => {
+        toast(err instanceof Error ? err.message : "Hintatietojen lataus epaonnistui / Failed to load pricing", "error");
+        setLoading(false);
+      });
+  }, [toast]);
 
   return (
     <div>
@@ -247,7 +291,24 @@ function PricingTab() {
         <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>Vanhentuneet hinnat</h3>
         <span className="badge badge-amber">&gt;30 paivaa</span>
       </div>
-      {stale.length === 0 ? (
+      {loading ? (
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={thStyle}>Materiaali</th>
+              <th style={thStyle}>Toimittaja</th>
+              <th style={thStyle}>Hinta</th>
+              <th style={thStyle}>Viimeksi paivitetty</th>
+              <th style={thStyle}>Ika</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <SkeletonTableRow key={i} columns={5} delay={i * 0.05} />
+            ))}
+          </tbody>
+        </table>
+      ) : stale.length === 0 ? (
         <div style={{ textAlign: "center", padding: "40px 20px" }}>
           <span className="badge badge-forest" style={{ padding: "6px 16px", fontSize: 13 }}>
             Kaikki hinnat ajan tasalla

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { ToastProvider } from "@/components/ToastProvider";
 
 export const metadata: Metadata = {
   title: "Helscoop - Rakennusprojektien suunnittelu",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fi">
-      <body className="grain">{children}</body>
+      <body className="grain">
+        <ToastProvider>{children}</ToastProvider>
+      </body>
     </html>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from "react";
 import { api, setToken, getToken } from "@/lib/api";
+import { useToast } from "@/components/ToastProvider";
+import { SkeletonProjectCard } from "@/components/Skeleton";
 
 interface Project {
   id: string;
@@ -246,45 +248,81 @@ function ProjectList() {
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
 
   useEffect(() => {
-    api.getProjects().then(setProjects).catch(console.error);
-    api.getTemplates().then(setTemplates).catch(console.error);
-  }, []);
+    let mounted = true;
+    Promise.all([api.getProjects(), api.getTemplates()])
+      .then(([projs, tmpls]) => {
+        if (mounted) {
+          setProjects(projs);
+          setTemplates(tmpls);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (mounted) {
+          toast(err instanceof Error ? err.message : "Projektien lataus epaonnistui / Failed to load projects", "error");
+          setLoading(false);
+        }
+      });
+    return () => { mounted = false; };
+  }, [toast]);
 
   async function createProject() {
     if (!newName.trim()) return;
     setCreating(true);
-    const p = await api.createProject({ name: newName });
-    setProjects([p, ...projects]);
-    setNewName("");
+    try {
+      const p = await api.createProject({ name: newName });
+      setProjects([p, ...projects]);
+      setNewName("");
+      toast("Projekti luotu / Project created", "success");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Projektin luonti epaonnistui / Failed to create project", "error");
+    }
     setCreating(false);
   }
 
   async function createFromTemplate(t: Template) {
     setCreating(true);
-    const p = await api.createProject({
-      name: t.name,
-      description: t.description,
-      scene_js: t.scene_js,
-    });
-    if (t.bom.length > 0) {
-      await api.saveBOM(p.id, t.bom);
+    try {
+      const p = await api.createProject({
+        name: t.name,
+        description: t.description,
+        scene_js: t.scene_js,
+      });
+      if (t.bom.length > 0) {
+        await api.saveBOM(p.id, t.bom);
+      }
+      setProjects([{ ...p, estimated_cost: t.estimated_cost }, ...projects]);
+      setShowTemplates(false);
+      toast(`Projekti "${t.name}" luotu mallista / Created from template`, "success");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Mallin luonti epaonnistui / Template creation failed", "error");
     }
-    setProjects([{ ...p, estimated_cost: t.estimated_cost }, ...projects]);
-    setShowTemplates(false);
     setCreating(false);
   }
 
   async function deleteProject(id: string) {
     if (!confirm("Haluatko varmasti poistaa taman projektin?")) return;
-    await api.deleteProject(id);
-    setProjects(projects.filter((p) => p.id !== id));
+    try {
+      await api.deleteProject(id);
+      setProjects(projects.filter((p) => p.id !== id));
+      toast("Projekti poistettu / Project deleted", "success");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Poistaminen epaonnistui / Delete failed", "error");
+    }
   }
 
   async function duplicateProject(id: string) {
-    const p = await api.duplicateProject(id);
-    setProjects([p, ...projects]);
+    try {
+      const p = await api.duplicateProject(id);
+      setProjects([p, ...projects]);
+      toast("Projekti kopioitu / Project duplicated", "success");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Kopiointi epaonnistui / Duplicate failed", "error");
+    }
   }
 
   return (
@@ -332,9 +370,11 @@ function ProjectList() {
             Omat projektit
           </h1>
           <p style={{ color: "var(--text-muted)", fontSize: 15, marginBottom: 24 }}>
-            {projects.length > 0
-              ? `${projects.length} projekti${projects.length !== 1 ? "a" : ""}`
-              : "Aloita ensimmainen projektisi"}
+            {loading
+              ? "Ladataan projekteja..."
+              : projects.length > 0
+                ? `${projects.length} projekti${projects.length !== 1 ? "a" : ""}`
+                : "Aloita ensimmainen projektisi"}
           </p>
 
           <div style={{ display: "flex", gap: 8, maxWidth: 560 }}>
@@ -357,7 +397,13 @@ function ProjectList() {
           </div>
         </div>
 
-        {projects.length === 0 ? (
+        {loading ? (
+          <div style={{ display: "grid", gap: 10 }}>
+            {[0, 1, 2].map((i) => (
+              <SkeletonProjectCard key={i} delay={i * 0.08} />
+            ))}
+          </div>
+        ) : projects.length === 0 ? (
           <div className="anim-up delay-1" style={{
             padding: "80px 40px",
             textAlign: "center",

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { api, getToken, setToken } from "@/lib/api";
+import { useToast } from "@/components/ToastProvider";
+import { SkeletonProjectEditor } from "@/components/Skeleton";
 
 interface Material {
   id: string;
@@ -298,6 +300,7 @@ function ChatPanel({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const { toast } = useToast();
 
   async function send() {
     if (!input.trim() || loading) return;
@@ -310,10 +313,11 @@ function ChatPanel({
     try {
       const reply = await api.chat(newMessages, sceneJs);
       setMessages([...newMessages, reply]);
-    } catch {
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "AI-avustajan virhe / AI assistant error", "error");
       setMessages([
         ...newMessages,
-        { role: "assistant", content: "Something went wrong. Please try again." },
+        { role: "assistant", content: "Jokin meni pieleen. Yrita uudelleen." },
       ]);
     }
     setLoading(false);
@@ -489,6 +493,7 @@ export default function ProjectPage() {
   const params = useParams();
   const router = useRouter();
   const projectId = params.id as string;
+  const { toast } = useToast();
 
   const [project, setProject] = useState<Project | null>(null);
   const [materials, setMaterials] = useState<Material[]>([]);
@@ -496,7 +501,7 @@ export default function ProjectPage() {
   const [sceneJs, setSceneJs] = useState("");
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("saved");
   const [lastSaved, setLastSaved] = useState<string | null>(null);
-  const [error, setError] = useState("");
+  const [loadError, setLoadError] = useState(false);
   const [projectName, setProjectName] = useState("");
   const [projectDesc, setProjectDesc] = useState("");
   const [showChat, setShowChat] = useState(false);
@@ -567,14 +572,15 @@ export default function ProjectPage() {
         }, 0);
       })
       .catch((err) => {
-        if (err.message?.includes("401") || err.message?.includes("authorization")) {
+        if (err.message?.includes("401") || err.message?.includes("authorization") || err.message?.includes("Session expired")) {
           setToken(null);
           router.push("/");
         } else {
-          setError(err.message);
+          toast(err instanceof Error ? err.message : "Projektin lataus epaonnistui / Failed to load project", "error");
+          setLoadError(true);
         }
       });
-  }, [projectId, router]);
+  }, [projectId, router, toast]);
 
   // Save function (used by both auto-save and manual save)
   const save = useCallback(async () => {
@@ -603,11 +609,12 @@ export default function ProjectPage() {
       await Promise.all(savePromises);
       setLastSaved(new Date().toLocaleTimeString());
       setSaveStatus("saved");
+      toast("Tallennettu / Saved", "success");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Save failed");
+      toast(err instanceof Error ? err.message : "Tallennus epaonnistui / Save failed", "error");
       setSaveStatus("unsaved");
     }
-  }, [projectId, projectName, projectDesc, sceneJs, bom]);
+  }, [projectId, projectName, projectDesc, sceneJs, bom, toast]);
 
   // Schedule auto-save (debounced 2 seconds)
   const scheduleAutoSave = useCallback(() => {
@@ -718,11 +725,11 @@ export default function ProjectPage() {
     );
   }, []);
 
-  if (error) {
+  if (loadError) {
     return (
       <div className="anim-up" style={{ padding: 60, textAlign: "center" }}>
         <h2 className="heading-display" style={{ marginBottom: 8 }}>Virhe</h2>
-        <p style={{ color: "var(--danger)", marginBottom: 16 }}>{error}</p>
+        <p style={{ color: "var(--danger)", marginBottom: 16 }}>Projektia ei voitu ladata / Could not load project</p>
         <button className="btn btn-primary" onClick={() => router.push("/")}>
           Takaisin projekteihin
         </button>
@@ -731,11 +738,7 @@ export default function ProjectPage() {
   }
 
   if (!project) {
-    return (
-      <div style={{ padding: 60, textAlign: "center", color: "var(--text-muted)" }}>
-        Ladataan...
-      </div>
-    );
+    return <SkeletonProjectEditor />;
   }
 
   return (
@@ -846,14 +849,19 @@ export default function ProjectPage() {
           Tallenna
         </button>
         <button className="btn btn-ghost" onClick={async () => {
-          const res = await api.exportBOM(projectId);
-          const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
-          const url = URL.createObjectURL(blob);
-          const a = document.createElement("a");
-          a.href = url;
-          a.download = `bom_${projectId}.json`;
-          a.click();
-          URL.revokeObjectURL(url);
+          try {
+            const res = await api.exportBOM(projectId);
+            const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `bom_${projectId}.json`;
+            a.click();
+            URL.revokeObjectURL(url);
+            toast("BOM viety / BOM exported", "success");
+          } catch (err) {
+            toast(err instanceof Error ? err.message : "BOM-vienti epaonnistui / BOM export failed", "error");
+          }
         }}>
           Vie BOM
         </button>

--- a/web/src/components/Skeleton.tsx
+++ b/web/src/components/Skeleton.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+const shimmerStyle = {
+  background: `linear-gradient(
+    90deg,
+    var(--bg-tertiary) 25%,
+    var(--bg-elevated) 50%,
+    var(--bg-tertiary) 75%
+  )`,
+  backgroundSize: "200% 100%",
+  animation: "shimmer 1.8s ease-in-out infinite",
+  borderRadius: "var(--radius-sm)",
+};
+
+/** A single rectangular shimmer block. */
+export function SkeletonBlock({
+  width,
+  height,
+  radius,
+  style,
+}: {
+  width?: string | number;
+  height?: string | number;
+  radius?: string | number;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        ...shimmerStyle,
+        width: width ?? "100%",
+        height: height ?? 16,
+        borderRadius: radius ?? "var(--radius-sm)",
+        ...style,
+      }}
+    />
+  );
+}
+
+/** Skeleton for a project card in the project list. */
+export function SkeletonProjectCard({ delay = 0 }: { delay?: number }) {
+  return (
+    <div
+      className="card"
+      style={{
+        padding: "22px 28px",
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        gap: 16,
+        alignItems: "center",
+        animation: `fadeIn 0.3s ease ${delay}s both`,
+      }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <SkeletonBlock width={180} height={20} />
+          <SkeletonBlock width={60} height={22} radius={100} />
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <SkeletonBlock width={120} height={14} />
+          <SkeletonBlock width={70} height={14} />
+        </div>
+      </div>
+      <div style={{ display: "flex", gap: 6 }}>
+        <SkeletonBlock width={52} height={30} />
+        <SkeletonBlock width={52} height={30} />
+        <SkeletonBlock width={52} height={30} />
+      </div>
+    </div>
+  );
+}
+
+/** Skeleton for a table row (e.g. admin panel). */
+export function SkeletonTableRow({ columns = 5, delay = 0 }: { columns?: number; delay?: number }) {
+  return (
+    <tr style={{ animation: `fadeIn 0.3s ease ${delay}s both` }}>
+      {Array.from({ length: columns }).map((_, i) => (
+        <td key={i} style={{ padding: "12px 16px", borderBottom: "1px solid var(--border)" }}>
+          <SkeletonBlock
+            width={i === 0 ? 36 : `${60 + Math.random() * 40}%`}
+            height={i === 0 ? 36 : 14}
+            radius={i === 0 ? 6 : undefined}
+          />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+/** Full-page loading skeleton for the project editor. */
+export function SkeletonProjectEditor() {
+  return (
+    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+      {/* Header skeleton */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "8px 16px",
+          background: "var(--bg-secondary)",
+          borderBottom: "1px solid var(--border)",
+          flexShrink: 0,
+        }}
+      >
+        <SkeletonBlock width={32} height={32} />
+        <div style={{ width: 1, height: 20, background: "var(--border)" }} />
+        <SkeletonBlock width={200} height={20} />
+        <div style={{ flex: 1 }} />
+        <SkeletonBlock width={80} height={32} />
+        <SkeletonBlock width={72} height={32} />
+      </div>
+      {/* Body skeleton */}
+      <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+        <div style={{ flex: 1, padding: 16, display: "flex", flexDirection: "column", gap: 12 }}>
+          <SkeletonBlock width={100} height={14} />
+          <SkeletonBlock height="100%" radius="var(--radius-md)" />
+        </div>
+        <div style={{ width: 360, borderLeft: "1px solid var(--border)", padding: 16 }}>
+          <SkeletonBlock width={140} height={18} style={{ marginBottom: 16 }} />
+          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            {[0, 1, 2].map((i) => (
+              <SkeletonBlock key={i} height={70} radius="var(--radius-sm)" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type ToastType = "success" | "error" | "info";
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  type: ToastType;
+  exiting?: boolean;
+}
+
+const TYPE_STYLES: Record<ToastType, { bg: string; color: string; border: string; icon: string }> = {
+  success: {
+    bg: "var(--forest-dim)",
+    color: "var(--forest)",
+    border: "rgba(74, 124, 89, 0.25)",
+    icon: "M20 6L9 17l-5-5",
+  },
+  error: {
+    bg: "var(--danger-dim)",
+    color: "var(--danger)",
+    border: "rgba(199, 95, 95, 0.2)",
+    icon: "M18 6L6 18M6 6l12 12",
+  },
+  info: {
+    bg: "var(--amber-glow)",
+    color: "var(--amber-light)",
+    border: "var(--amber-border)",
+    icon: "M12 2v10M12 16v2",
+  },
+};
+
+export function ToastContainer({ toasts, onDismiss }: { toasts: ToastItem[]; onDismiss: (id: number) => void }) {
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 24,
+        right: 24,
+        zIndex: 10000,
+        display: "flex",
+        flexDirection: "column-reverse",
+        gap: 8,
+        pointerEvents: "none",
+      }}
+    >
+      {toasts.map((t) => (
+        <ToastMessage key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+function ToastMessage({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: number) => void }) {
+  const [visible, setVisible] = useState(false);
+  const [exiting, setExiting] = useState(false);
+  const style = TYPE_STYLES[toast.type];
+
+  useEffect(() => {
+    // Trigger enter animation
+    requestAnimationFrame(() => setVisible(true));
+
+    const timer = setTimeout(() => {
+      setExiting(true);
+      setTimeout(() => onDismiss(toast.id), 300);
+    }, 4000);
+
+    return () => clearTimeout(timer);
+  }, [toast.id, onDismiss]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "12px 18px",
+        background: style.bg,
+        border: `1px solid ${style.border}`,
+        borderRadius: "var(--radius-md)",
+        color: style.color,
+        fontSize: 13,
+        fontFamily: "var(--font-body)",
+        fontWeight: 500,
+        boxShadow: "var(--shadow-md)",
+        backdropFilter: "blur(12px)",
+        pointerEvents: "auto",
+        cursor: "pointer",
+        transform: visible && !exiting ? "translateX(0)" : "translateX(120%)",
+        opacity: visible && !exiting ? 1 : 0,
+        transition: "transform 0.35s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s ease",
+        maxWidth: 380,
+      }}
+      onClick={() => {
+        setExiting(true);
+        setTimeout(() => onDismiss(toast.id), 300);
+      }}
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        style={{ flexShrink: 0 }}
+      >
+        <path d={style.icon} />
+      </svg>
+      <span>{toast.message}</span>
+    </div>
+  );
+}

--- a/web/src/components/ToastProvider.tsx
+++ b/web/src/components/ToastProvider.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { createContext, useContext, useCallback, useState, type ReactNode } from "react";
+import { ToastContainer, type ToastItem, type ToastType } from "./Toast";
+
+interface ToastContextValue {
+  toast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let nextId = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const toast = useCallback((message: string, type: ToastType = "info") => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+  }, []);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return ctx;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -16,6 +16,29 @@ export function getToken(): string | null {
   return token;
 }
 
+export class ApiError extends Error {
+  status: number;
+  statusText: string;
+
+  constructor(message: string, status: number, statusText: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
+const ERROR_MESSAGES: Record<number, string> = {
+  400: "Virheellinen pyynto / Bad request",
+  401: "Istunto vanhentunut / Session expired",
+  403: "Ei kayttooikeutta / Access denied",
+  404: "Ei loytynyt / Not found",
+  409: "Ristiriita / Conflict",
+  422: "Virheelliset tiedot / Validation failed",
+  429: "Liian monta pyyntoa / Too many requests",
+  500: "Palvelinvirhe / Server error",
+};
+
 async function apiFetch(path: string, opts?: RequestInit) {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -25,9 +48,20 @@ async function apiFetch(path: string, opts?: RequestInit) {
   if (t) headers.Authorization = `Bearer ${t}`;
 
   const res = await fetch(`${API_URL}${path}`, { ...opts, headers });
+
   if (!res.ok) {
+    if (res.status === 401) {
+      setToken(null);
+      if (typeof window !== "undefined") {
+        window.location.href = "/";
+      }
+      throw new ApiError(ERROR_MESSAGES[401], 401, res.statusText);
+    }
+
     const body = await res.json().catch(() => ({ error: res.statusText }));
-    throw new Error(body.error || res.statusText);
+    const serverMsg = body.error || body.message;
+    const fallback = ERROR_MESSAGES[res.status] || `Virhe ${res.status} / Error ${res.status}`;
+    throw new ApiError(serverMsg || fallback, res.status, res.statusText);
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Toast notification system (success/error/info) with auto-dismiss, stacking, and slide-in animation
- Loading skeleton components for project cards, table rows, and project editor
- Applied across all pages: login, project list, project editor, admin panel
- API error interceptor with bilingual Finnish/English messages and 401 auto-redirect

Closes #20

## Test plan
- [ ] Toasts appear on project create/delete/duplicate
- [ ] Skeleton loaders show while data fetches on project list and admin tables
- [ ] Error toasts replace console.error calls
- [ ] Project editor shows skeleton while loading
- [ ] Save button shows toast on success/failure
- [ ] Web app builds without type errors (`npx tsc --noEmit` passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)