### PR TITLE
Add building lookup with Helsinki demo addresses (#30, #32)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,6 +6,7 @@ import projectsRouter from "./routes/projects";
 import suppliersRouter from "./routes/suppliers";
 import pricingRouter from "./routes/pricing";
 import chatRouter from "./routes/chat";
+import buildingRouter from "./routes/building";
 
 const app = express();
 const PORT = parseInt(process.env.PORT || "3001");
@@ -46,6 +47,7 @@ app.use("/projects", projectsRouter);
 app.use("/suppliers", suppliersRouter);
 app.use("/pricing", pricingRouter);
 app.use("/chat", chatRouter);
+app.use("/building", buildingRouter);
 
 app.get("/materials/export/viewer", async (_req, res) => {
   const { query: dbQuery } = await import("./db");

--- a/api/src/routes/building.ts
+++ b/api/src/routes/building.ts
@@ -1,0 +1,220 @@
+import { Router, Request, Response } from "express";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const router = Router();
+
+// Load demo building data at startup
+interface BuildingInfo {
+  type: string;
+  year_built: number;
+  material: string;
+  floors: number;
+  area_m2: number;
+  heating: string;
+  roof_type?: string;
+  roof_material?: string;
+  units?: number;
+}
+
+interface BomItem {
+  material_id: string;
+  quantity: number;
+  unit: string;
+}
+
+interface BuildingData {
+  address: string;
+  coordinates: { lat: number; lon: number };
+  building_info: BuildingInfo;
+  scene_js: string;
+  bom_suggestion: BomItem[];
+}
+
+function loadDemoData(): BuildingData[] {
+  const dataDir = join(__dirname, "..", "..", "..", "data", "demo");
+  const files = ["ribbingintie-109.json", "uunimaentie-1.json"];
+  const buildings: BuildingData[] = [];
+
+  for (const file of files) {
+    try {
+      const raw = readFileSync(join(dataDir, file), "utf-8");
+      buildings.push(JSON.parse(raw));
+    } catch (e) {
+      console.warn(`Could not load demo data file ${file}:`, e);
+    }
+  }
+
+  return buildings;
+}
+
+const demoBuildings = loadDemoData();
+
+/**
+ * Normalize an address string for fuzzy matching:
+ * lowercase, collapse whitespace, strip commas and dots.
+ */
+function normalizeAddress(addr: string): string {
+  return addr
+    .toLowerCase()
+    .replace(/[,.\-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Check whether a query address matches a demo address.
+ * Matches if the normalized query contains the street name and number.
+ */
+function matchesDemoAddress(query: string, demoAddress: string): boolean {
+  const normQ = normalizeAddress(query);
+  const normD = normalizeAddress(demoAddress);
+
+  // Extract the street name and number (first part before postal code)
+  const streetPart = normD.split(/\d{5}/)[0].trim();
+  if (!streetPart) return false;
+
+  // Try exact substring match on the street portion
+  if (normQ.includes(streetPart)) return true;
+
+  // Also try matching just the street name (without house number suffix)
+  const words = streetPart.split(" ");
+  const streetName = words[0];
+  if (streetName && streetName.length > 4 && normQ.includes(streetName)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Generate a generic building based on postal code area characteristics.
+ */
+function generateGenericBuilding(address: string): BuildingData {
+  // Try to extract postal code
+  const postalMatch = address.match(/\b(\d{5})\b/);
+  const postalCode = postalMatch ? postalMatch[1] : "00100";
+  const prefix = postalCode.substring(0, 2);
+
+  // Helsinki downtown (001-002): likely apartment
+  // Helsinki suburbs (003-009): likely detached/row house
+  // Espoo (02): mixed
+  // Vantaa (01): mixed suburban
+  let buildingType = "omakotitalo";
+  let floors = 2;
+  let area = 120;
+  let yearBuilt = 1990;
+  let material = "puu";
+
+  if (prefix === "00" && parseInt(postalCode) < 300) {
+    buildingType = "kerrostalo";
+    floors = 5;
+    area = 65;
+    yearBuilt = 1960;
+    material = "betoni";
+  } else if (prefix === "00" && parseInt(postalCode) >= 300) {
+    buildingType = "omakotitalo";
+    floors = 2;
+    area = 130;
+    yearBuilt = 1985;
+    material = "puu";
+  } else if (prefix === "02") {
+    buildingType = "omakotitalo";
+    floors = 2;
+    area = 145;
+    yearBuilt = 1995;
+    material = "puu";
+  }
+
+  return {
+    address,
+    coordinates: { lat: 60.17, lon: 24.94 },
+    building_info: {
+      type: buildingType,
+      year_built: yearBuilt,
+      material: material,
+      floors: floors,
+      area_m2: area,
+      heating: "kaukolampo",
+      roof_type: "harjakatto",
+      roof_material: "pelti",
+    },
+    scene_js: generateGenericScene(buildingType, floors, area),
+    bom_suggestion: [
+      { material_id: "pine_48x148_c24", quantity: Math.round(area * 0.6), unit: "jm" },
+      { material_id: "pine_48x98_c24", quantity: Math.round(area * 0.4), unit: "jm" },
+      { material_id: "osb_11mm", quantity: Math.round(area * 0.35), unit: "m2" },
+      { material_id: "mineral_wool_150", quantity: Math.round(area * 0.7), unit: "m2" },
+      { material_id: "concrete_c25", quantity: Math.round(area * 0.06 * 10) / 10, unit: "m3" },
+      { material_id: "metal_roof_ruukki", quantity: Math.round(area * 0.55), unit: "m2" },
+    ],
+  };
+}
+
+function generateGenericScene(
+  type: string,
+  floors: number,
+  area: number
+): string {
+  const floorHeight = 2.7;
+  // Approximate footprint from area
+  const ratio = 1.2; // length/width ratio
+  const width = Math.sqrt(area / floors / ratio);
+  const length = width * ratio;
+  const w = Math.round(width * 10) / 10;
+  const l = Math.round(length * 10) / 10;
+
+  let lines = `// Generic ${type}, ${floors} floors, ~${area}m2\n`;
+  lines += `const foundation = translate(cube({size: [${l}, 0.3, ${w}], center: true}), [0, 0.15, 0]);\n`;
+
+  for (let f = 0; f < floors; f++) {
+    const baseY = 0.3 + f * (floorHeight + 0.25);
+    const prefix = f === 0 ? "gf" : `f${f}`;
+    lines += `const ${prefix}_front = translate(cube({size: [${l}, ${floorHeight}, 0.2], center: true}), [0, ${(baseY + floorHeight / 2).toFixed(2)}, ${(-w / 2 - 0.1).toFixed(2)}]);\n`;
+    lines += `const ${prefix}_back = translate(cube({size: [${l}, ${floorHeight}, 0.2], center: true}), [0, ${(baseY + floorHeight / 2).toFixed(2)}, ${(w / 2 + 0.1).toFixed(2)}]);\n`;
+    lines += `const ${prefix}_left = translate(cube({size: [0.2, ${floorHeight}, ${w}], center: true}), [${(-l / 2 - 0.1).toFixed(2)}, ${(baseY + floorHeight / 2).toFixed(2)}, 0]);\n`;
+    lines += `const ${prefix}_right = translate(cube({size: [0.2, ${floorHeight}, ${w}], center: true}), [${(l / 2 + 0.1).toFixed(2)}, ${(baseY + floorHeight / 2).toFixed(2)}, 0]);\n`;
+    if (f < floors - 1) {
+      lines += `const slab${f} = translate(cube({size: [${l}, 0.25, ${w}], center: true}), [0, ${(baseY + floorHeight + 0.125).toFixed(2)}, 0]);\n`;
+    }
+  }
+
+  const totalH = 0.3 + floors * floorHeight + (floors - 1) * 0.25;
+  const roofPeakH = totalH + w * 0.29; // ~30deg pitch
+  lines += `const roof_l = translate(rotate(cube({size: [${l + 0.6}, 0.08, ${(w / 2 + 0.6).toFixed(1)}], center: true}), [0.52, 0, 0]), [0, ${((totalH + roofPeakH) / 2).toFixed(2)}, ${(-w / 4).toFixed(2)}]);\n`;
+  lines += `const roof_r = translate(rotate(cube({size: [${l + 0.6}, 0.08, ${(w / 2 + 0.6).toFixed(1)}], center: true}), [-0.52, 0, 0]), [0, ${((totalH + roofPeakH) / 2).toFixed(2)}, ${(w / 4).toFixed(2)}]);\n`;
+
+  // Collect all parts
+  const parts = ["foundation"];
+  for (let f = 0; f < floors; f++) {
+    const prefix = f === 0 ? "gf" : `f${f}`;
+    parts.push(`${prefix}_front`, `${prefix}_back`, `${prefix}_left`, `${prefix}_right`);
+    if (f < floors - 1) parts.push(`slab${f}`);
+  }
+  parts.push("roof_l", "roof_r");
+
+  lines += `\nscene = union(${parts.join(", ")});`;
+
+  return lines;
+}
+
+// GET /building?address=<address>
+router.get("/", (req: Request, res: Response) => {
+  const address = (req.query.address as string) || "";
+  if (!address || address.length < 3) {
+    return res.status(400).json({ error: "Address query parameter required (min 3 characters)" });
+  }
+
+  // Try to match against demo buildings
+  for (const building of demoBuildings) {
+    if (matchesDemoAddress(address, building.address)) {
+      return res.json(building);
+    }
+  }
+
+  // Fallback: generate generic building
+  const generic = generateGenericBuilding(address);
+  return res.json(generic);
+});
+
+export default router;

--- a/data/demo/ribbingintie-109.json
+++ b/data/demo/ribbingintie-109.json
@@ -1,0 +1,27 @@
+{
+  "address": "Ribbingintie 109-11, 00890 Helsinki",
+  "coordinates": { "lat": 60.2685, "lon": 25.1955 },
+  "building_info": {
+    "type": "omakotitalo",
+    "year_built": 1985,
+    "material": "puu",
+    "floors": 2,
+    "area_m2": 135,
+    "heating": "kaukolampo",
+    "roof_type": "harjakatto",
+    "roof_material": "pelti"
+  },
+  "scene_js": "// Ribbingintie 109-11, Helsinki — 1980s omakotitalo\n// Rectangular 2-story wood-frame house, gable roof, ~10x12m footprint\n\n// Foundation (visible concrete, 0.3m)\nconst foundation = translate(cube({size: [12, 0.3, 10], center: true}), [0, 0.15, 0]);\n\n// Ground floor walls (2.7m)\nconst gf_wall_front = translate(cube({size: [12, 2.7, 0.2], center: true}), [0, 1.65, -4.9]);\nconst gf_wall_back = translate(cube({size: [12, 2.7, 0.2], center: true}), [0, 1.65, 4.9]);\nconst gf_wall_left = translate(cube({size: [0.2, 2.7, 10], center: true}), [-5.9, 1.65, 0]);\nconst gf_wall_right = translate(cube({size: [0.2, 2.7, 10], center: true}), [5.9, 1.65, 0]);\n\n// Front door opening\nconst front_door = translate(cube({size: [1.0, 2.1, 0.3], center: true}), [0, 1.35, -4.9]);\nconst gf_wall_front_cut = difference(gf_wall_front, front_door);\n\n// Ground floor windows\nconst gf_win1 = translate(cube({size: [1.2, 1.4, 0.3], center: true}), [-3.0, 1.7, -4.9]);\nconst gf_win2 = translate(cube({size: [1.2, 1.4, 0.3], center: true}), [3.0, 1.7, -4.9]);\nconst gf_wall_front_final = difference(difference(gf_wall_front_cut, gf_win1), gf_win2);\n\n// Back wall windows\nconst gf_bwin1 = translate(cube({size: [1.4, 1.4, 0.3], center: true}), [-3.0, 1.7, 4.9]);\nconst gf_bwin2 = translate(cube({size: [1.4, 1.4, 0.3], center: true}), [2.0, 1.7, 4.9]);\nconst gf_wall_back_final = difference(difference(gf_wall_back, gf_bwin1), gf_bwin2);\n\n// First floor slab\nconst floor1 = translate(cube({size: [12, 0.25, 10], center: true}), [0, 3.125, 0]);\n\n// Upper floor walls (2.7m)\nconst uf_wall_front = translate(cube({size: [12, 2.7, 0.2], center: true}), [0, 4.6, -4.9]);\nconst uf_wall_back = translate(cube({size: [12, 2.7, 0.2], center: true}), [0, 4.6, 4.9]);\nconst uf_wall_left = translate(cube({size: [0.2, 2.7, 10], center: true}), [-5.9, 4.6, 0]);\nconst uf_wall_right = translate(cube({size: [0.2, 2.7, 10], center: true}), [5.9, 4.6, 0]);\n\n// Upper floor windows\nconst uf_win1 = translate(cube({size: [1.2, 1.2, 0.3], center: true}), [-3.0, 4.6, -4.9]);\nconst uf_win2 = translate(cube({size: [1.2, 1.2, 0.3], center: true}), [1.0, 4.6, -4.9]);\nconst uf_win3 = translate(cube({size: [1.2, 1.2, 0.3], center: true}), [4.0, 4.6, -4.9]);\nconst uf_wall_front_final = difference(difference(difference(uf_wall_front, uf_win1), uf_win2), uf_win3);\n\nconst uf_bwin1 = translate(cube({size: [1.2, 1.2, 0.3], center: true}), [-2.0, 4.6, 4.9]);\nconst uf_bwin2 = translate(cube({size: [1.2, 1.2, 0.3], center: true}), [2.5, 4.6, 4.9]);\nconst uf_wall_back_final = difference(difference(uf_wall_back, uf_bwin1), uf_bwin2);\n\n// Gable roof — two sloped panels, 30deg pitch\nconst roof_left = translate(rotate(cube({size: [12.6, 0.08, 6.2], center: true}), [0.52, 0, 0]), [0, 7.5, -2.5]);\nconst roof_right = translate(rotate(cube({size: [12.6, 0.08, 6.2], center: true}), [-0.52, 0, 0]), [0, 7.5, 2.5]);\n\n// Front porch roof and posts\nconst porch_post_l = translate(cube({size: [0.12, 2.5, 0.12], center: true}), [-1.0, 1.55, -5.8]);\nconst porch_post_r = translate(cube({size: [0.12, 2.5, 0.12], center: true}), [1.0, 1.55, -5.8]);\nconst porch_roof = translate(rotate(cube({size: [2.8, 0.06, 1.4], center: true}), [0.15, 0, 0]), [0, 2.9, -5.5]);\nconst porch_floor = translate(cube({size: [2.4, 0.12, 1.2], center: true}), [0, 0.36, -5.5]);\n\nscene = union(\n  foundation,\n  gf_wall_front_final, gf_wall_back_final, gf_wall_left, gf_wall_right,\n  floor1,\n  uf_wall_front_final, uf_wall_back_final, uf_wall_left, uf_wall_right,\n  roof_left, roof_right,\n  porch_post_l, porch_post_r, porch_roof, porch_floor\n);",
+  "bom_suggestion": [
+    { "material_id": "pine_48x148_c24", "quantity": 85, "unit": "jm" },
+    { "material_id": "pine_48x98_c24", "quantity": 60, "unit": "jm" },
+    { "material_id": "osb_11mm", "quantity": 48, "unit": "m2" },
+    { "material_id": "mineral_wool_150", "quantity": 96, "unit": "m2" },
+    { "material_id": "concrete_c25", "quantity": 8.5, "unit": "m3" },
+    { "material_id": "metal_roof_ruukki", "quantity": 72, "unit": "m2" },
+    { "material_id": "gypsum_board_13mm", "quantity": 180, "unit": "m2" },
+    { "material_id": "vapor_barrier", "quantity": 120, "unit": "m2" },
+    { "material_id": "wind_barrier", "quantity": 120, "unit": "m2" },
+    { "material_id": "wood_screw_5x80", "quantity": 1200, "unit": "kpl" }
+  ]
+}

--- a/data/demo/uunimaentie-1.json
+++ b/data/demo/uunimaentie-1.json
@@ -1,0 +1,28 @@
+{
+  "address": "Uunimaentie 1, 01200 Vantaa",
+  "coordinates": { "lat": 60.2924, "lon": 25.0462 },
+  "building_info": {
+    "type": "rivitalo",
+    "year_built": 1978,
+    "material": "tiili",
+    "floors": 2,
+    "area_m2": 220,
+    "heating": "kaukolampo",
+    "roof_type": "harjakatto",
+    "roof_material": "tiili",
+    "units": 4
+  },
+  "scene_js": "// Uunimaentie 1, Vantaa — 1970s rivitalo (row house), 4 units\n// Long rectangular footprint ~28x8m, 2 stories, brick facade, tile roof\n\n// Foundation\nconst foundation = translate(cube({size: [28, 0.35, 8], center: true}), [0, 0.175, 0]);\n\n// Ground floor walls\nconst gf_front = translate(cube({size: [28, 2.7, 0.25], center: true}), [0, 1.7, -3.875]);\nconst gf_back = translate(cube({size: [28, 2.7, 0.25], center: true}), [0, 1.7, 3.875]);\nconst gf_left = translate(cube({size: [0.25, 2.7, 8], center: true}), [-13.875, 1.7, 0]);\nconst gf_right = translate(cube({size: [0.25, 2.7, 8], center: true}), [13.875, 1.7, 0]);\n\n// Unit dividing walls (3 dividers for 4 units, each ~7m wide)\nconst div1 = translate(cube({size: [0.2, 2.7, 8], center: true}), [-7, 1.7, 0]);\nconst div2 = translate(cube({size: [0.2, 2.7, 8], center: true}), [0, 1.7, 0]);\nconst div3 = translate(cube({size: [0.2, 2.7, 8], center: true}), [7, 1.7, 0]);\n\n// Front doors (one per unit)\nconst door1 = translate(cube({size: [1.0, 2.1, 0.35], center: true}), [-10.5, 1.4, -3.875]);\nconst door2 = translate(cube({size: [1.0, 2.1, 0.35], center: true}), [-3.5, 1.4, -3.875]);\nconst door3 = translate(cube({size: [1.0, 2.1, 0.35], center: true}), [3.5, 1.4, -3.875]);\nconst door4 = translate(cube({size: [1.0, 2.1, 0.35], center: true}), [10.5, 1.4, -3.875]);\nconst gf_front_cut = difference(difference(difference(difference(gf_front, door1), door2), door3), door4);\n\n// Front windows (two per unit)\nconst fw = [];\nconst fwPositions = [-12.5, -8.5, -5.5, -1.5, 1.5, 5.5, 8.5, 12.5];\nlet gf_front_final = gf_front_cut;\nfor (let i = 0; i < fwPositions.length; i++) {\n  const w = translate(cube({size: [1.2, 1.3, 0.35], center: true}), [fwPositions[i], 1.8, -3.875]);\n  gf_front_final = difference(gf_front_final, w);\n}\n\n// Back windows and terrace doors\nlet gf_back_final = gf_back;\nconst bwPositions = [-11.5, -8.0, -4.5, -1.0, 1.0, 4.5, 8.0, 11.5];\nfor (let i = 0; i < bwPositions.length; i++) {\n  const w = translate(cube({size: [1.4, 1.3, 0.35], center: true}), [bwPositions[i], 1.8, 3.875]);\n  gf_back_final = difference(gf_back_final, w);\n}\n\n// First floor slab\nconst floor1 = translate(cube({size: [28, 0.25, 8], center: true}), [0, 3.175, 0]);\n\n// Upper floor walls\nconst uf_front = translate(cube({size: [28, 2.7, 0.25], center: true}), [0, 4.65, -3.875]);\nconst uf_back = translate(cube({size: [28, 2.7, 0.25], center: true}), [0, 4.65, 3.875]);\nconst uf_left = translate(cube({size: [0.25, 2.7, 8], center: true}), [-13.875, 4.65, 0]);\nconst uf_right = translate(cube({size: [0.25, 2.7, 8], center: true}), [13.875, 4.65, 0]);\n\n// Upper dividers\nconst udiv1 = translate(cube({size: [0.2, 2.7, 8], center: true}), [-7, 4.65, 0]);\nconst udiv2 = translate(cube({size: [0.2, 2.7, 8], center: true}), [0, 4.65, 0]);\nconst udiv3 = translate(cube({size: [0.2, 2.7, 8], center: true}), [7, 4.65, 0]);\n\n// Upper floor windows\nlet uf_front_final = uf_front;\nfor (let i = 0; i < fwPositions.length; i++) {\n  const w = translate(cube({size: [1.1, 1.1, 0.35], center: true}), [fwPositions[i], 4.7, -3.875]);\n  uf_front_final = difference(uf_front_final, w);\n}\n\nlet uf_back_final = uf_back;\nfor (let i = 0; i < bwPositions.length; i++) {\n  const w = translate(cube({size: [1.1, 1.1, 0.35], center: true}), [bwPositions[i], 4.7, 3.875]);\n  uf_back_final = difference(uf_back_final, w);\n}\n\n// Gable roof — 25deg pitch, tile look\nconst roof_left = translate(rotate(cube({size: [28.8, 0.1, 5.2], center: true}), [0.44, 0, 0]), [0, 7.4, -2.2]);\nconst roof_right = translate(rotate(cube({size: [28.8, 0.1, 5.2], center: true}), [-0.44, 0, 0]), [0, 7.4, 2.2]);\n\nscene = union(\n  foundation,\n  gf_front_final, gf_back_final, gf_left, gf_right,\n  div1, div2, div3,\n  floor1,\n  uf_front_final, uf_back_final, uf_left, uf_right,\n  udiv1, udiv2, udiv3,\n  roof_left, roof_right\n);",
+  "bom_suggestion": [
+    { "material_id": "pine_48x148_c24", "quantity": 180, "unit": "jm" },
+    { "material_id": "pine_48x98_c24", "quantity": 120, "unit": "jm" },
+    { "material_id": "osb_11mm", "quantity": 96, "unit": "m2" },
+    { "material_id": "mineral_wool_150", "quantity": 220, "unit": "m2" },
+    { "material_id": "concrete_c25", "quantity": 22, "unit": "m3" },
+    { "material_id": "metal_roof_ruukki", "quantity": 140, "unit": "m2" },
+    { "material_id": "gypsum_board_13mm", "quantity": 380, "unit": "m2" },
+    { "material_id": "vapor_barrier", "quantity": 260, "unit": "m2" },
+    { "material_id": "wind_barrier", "quantity": 260, "unit": "m2" },
+    { "material_id": "wood_screw_5x80", "quantity": 3000, "unit": "kpl" }
+  ]
+}

--- a/data/geocode.ts
+++ b/data/geocode.ts
@@ -1,0 +1,41 @@
+/**
+ * Address geocoding via Digitransit Geocoding API (free, no key required).
+ * Returns WGS84 lat/lon for a Finnish address.
+ */
+
+export interface GeocodingResult {
+  lat: number;
+  lon: number;
+  label: string;
+  confidence: number;
+}
+
+const DIGITRANSIT_GEOCODING_URL =
+  "https://api.digitransit.fi/geocoding/v1/search";
+
+export async function geocodeAddress(
+  address: string
+): Promise<GeocodingResult | null> {
+  const url = `${DIGITRANSIT_GEOCODING_URL}?text=${encodeURIComponent(address)}&size=1&lang=fi`;
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    const features = data?.features;
+    if (!features || features.length === 0) return null;
+
+    const feature = features[0];
+    const [lon, lat] = feature.geometry.coordinates;
+    return {
+      lat,
+      lon,
+      label: feature.properties?.label || address,
+      confidence: feature.properties?.confidence || 0,
+    };
+  } catch {
+    console.error("Geocoding failed for:", address);
+    return null;
+  }
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { api, setToken, getToken } from "@/lib/api";
 
 interface Project {
@@ -11,7 +11,184 @@ interface Project {
   updated_at: string;
 }
 
-function LoginForm({ onLogin }: { onLogin: () => void }) {
+interface BuildingResult {
+  address: string;
+  coordinates: { lat: number; lon: number };
+  building_info: {
+    type: string;
+    year_built: number;
+    material: string;
+    floors: number;
+    area_m2: number;
+    heating: string;
+    roof_type?: string;
+    roof_material?: string;
+    units?: number;
+  };
+  scene_js: string;
+  bom_suggestion: { material_id: string; quantity: number; unit: string }[];
+}
+
+const BUILDING_TYPE_LABELS: Record<string, string> = {
+  omakotitalo: "Omakotitalo",
+  rivitalo: "Rivitalo",
+  kerrostalo: "Kerrostalo",
+  paritalo: "Paritalo",
+};
+
+const MATERIAL_LABELS: Record<string, string> = {
+  puu: "Puu",
+  tiili: "Tiili",
+  betoni: "Betoni",
+  hirsi: "Hirsi",
+};
+
+const HEATING_LABELS: Record<string, string> = {
+  kaukolampo: "Kaukolampo",
+  sahko: "Sahko",
+  maalampopumppu: "Maalampopumppu",
+  oljy: "Oljy",
+};
+
+function AddressSearch({ onCreateProject }: { onCreateProject: (building: BuildingResult) => void }) {
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<BuildingResult | null>(null);
+  const [searched, setSearched] = useState(false);
+
+  const search = useCallback(async () => {
+    if (!query.trim() || query.trim().length < 3) return;
+    setLoading(true);
+    setSearched(true);
+    try {
+      const data = await api.getBuilding(query.trim());
+      setResult(data);
+    } catch {
+      setResult(null);
+    }
+    setLoading(false);
+  }, [query]);
+
+  return (
+    <div style={{
+      width: "100%",
+      padding: "48px 24px 40px",
+      background: "linear-gradient(180deg, rgba(196,145,92,0.06) 0%, transparent 100%)",
+      borderBottom: "1px solid var(--border)",
+    }}>
+      <div style={{ maxWidth: 640, margin: "0 auto", textAlign: "center" }}>
+        <div className="label-mono" style={{ color: "var(--amber)", marginBottom: 12, letterSpacing: "0.12em" }}>
+          TALOHAUN DEMO
+        </div>
+        <h2 className="heading-display" style={{ fontSize: 28, marginBottom: 8 }}>
+          Miltae talosi nayttaa 3D:ssa?
+        </h2>
+        <p style={{ color: "var(--text-muted)", fontSize: 14, marginBottom: 24 }}>
+          Syota osoitteesi ja nae talosi kolmiulotteisena mallina.
+        </p>
+
+        <div style={{ display: "flex", gap: 8, maxWidth: 520, margin: "0 auto" }}>
+          <input
+            className="input"
+            placeholder="Syota osoitteesi, esim. Ribbingintie 109..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              if (searched) { setResult(null); setSearched(false); }
+            }}
+            onKeyDown={(e) => e.key === "Enter" && search()}
+            style={{ flex: 1, padding: "14px 16px", fontSize: 15 }}
+          />
+          <button
+            className={`btn ${query.trim().length >= 3 ? "btn-primary" : "btn-ghost"}`}
+            onClick={search}
+            disabled={loading || query.trim().length < 3}
+            style={{ padding: "14px 28px", fontSize: 14 }}
+          >
+            {loading ? "Haetaan..." : "Hae"}
+          </button>
+        </div>
+
+        {result && (
+          <div className="card anim-up" style={{
+            marginTop: 24,
+            padding: "24px 28px",
+            textAlign: "left",
+            maxWidth: 520,
+            marginLeft: "auto",
+            marginRight: "auto",
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 16 }}>
+              <div>
+                <h3 className="heading-display" style={{ fontSize: 18, marginBottom: 4 }}>
+                  {result.address}
+                </h3>
+                <span className="badge badge-amber">
+                  {BUILDING_TYPE_LABELS[result.building_info.type] || result.building_info.type}
+                </span>
+              </div>
+              <div style={{
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                color: "var(--text-muted)",
+                textAlign: "right",
+              }}>
+                {result.coordinates.lat.toFixed(4)}, {result.coordinates.lon.toFixed(4)}
+              </div>
+            </div>
+
+            <div style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr 1fr",
+              gap: 12,
+              marginBottom: 20,
+            }}>
+              {[
+                { label: "Rakennettu", value: String(result.building_info.year_built) },
+                { label: "Pinta-ala", value: `${result.building_info.area_m2} m\u00B2` },
+                { label: "Kerroksia", value: String(result.building_info.floors) },
+                { label: "Materiaali", value: MATERIAL_LABELS[result.building_info.material] || result.building_info.material },
+                { label: "Lammitys", value: HEATING_LABELS[result.building_info.heating] || result.building_info.heating },
+                { label: "BOM-rivit", value: `${result.bom_suggestion.length} kpl` },
+              ].map((item, i) => (
+                <div key={i} style={{
+                  padding: "10px 12px",
+                  background: "var(--bg-tertiary)",
+                  borderRadius: "var(--radius-sm)",
+                  border: "1px solid var(--border)",
+                }}>
+                  <div className="label-mono" style={{ marginBottom: 4, fontSize: 10 }}>{item.label}</div>
+                  <div style={{ fontSize: 14, fontWeight: 600 }}>{item.value}</div>
+                </div>
+              ))}
+            </div>
+
+            <button
+              className="btn btn-primary"
+              onClick={() => onCreateProject(result)}
+              style={{ width: "100%", padding: "13px 16px", fontSize: 14 }}
+            >
+              Luo projekti tasta talosta
+            </button>
+          </div>
+        )}
+
+        {searched && !loading && !result && (
+          <div className="anim-fade" style={{
+            marginTop: 20,
+            padding: "16px",
+            color: "var(--text-muted)",
+            fontSize: 13,
+          }}>
+            Osoitetta ei loytynyt. Kokeile esim. &quot;Ribbingintie 109&quot; tai &quot;Uunimaentie 1&quot;.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LoginForm({ onLogin, pendingBuilding }: { onLogin: () => void; pendingBuilding: BuildingResult | null }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
@@ -136,9 +313,11 @@ function LoginForm({ onLogin }: { onLogin: () => void }) {
               {isRegister ? "Luo tili" : "Kirjaudu sisaan"}
             </h2>
             <p style={{ color: "var(--text-muted)", fontSize: 14 }}>
-              {isRegister
-                ? "Aloita rakennusprojektien suunnittelu"
-                : "Jatka siita mihin jait"}
+              {pendingBuilding
+                ? "Kirjaudu luodaksesi projekti osoitteesta: " + pendingBuilding.address
+                : isRegister
+                  ? "Aloita rakennusprojektien suunnittelu"
+                  : "Jatka siita mihin jait"}
             </p>
           </div>
 
@@ -452,6 +631,7 @@ function ProjectList() {
 
 export default function Home() {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [pendingBuilding, setPendingBuilding] = useState<BuildingResult | null>(null);
 
   useEffect(() => {
     if (getToken()) {
@@ -459,6 +639,53 @@ export default function Home() {
     }
   }, []);
 
-  if (!loggedIn) return <LoginForm onLogin={() => setLoggedIn(true)} />;
-  return <ProjectList />;
+  async function handleCreateFromBuilding(building: BuildingResult) {
+    if (!loggedIn) {
+      // Store the building and prompt login
+      setPendingBuilding(building);
+      return;
+    }
+    await createProjectFromBuilding(building);
+  }
+
+  async function createProjectFromBuilding(building: BuildingResult) {
+    try {
+      const project = await api.createProject({
+        name: building.address,
+        description: `${BUILDING_TYPE_LABELS[building.building_info.type] || building.building_info.type}, ${building.building_info.year_built}, ${building.building_info.area_m2} m\u00B2`,
+        scene_js: building.scene_js,
+      });
+      if (building.bom_suggestion.length > 0) {
+        await api.saveBOM(project.id, building.bom_suggestion);
+      }
+      window.location.href = `/project/${project.id}`;
+    } catch (err) {
+      console.error("Failed to create project from building:", err);
+    }
+  }
+
+  async function handleLogin() {
+    setLoggedIn(true);
+    // If there was a pending building lookup, create the project now
+    if (pendingBuilding) {
+      await createProjectFromBuilding(pendingBuilding);
+      setPendingBuilding(null);
+    }
+  }
+
+  if (!loggedIn) {
+    return (
+      <div>
+        <AddressSearch onCreateProject={handleCreateFromBuilding} />
+        <LoginForm onLogin={handleLogin} pendingBuilding={pendingBuilding} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <AddressSearch onCreateProject={handleCreateFromBuilding} />
+      <ProjectList />
+    </div>
+  );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -82,4 +82,7 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ messages, currentScene }),
     }),
+
+  getBuilding: (address: string) =>
+    apiFetch(`/building?address=${encodeURIComponent(address)}`),
 };


### PR DESCRIPTION
## Summary
- Address geocoding module via Digitransit API (`data/geocode.ts`)
- Building data API endpoint: `GET /building?address=...` with fuzzy address matching
- Pre-built demo data for Ribbingintie 109-11 (Helsinki) and Uunimäentie 1 (Vantaa) with realistic 3D scene scripts
- Address search bar prominently placed on landing page (works without login)
- Full project creation flow: search → preview building info → login → auto-create project with scene + BOM
- Generic fallback building generation based on postal code area characteristics

Closes #30
Closes #32

## Test plan
- [ ] `GET /building?address=Ribbingintie+109` returns valid scene data for the Helsinki omakotitalo
- [ ] `GET /building?address=Uunimäentie+1` returns valid scene data for the Vantaa rivitalo
- [ ] Unknown addresses return a generic building based on postal code
- [ ] Address search visible on landing page above login form
- [ ] Building preview card shows type, year, area, floors, material, heating
- [ ] "Luo projekti tästä talosta" button triggers login flow for unauthenticated users
- [ ] After login, project is auto-created with scene_js and BOM pre-filled
- [ ] Web app builds without type errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)