### PR TITLE
Add Three.js 3D viewport to project editor (#5)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,9 +8,11 @@
       "name": "helscoop-web",
       "version": "0.1.0",
       "dependencies": {
+        "@types/three": "^0.184.0",
         "next": "^14.1.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -19,6 +21,12 @@
         "typescript": "^5.3.3",
         "vitest": "^1.2.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -954,6 +962,12 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -998,6 +1012,32 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -1344,6 +1384,12 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1478,6 +1524,12 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
     },
     "node_modules/mimic-fn": {
@@ -1959,6 +2011,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/web/package.json
+++ b/web/package.json
@@ -9,9 +9,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@types/three": "^0.184.0",
     "next": "^14.1.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1,10 +1,20 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import dynamic from "next/dynamic";
 import { useParams, useRouter } from "next/navigation";
 import { api, getToken, setToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectEditor } from "@/components/Skeleton";
+
+const Viewport3D = dynamic(() => import("@/components/Viewport3D"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ width: "100%", height: "100%", background: "#1a1816", borderRadius: "var(--radius-md)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-muted)", fontSize: 13 }}>
+      Ladataan 3D-nakyma...
+    </div>
+  ),
+});
 
 interface Material {
   id: string;
@@ -505,6 +515,11 @@ export default function ProjectPage() {
   const [projectName, setProjectName] = useState("");
   const [projectDesc, setProjectDesc] = useState("");
   const [showChat, setShowChat] = useState(false);
+  const [showCode, setShowCode] = useState(false);
+  const [wireframe, setWireframe] = useState(false);
+  const [objectCount, setObjectCount] = useState(0);
+  const [sceneError, setSceneError] = useState<string | null>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
 
   // Undo/redo history for scene script
   const historyRef = useRef<string[]>([]);
@@ -883,22 +898,143 @@ export default function ProjectPage() {
 
       {/* Main content */}
       <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+        {/* Left: Viewport + Code */}
         <div
           style={{
             flex: 1,
             display: "flex",
             flexDirection: "column",
-            padding: 16,
-            gap: 12,
+            overflow: "hidden",
           }}
         >
-          <SceneEditor sceneJs={sceneJs} onChange={handleSceneChange} />
+          {/* Toolbar */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "6px 12px",
+              background: "var(--bg-tertiary)",
+              borderBottom: "1px solid var(--border)",
+              flexShrink: 0,
+            }}
+          >
+            <button
+              className="btn"
+              onClick={() => setShowCode(!showCode)}
+              style={{
+                padding: "4px 10px",
+                fontSize: 11,
+                fontWeight: 600,
+                background: showCode ? "rgba(196,145,92,0.2)" : "transparent",
+                color: showCode ? "#c4915c" : "var(--text-muted)",
+                border: showCode ? "1px solid rgba(196,145,92,0.3)" : "1px solid transparent",
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 4 }}>
+                <polyline points="16 18 22 12 16 6" />
+                <polyline points="8 6 2 12 8 18" />
+              </svg>
+              {showCode ? "Piilota koodi" : "Nayta koodi"}
+            </button>
+            <div style={{ width: 1, height: 16, background: "var(--border)" }} />
+            <button
+              className="btn"
+              onClick={() => setWireframe(!wireframe)}
+              style={{
+                padding: "4px 10px",
+                fontSize: 11,
+                fontWeight: 600,
+                background: wireframe ? "rgba(196,145,92,0.2)" : "transparent",
+                color: wireframe ? "#c4915c" : "var(--text-muted)",
+                border: wireframe ? "1px solid rgba(196,145,92,0.3)" : "1px solid transparent",
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 4 }}>
+                <path d="M12 2L2 7l10 5 10-5-10-5z" />
+                <path d="M2 17l10 5 10-5" />
+                <path d="M2 12l10 5 10-5" />
+              </svg>
+              Rautalanka
+            </button>
+            <button
+              className="btn"
+              onClick={() => {
+                const container = viewportRef.current;
+                if (container) {
+                  const el = container.querySelector("div") as HTMLDivElement & { resetCamera?: () => void };
+                  el?.resetCamera?.();
+                }
+              }}
+              style={{
+                padding: "4px 10px",
+                fontSize: 11,
+                fontWeight: 600,
+                background: "transparent",
+                color: "var(--text-muted)",
+                border: "1px solid transparent",
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ marginRight: 4 }}>
+                <path d="M1 4v6h6" />
+                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+              </svg>
+              Nollaa kamera
+            </button>
+            <div style={{ flex: 1 }} />
+            <span style={{
+              fontSize: 11,
+              color: sceneError ? "var(--danger, #e06c75)" : "var(--text-muted)",
+              fontFamily: "var(--font-mono)",
+            }}>
+              {sceneError
+                ? `Virhe: ${sceneError.substring(0, 40)}${sceneError.length > 40 ? "..." : ""}`
+                : `${objectCount} objektia`}
+            </span>
+          </div>
+
+          {/* 3D Viewport */}
+          <div
+            ref={viewportRef}
+            style={{
+              flex: 1,
+              minHeight: 0,
+              padding: 8,
+              paddingBottom: showCode ? 0 : 8,
+            }}
+          >
+            <Viewport3D
+              sceneJs={sceneJs}
+              wireframe={wireframe}
+              onObjectCount={setObjectCount}
+              onError={setSceneError}
+            />
+          </div>
+
+          {/* Collapsible Code Editor */}
+          {showCode && (
+            <div
+              style={{
+                height: 260,
+                flexShrink: 0,
+                padding: "0 8px 8px 8px",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <SceneEditor sceneJs={sceneJs} onChange={handleSceneChange} />
+            </div>
+          )}
         </div>
+
+        {/* Chat panel */}
         {showChat && (
           <div style={{ width: 340, borderLeft: "1px solid var(--border)", flexShrink: 0 }}>
             <ChatPanel sceneJs={sceneJs} onApplyCode={handleApplyCode} />
           </div>
         )}
+
+        {/* BOM panel */}
         <BomPanel
           bom={bom}
           materials={materials}

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { interpretScene, SceneObject } from "@/lib/scene-interpreter";
+
+interface Viewport3DProps {
+  sceneJs: string;
+  wireframe?: boolean;
+  onObjectCount?: (count: number) => void;
+  onError?: (error: string | null) => void;
+}
+
+function createGeometry(obj: SceneObject): THREE.BufferGeometry {
+  switch (obj.geometry) {
+    case "box":
+      return new THREE.BoxGeometry(
+        obj.args[0] || 1,
+        obj.args[1] || 1,
+        obj.args[2] || 1
+      );
+    case "cylinder":
+      return new THREE.CylinderGeometry(
+        obj.args[0] || 0.5,
+        obj.args[0] || 0.5,
+        obj.args[1] || 1,
+        32
+      );
+    case "sphere":
+      return new THREE.SphereGeometry(obj.args[0] || 0.5, 32, 16);
+    default:
+      return new THREE.BoxGeometry(1, 1, 1);
+  }
+}
+
+function addSceneObjects(
+  parent: THREE.Group,
+  objects: SceneObject[],
+  wireframe: boolean
+): number {
+  let count = 0;
+
+  for (const obj of objects) {
+    if (obj.geometry === "group" && obj.children) {
+      const group = new THREE.Group();
+      group.position.set(...obj.position);
+      group.rotation.set(...obj.rotation);
+      count += addSceneObjects(group, obj.children, wireframe);
+      parent.add(group);
+    } else {
+      const geometry = createGeometry(obj);
+      const material = new THREE.MeshStandardMaterial({
+        color: new THREE.Color(obj.color[0], obj.color[1], obj.color[2]),
+        roughness: 0.7,
+        metalness: 0.05,
+        wireframe,
+      });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.set(...obj.position);
+      mesh.rotation.set(...obj.rotation);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      parent.add(mesh);
+      count++;
+    }
+  }
+
+  return count;
+}
+
+export default function Viewport3D({
+  sceneJs,
+  wireframe = false,
+  onObjectCount,
+  onError,
+}: Viewport3DProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const controlsRef = useRef<OrbitControls | null>(null);
+  const objectGroupRef = useRef<THREE.Group | null>(null);
+  const animFrameRef = useRef<number>(0);
+  const lastValidSceneRef = useRef<string>(sceneJs);
+
+  // Initialize Three.js scene
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Scene
+    const scene = new THREE.Scene();
+    sceneRef.current = scene;
+
+    // Sky gradient background
+    const canvas = document.createElement("canvas");
+    canvas.width = 2;
+    canvas.height = 256;
+    const ctx = canvas.getContext("2d")!;
+    const gradient = ctx.createLinearGradient(0, 0, 0, 256);
+    gradient.addColorStop(0, "#1a1d2e");
+    gradient.addColorStop(0.6, "#1e1f28");
+    gradient.addColorStop(1, "#2a2420");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, 2, 256);
+    const bgTexture = new THREE.CanvasTexture(canvas);
+    bgTexture.magFilter = THREE.LinearFilter;
+    scene.background = bgTexture;
+
+    // Camera
+    const aspect = container.clientWidth / container.clientHeight;
+    const camera = new THREE.PerspectiveCamera(50, aspect, 0.1, 200);
+    camera.position.set(8, 6, 8);
+    camera.lookAt(0, 1, 0);
+    cameraRef.current = camera;
+
+    // Renderer
+    const renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      alpha: false,
+    });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.shadowMap.enabled = true;
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 0.9;
+    container.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
+
+    // Orbit Controls
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controls.dampingFactor = 0.08;
+    controls.target.set(0, 1, 0);
+    controls.minDistance = 2;
+    controls.maxDistance = 50;
+    controls.maxPolarAngle = Math.PI * 0.85;
+    controls.update();
+    controlsRef.current = controls;
+
+    // Lights
+    const ambientLight = new THREE.AmbientLight(0xffeedd, 0.4);
+    scene.add(ambientLight);
+
+    const hemisphereLight = new THREE.HemisphereLight(0x8899bb, 0x443322, 0.3);
+    scene.add(hemisphereLight);
+
+    const dirLight = new THREE.DirectionalLight(0xfff5e6, 1.2);
+    dirLight.position.set(5, 8, 4);
+    dirLight.castShadow = true;
+    dirLight.shadow.mapSize.width = 2048;
+    dirLight.shadow.mapSize.height = 2048;
+    dirLight.shadow.camera.near = 0.5;
+    dirLight.shadow.camera.far = 30;
+    dirLight.shadow.camera.left = -10;
+    dirLight.shadow.camera.right = 10;
+    dirLight.shadow.camera.top = 10;
+    dirLight.shadow.camera.bottom = -10;
+    dirLight.shadow.bias = -0.001;
+    scene.add(dirLight);
+
+    // Grid floor
+    const gridHelper = new THREE.GridHelper(20, 20, 0x333333, 0x222222);
+    (gridHelper.material as THREE.Material).opacity = 0.15;
+    (gridHelper.material as THREE.Material).transparent = true;
+    scene.add(gridHelper);
+
+    // Ground plane (receives shadows, subtle)
+    const groundGeom = new THREE.PlaneGeometry(40, 40);
+    const groundMat = new THREE.MeshStandardMaterial({
+      color: 0x1a1816,
+      roughness: 0.95,
+      metalness: 0.0,
+    });
+    const ground = new THREE.Mesh(groundGeom, groundMat);
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = -0.01;
+    ground.receiveShadow = true;
+    scene.add(ground);
+
+    // Object group (will be populated with scene objects)
+    const objectGroup = new THREE.Group();
+    scene.add(objectGroup);
+    objectGroupRef.current = objectGroup;
+
+    // Animation loop
+    function animate() {
+      animFrameRef.current = requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    }
+    animate();
+
+    // Resize handler
+    const resizeObserver = new ResizeObserver(() => {
+      if (!container) return;
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      if (w === 0 || h === 0) return;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    });
+    resizeObserver.observe(container);
+
+    return () => {
+      resizeObserver.disconnect();
+      cancelAnimationFrame(animFrameRef.current);
+      controls.dispose();
+      renderer.dispose();
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+      bgTexture.dispose();
+      groundGeom.dispose();
+      groundMat.dispose();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Update scene objects when sceneJs or wireframe changes
+  const updateScene = useCallback(
+    (script: string, wf: boolean) => {
+      const group = objectGroupRef.current;
+      if (!group) return;
+
+      // Clear existing objects
+      while (group.children.length > 0) {
+        const child = group.children[0];
+        group.remove(child);
+        if (child instanceof THREE.Mesh) {
+          child.geometry.dispose();
+          if (child.material instanceof THREE.Material) {
+            child.material.dispose();
+          }
+        }
+      }
+
+      // Interpret and render
+      const result = interpretScene(script);
+
+      if (result.error) {
+        onError?.(result.error);
+        // On error, try rendering last valid scene
+        if (script !== lastValidSceneRef.current) {
+          const fallback = interpretScene(lastValidSceneRef.current);
+          if (!fallback.error) {
+            const count = addSceneObjects(group, fallback.objects, wf);
+            onObjectCount?.(count);
+          }
+        }
+        return;
+      }
+
+      lastValidSceneRef.current = script;
+      onError?.(null);
+      const count = addSceneObjects(group, result.objects, wf);
+      onObjectCount?.(count);
+    },
+    [onObjectCount, onError]
+  );
+
+  // Debounced scene update
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      updateScene(sceneJs, wireframe);
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [sceneJs, wireframe, updateScene]);
+
+  // Expose reset camera function via ref on container
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    (container as HTMLDivElement & { resetCamera?: () => void }).resetCamera =
+      () => {
+        const camera = cameraRef.current;
+        const controls = controlsRef.current;
+        if (camera && controls) {
+          camera.position.set(8, 6, 8);
+          controls.target.set(0, 1, 0);
+          controls.update();
+        }
+      };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: "100%",
+        height: "100%",
+        minHeight: 200,
+        background: "#1a1816",
+        borderRadius: "var(--radius-md)",
+        overflow: "hidden",
+      }}
+    />
+  );
+}

