### PR TITLE
Add CSV export dropdown for BOM (#57)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -418,7 +418,7 @@ app.get("/bom/export/:projectId", requireAuth, async (req, res) => {
       "Content-Disposition",
       `attachment; filename="bom_${req.params.projectId}.csv"`
     );
-    return res.send(header + rows);
+    return res.send('\uFEFF' + header + rows);
   }
 
   res.json(result.rows);

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -522,6 +522,8 @@ export default function ProjectPage() {
   const [projectName, setProjectName] = useState("");
   const [projectDesc, setProjectDesc] = useState("");
   const [showChat, setShowChat] = useState(false);
+  const [showExport, setShowExport] = useState(false);
+  const exportDropdownRef = useRef<HTMLDivElement>(null);
   const [showCode, setShowCode] = useState(false);
   const [wireframe, setWireframe] = useState(false);
   const [objectCount, setObjectCount] = useState(0);
@@ -671,6 +673,18 @@ export default function ProjectPage() {
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
   }, [saveStatus]);
+
+  // Close export dropdown on click outside
+  useEffect(() => {
+    if (!showExport) return;
+    const handler = (e: MouseEvent) => {
+      if (exportDropdownRef.current && !exportDropdownRef.current.contains(e.target as Node)) {
+        setShowExport(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showExport]);
 
   // Keyboard shortcuts for undo/redo
   useEffect(() => {
@@ -868,23 +882,71 @@ export default function ProjectPage() {
         <button className="btn" onClick={save} style={{ padding: "6px 16px", background: "linear-gradient(135deg, #c4915c 0%, #a67745 100%)", color: "#fff", border: "none" }}>
           {t('editor.save')}
         </button>
-        <button className="btn btn-ghost" onClick={async () => {
-          try {
-            const res = await api.exportBOM(projectId);
-            const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = `bom_${projectId}.json`;
-            a.click();
-            URL.revokeObjectURL(url);
-            toast(t('toast.bomExported'), "success");
-          } catch (err) {
-            toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
-          }
-        }}>
-          {t('editor.export')}
-        </button>
+        <div ref={exportDropdownRef} style={{ position: 'relative' }}>
+          <button
+            className="btn btn-ghost"
+            onClick={() => setShowExport(!showExport)}
+            style={{ padding: "6px 12px", display: "flex", alignItems: "center", gap: 4 }}
+          >
+            {t('editor.export')} <span style={{ fontSize: 10 }}>{"\u25BE"}</span>
+          </button>
+          {showExport && (
+            <div style={{
+              position: 'absolute', top: '100%', right: 0, marginTop: 4,
+              background: 'var(--bg-elevated)', border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)', overflow: 'hidden', zIndex: 10,
+              minWidth: 160, boxShadow: 'var(--shadow-md)',
+            }}>
+              <button
+                onClick={async () => {
+                  setShowExport(false);
+                  try {
+                    await api.exportBOMCsv(projectId, projectName);
+                    toast(t('toast.bomExported'), "success");
+                  } catch (err) {
+                    toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
+                  }
+                }}
+                style={{
+                  display: 'block', width: '100%', textAlign: 'left',
+                  padding: '10px 16px', fontSize: 13, border: 'none',
+                  background: 'transparent', color: 'var(--text-primary)', cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+              >
+                CSV (Excel)
+              </button>
+              <button
+                onClick={async () => {
+                  setShowExport(false);
+                  try {
+                    const res = await api.exportBOM(projectId);
+                    const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = `bom_${projectId}.json`;
+                    a.click();
+                    URL.revokeObjectURL(url);
+                    toast(t('toast.bomExported'), "success");
+                  } catch (err) {
+                    toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
+                  }
+                }}
+                style={{
+                  display: 'block', width: '100%', textAlign: 'left',
+                  padding: '10px 16px', fontSize: 13, border: 'none',
+                  background: 'transparent', color: 'var(--text-primary)', cursor: 'pointer',
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--bg-hover)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+              >
+                JSON
+              </button>
+            </div>
+          )}
+        </div>
         <button
           className="btn"
           onClick={() => setShowChat(!showChat)}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -115,6 +115,26 @@ export const api = {
   getCategories: () => apiFetch("/categories"),
   getTemplates: () => apiFetch("/templates"),
   exportBOM: (projectId: string) => apiFetch(`/bom/export/${projectId}`),
+  exportBOMCsv: async (projectId: string, projectName: string) => {
+    const t = getToken();
+    const res = await fetch(`${API_URL}/bom/export/${projectId}?format=csv`, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (!res.ok) {
+      throw new ApiError(
+        ERROR_MESSAGES[res.status] || `Virhe ${res.status} / Error ${res.status}`,
+        res.status,
+        res.statusText
+      );
+    }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `helscoop_${projectName.replace(/\s+/g, '_')}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  },
   saveBOM: (projectId: string, items: { material_id: string; quantity: number; unit: string }[]) =>
     apiFetch(`/projects/${projectId}/bom`, {
       method: "PUT",


### PR DESCRIPTION
## Summary
- Replace single "Vie BOM" button with an export dropdown offering CSV (Excel) and JSON options
- CSV download triggers a file save with the project name in the filename (`helscoop_<project>.csv`)
- Prepend UTF-8 BOM character (`\uFEFF`) to CSV output so Excel renders Finnish characters (e.g. a, o) correctly
- Dropdown matches dark theme using design system variables, closes on outside click or after selection

Closes #57

## Test plan
- [ ] Click "Vie" dropdown in project editor header -- two options appear
- [ ] "CSV (Excel)" downloads a `.csv` file with correct Finnish characters
- [ ] File opens in Excel without encoding issues
- [ ] "JSON" export still works as before
- [ ] Dropdown closes on selection and on click outside
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)