### PR TITLE
Add brand assets: favicon, OG meta tags, manifest (#47)

### DIFF
--- a/web/public/icon.svg
+++ b/web/public/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- House silhouette with scoop-shaped roof -->
+  <path d="M16 3L3 15h3v13h8v-8h4v8h8V15h3L16 3z" fill="none" stroke="#c4915c" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round"/>
+  <!-- Chimney -->
+  <path d="M22 8v-3h3v7" fill="none" stroke="#c4915c" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round"/>
+</svg>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Helscoop",
+  "short_name": "Helscoop",
+  "description": "Finnish house visualization and renovation platform",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#12110f",
+  "theme_color": "#12110f",
+  "icons": [
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml" }
+  ]
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -3,8 +3,19 @@ import "./globals.css";
 import { ToastProvider } from "@/components/ToastProvider";
 
 export const metadata: Metadata = {
-  title: "Helscoop - Rakennusprojektien suunnittelu",
-  description: "Suunnittele ja laske rakennusprojektisi reaaliaikaisilla hinnoilla",
+  title: "Helscoop — Näe talosi. Muuta. Rakenna.",
+  description:
+    "3D-mallinna talosi ja suunnittele remontti reaaliaikaisilla hinnoilla",
+  icons: {
+    icon: { url: "/icon.svg", type: "image/svg+xml" },
+    apple: "/icon.svg",
+  },
+  manifest: "/manifest.json",
+  openGraph: {
+    title: "Helscoop",
+    description: "Näe talosi 3D:nä, suunnittele remontti suomeksi",
+    type: "website",
+  },
 };
 
 export default function RootLayout({
@@ -14,6 +25,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fi">
+      <head>
+        <style
+          dangerouslySetInnerHTML={{ __html: "html{background:#12110f}" }}
+        />
+      </head>
       <body className="grain">
         <ToastProvider>{children}</ToastProvider>
       </body>


### PR DESCRIPTION
## Summary
- SVG favicon with house silhouette in amber (#c4915c) brand color
- Open Graph meta tags for Finnish social sharing previews
- Web app manifest for PWA-readiness with dark theme colors
- Anti-flash inline style prevents white background flash on load
- Apple touch icon reference

Closes #47

## Test plan
- [ ] Favicon visible in browser tab
- [ ] No white flash on initial page load
- [ ] Social share preview shows correct title/description
- [ ] Web app builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)