--- a/web/src/lib/scene-interpreter.ts
+++ b/web/src/lib/scene-interpreter.ts
@@ -1,0 +1,175 @@
+/**
+ * Scene Script Interpreter for Helscoop
+ *
+ * Executes scene scripts in a sandboxed manner using the Function constructor.
+ * Provides primitives (box, cylinder, sphere), transforms (translate, rotate),
+ * boolean-like operations (union, subtract, intersect), and scene.add().
+ */
+
+export interface MeshDescriptor {
+  type: "box" | "cylinder" | "sphere" | "group";
+  args: number[];
+  position: [number, number, number];
+  rotation: [number, number, number];
+  children?: MeshDescriptor[];
+}
+
+export interface SceneObject {
+  geometry: "box" | "cylinder" | "sphere" | "group";
+  args: number[];
+  position: [number, number, number];
+  rotation: [number, number, number];
+  color: [number, number, number];
+  material: string;
+  children?: SceneObject[];
+}
+
+function createMesh(
+  type: MeshDescriptor["type"],
+  args: number[]
+): MeshDescriptor {
+  return {
+    type,
+    args,
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+  };
+}
+
+function box(w: number, h: number, d: number): MeshDescriptor {
+  return createMesh("box", [w, h, d]);
+}
+
+function cylinder(r: number, h: number): MeshDescriptor {
+  return createMesh("cylinder", [r, h]);
+}
+
+function sphere(r: number): MeshDescriptor {
+  return createMesh("sphere", [r]);
+}
+
+function translate(
+  mesh: MeshDescriptor,
+  x: number,
+  y: number,
+  z: number
+): MeshDescriptor {
+  return {
+    ...mesh,
+    position: [
+      mesh.position[0] + x,
+      mesh.position[1] + y,
+      mesh.position[2] + z,
+    ],
+    children: mesh.children ? [...mesh.children] : undefined,
+  };
+}
+
+function rotate(
+  mesh: MeshDescriptor,
+  rx: number,
+  ry: number,
+  rz: number
+): MeshDescriptor {
+  return {
+    ...mesh,
+    rotation: [
+      mesh.rotation[0] + rx,
+      mesh.rotation[1] + ry,
+      mesh.rotation[2] + rz,
+    ],
+    children: mesh.children ? [...mesh.children] : undefined,
+  };
+}
+
+function union(a: MeshDescriptor, b: MeshDescriptor): MeshDescriptor {
+  return {
+    type: "group",
+    args: [],
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    children: [a, b],
+  };
+}
+
+function subtract(a: MeshDescriptor, b: MeshDescriptor): MeshDescriptor {
+  // For MVP, just return a (real CSG subtraction is complex)
+  return {
+    type: "group",
+    args: [],
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    children: [a, b],
+  };
+}
+
+function intersect(a: MeshDescriptor, b: MeshDescriptor): MeshDescriptor {
+  return {
+    type: "group",
+    args: [],
+    position: [0, 0, 0],
+    rotation: [0, 0, 0],
+    children: [a, b],
+  };
+}
+
+export interface InterpreterResult {
+  objects: SceneObject[];
+  error: string | null;
+}
+
+function meshToSceneObject(
+  mesh: MeshDescriptor,
+  material: string,
+  color: [number, number, number]
+): SceneObject {
+  return {
+    geometry: mesh.type,
+    args: mesh.args,
+    position: mesh.position,
+    rotation: mesh.rotation,
+    color,
+    material,
+    children: mesh.children?.map((c) => meshToSceneObject(c, material, color)),
+  };
+}
+
+export function interpretScene(script: string): InterpreterResult {
+  const objects: SceneObject[] = [];
+
+  const sceneProxy = {
+    add(
+      mesh: MeshDescriptor,
+      opts?: { material?: string; color?: [number, number, number] }
+    ) {
+      const mat = opts?.material || "default";
+      const col: [number, number, number] = opts?.color || [0.8, 0.8, 0.8];
+      objects.push(meshToSceneObject(mesh, mat, col));
+    },
+  };
+
+  try {
+    // Build the sandboxed function with restricted scope
+    const fn = new Function(
+      "box",
+      "cylinder",
+      "sphere",
+      "translate",
+      "rotate",
+      "union",
+      "subtract",
+      "intersect",
+      "scene",
+      script
+    );
+
+    fn(box, cylinder, sphere, translate, rotate, union, subtract, intersect, sceneProxy);
+
+    return { objects, error: null };
+  } catch (err) {
+    return {
+      objects,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Three.js 3D viewport rendering scene scripts in real-time
- Scene script interpreter (box, cylinder, sphere, translate, rotate, scene.add)
- Orbit controls (rotate, zoom, pan)
- Grid floor, ambient+directional lighting, dark sky gradient
- Collapsible code editor below viewport
- Toolbar with wireframe toggle and camera reset

Closes #5

## Test plan
- [ ] Default scene renders 3D boxes for walls and floor
- [ ] Orbit controls work (drag to rotate, scroll to zoom)
- [ ] Code changes update 3D view in real-time
- [ ] Scene parse errors show last valid render
- [ ] Web app builds without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)