### PR TITLE
Add responsive mobile-first layout (#6)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -303,3 +303,369 @@ body {
   text-transform: uppercase;
   color: var(--text-muted);
 }
+
+/* ===========================================
+   Responsive / Mobile-First Layout
+   =========================================== */
+
+/* -- Login page: 2-column grid stacks on mobile -- */
+.login-grid {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  position: relative;
+}
+
+.login-brand {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 60px 80px;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(160deg, #1a1510 0%, #12110f 100%);
+}
+
+.login-form-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 40px;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border);
+  position: relative;
+}
+
+/* -- Nav bar -- */
+.nav-bar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(18,17,15,0.85);
+  backdrop-filter: blur(16px) saturate(1.2);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-inner {
+  max-width: 1080;
+  margin: 0 auto;
+  padding: 12px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-links {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.nav-hamburger {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-mobile-menu {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 24px 16px;
+  background: rgba(18,17,15,0.95);
+  border-bottom: 1px solid var(--border);
+}
+
+.nav-mobile-menu.open {
+  display: flex;
+}
+
+/* -- Project editor: main layout -- */
+.editor-main {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.editor-viewport-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.editor-bom-panel {
+  width: 360px;
+  border-left: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.editor-chat-panel {
+  width: 340px;
+  border-left: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* -- Editor page container -- */
+.editor-page {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* -- Editor header -- */
+.editor-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.editor-header-meta {
+  display: contents;
+}
+
+.editor-header-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+  border: none;
+  background: transparent;
+  outline: none;
+  width: 180px;
+}
+
+.editor-header-actions {
+  display: contents;
+}
+
+/* -- Project cards -- */
+.project-card-grid {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 16px;
+  align-items: center;
+}
+
+.project-card-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* -- Template cards grid -- */
+.template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+/* -- Building info grid -- */
+.building-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+}
+
+/* -- Address search bar -- */
+.address-search-bar {
+  display: flex;
+  gap: 8px;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+/* -- Building result: 3D preview + info side by side -- */
+.building-result-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+/* -- Feature highlights grid -- */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+}
+
+/* -- Settings page card padding -- */
+.settings-card {
+  padding: 28px 32px;
+}
+
+/* ========= MOBILE BREAKPOINT (768px) ========= */
+
+@media (max-width: 768px) {
+  /* Login: stack vertically */
+  .login-grid {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .login-brand {
+    padding: 40px 24px;
+    min-height: auto;
+  }
+
+  .login-form-panel {
+    padding: 32px 20px;
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
+
+  /* Nav: hamburger menu */
+  .nav-hamburger {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .nav-links {
+    display: none;
+  }
+
+  .nav-links.mobile-open {
+    display: flex;
+  }
+
+  .nav-inner {
+    padding: 10px 16px;
+  }
+
+  /* Editor page: allow scrolling on mobile */
+  .editor-page {
+    height: auto;
+    min-height: 100vh;
+    min-height: 100dvh;
+  }
+
+  /* Editor: stack viewport and BOM vertically */
+  .editor-main {
+    flex-direction: column;
+    overflow: visible;
+  }
+
+  .editor-bom-panel {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid var(--border);
+    max-height: 50vh;
+  }
+
+  .editor-chat-panel {
+    width: 100%;
+    border-left: none;
+    border-top: 1px solid var(--border);
+    max-height: 50vh;
+  }
+
+  .editor-viewport-area {
+    min-height: 300px;
+  }
+
+  /* Editor header: wrap and collapse on mobile */
+  .editor-header {
+    flex-wrap: wrap;
+    gap: 6px;
+    padding: 8px 12px;
+  }
+
+  .editor-header-desc {
+    display: none;
+  }
+
+  .editor-header-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  /* Project cards: stack vertically */
+  .project-card-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .project-card-actions {
+    flex-wrap: wrap;
+  }
+
+  /* Template cards: single column */
+  .template-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Building info: 2 columns on mobile */
+  .building-info-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  /* Address search stacks */
+  .address-search-bar {
+    flex-direction: column;
+  }
+
+  /* Building result stacks */
+  .building-result-grid {
+    grid-template-columns: 1fr;
+  }
+
+  /* Feature highlights stack */
+  .feature-grid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  /* Settings */
+  .settings-card {
+    padding: 20px 16px;
+  }
+
+  /* Brand heading smaller */
+  .login-brand .heading-display {
+    font-size: 40px;
+  }
+
+  /* Fluid typography */
+  body {
+    font-size: 13px;
+  }
+}
+
+/* ========= SMALL MOBILE (480px) ========= */
+
+@media (max-width: 480px) {
+  .login-brand {
+    padding: 32px 16px;
+  }
+
+  .login-form-panel {
+    padding: 24px 16px;
+  }
+
+  .login-brand .heading-display {
+    font-size: 32px;
+  }
+
+  .building-info-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .nav-inner {
+    padding: 8px 12px;
+  }
+
+  .editor-header {
+    padding: 6px 10px;
+  }
+}

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -286,25 +286,10 @@ export default function ProjectPage() {
   }
 
   return (
-    <div
-      style={{
-        height: "100vh",
-        display: "flex",
-        flexDirection: "column",
-      }}
-    >
+    <div className="editor-page">
+
       {/* Header */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 10,
-          padding: "8px 16px",
-          background: "var(--bg-secondary)",
-          borderBottom: "1px solid var(--border)",
-          flexShrink: 0,
-        }}
-      >
+      <div className="editor-header">
         <button className="btn btn-ghost" onClick={() => router.push("/")} style={{ padding: "6px 10px" }}>
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="15 18 9 12 15 6" />
@@ -326,17 +311,10 @@ export default function ProjectPage() {
           }}
         />
         <input
+          className="editor-header-desc"
           value={projectDesc}
           onChange={(e) => setProjectDesc(e.target.value)}
           placeholder={t('project.descriptionPlaceholder')}
-          style={{
-            fontSize: 13,
-            color: "var(--text-muted)",
-            border: "none",
-            background: "transparent",
-            outline: "none",
-            width: 180,
-          }}
         />
         <div style={{ display: "flex", gap: 2 }}>
           <button
@@ -364,77 +342,73 @@ export default function ProjectPage() {
             </svg>
           </button>
         </div>
-        <div style={{ width: 1, height: 20, background: "var(--border)" }} />
-        <span style={{
-          fontSize: 11,
-          color: saveStatus === "unsaved" ? "var(--warning, #e5c07b)" : saveStatus === "saving" ? "var(--accent)" : "var(--success)",
-          fontFamily: "var(--font-mono)",
-          display: "flex",
-          alignItems: "center",
-          gap: 4,
-        }}>
-          {saveStatus === "saving" && (
-            <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--accent)", animation: "pulse 1.5s infinite" }} />
-          )}
-          {saveStatus === "saved" && (
-            <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--success)" }} />
-          )}
-          {saveStatus === "unsaved" && (
-            <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--warning, #e5c07b)" }} />
-          )}
-          {saveStatus === "saving"
-            ? t('editor.saving')
-            : saveStatus === "saved"
-              ? `${t('editor.saved')}${lastSaved ? ` ${lastSaved}` : ""}`
-              : t('editor.unsaved')}
-        </span>
-        <button className="btn" onClick={save} style={{ padding: "6px 16px", background: "linear-gradient(135deg, #c4915c 0%, #a67745 100%)", color: "#fff", border: "none" }}>
-          {t('editor.save')}
-        </button>
-        <button className="btn btn-ghost" onClick={async () => {
-          try {
-            const res = await api.exportBOM(projectId);
-            const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = `bom_${projectId}.json`;
-            a.click();
-            URL.revokeObjectURL(url);
-            toast(t('toast.bomExported'), "success");
-          } catch (err) {
-            toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
-          }
-        }}>
-          {t('editor.export')}
-        </button>
-        <button
-          className="btn"
-          onClick={() => setShowChat(!showChat)}
-          style={{
-            padding: "6px 12px",
-            background: showChat ? "#c4915c" : "rgba(196,145,92,0.12)",
-            color: showChat ? "#fff" : "#c4915c",
-          }}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-          </svg>
-          {t('editor.assistant')}
-        </button>
-        <LanguageSwitcher />
+        <div className="editor-header-actions">
+          <div style={{ width: 1, height: 20, background: "var(--border)" }} />
+          <span style={{
+            fontSize: 11,
+            color: saveStatus === "unsaved" ? "var(--warning, #e5c07b)" : saveStatus === "saving" ? "var(--accent)" : "var(--success)",
+            fontFamily: "var(--font-mono)",
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}>
+            {saveStatus === "saving" && (
+              <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--accent)", animation: "pulse 1.5s infinite" }} />
+            )}
+            {saveStatus === "saved" && (
+              <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--success)" }} />
+            )}
+            {saveStatus === "unsaved" && (
+              <span style={{ display: "inline-block", width: 6, height: 6, borderRadius: "50%", background: "var(--warning, #e5c07b)" }} />
+            )}
+            {saveStatus === "saving"
+              ? t('editor.saving')
+              : saveStatus === "saved"
+                ? `${t('editor.saved')}${lastSaved ? ` ${lastSaved}` : ""}`
+                : t('editor.unsaved')}
+          </span>
+          <button className="btn" onClick={save} style={{ padding: "6px 16px", background: "linear-gradient(135deg, #c4915c 0%, #a67745 100%)", color: "#fff", border: "none" }}>
+            {t('editor.save')}
+          </button>
+          <button className="btn btn-ghost" onClick={async () => {
+            try {
+              const res = await api.exportBOM(projectId);
+              const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = `bom_${projectId}.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+              toast(t('toast.bomExported'), "success");
+            } catch (err) {
+              toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
+            }
+          }}>
+            {t('editor.export')}
+          </button>
+          <button
+            className="btn"
+            onClick={() => setShowChat(!showChat)}
+            style={{
+              padding: "6px 12px",
+              background: showChat ? "#c4915c" : "rgba(196,145,92,0.12)",
+              color: showChat ? "#fff" : "#c4915c",
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+            </svg>
+            {t('editor.assistant')}
+          </button>
+          <LanguageSwitcher />
+        </div>
       </div>
 
       {/* Main content */}
-      <div style={{ flex: 1, display: "flex", overflow: "hidden" }}>
-        <div
-          style={{
-            flex: 1,
-            display: "flex",
-            flexDirection: "column",
-            overflow: "hidden",
-          }}
-        >
+      <div className="editor-main">
+        {/* Left: Viewport + Code */}
+        <div className="editor-viewport-area">
           {/* Toolbar */}
           <div
             style={{
@@ -557,7 +531,7 @@ export default function ProjectPage() {
 
         {/* Chat panel */}
         {showChat && (
-          <div style={{ width: 340, borderLeft: "1px solid var(--border)", flexShrink: 0 }}>
+          <div className="editor-chat-panel">
             <ChatPanel sceneJs={sceneJs} onApplyCode={handleApplyCode} />
           </div>
         )}

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -135,26 +135,8 @@ export default function SettingsPage() {
   return (
     <div style={{ minHeight: "100vh" }}>
       {/* Top bar */}
-      <div
-        style={{
-          position: "sticky",
-          top: 0,
-          zIndex: 50,
-          background: "rgba(18,17,15,0.85)",
-          backdropFilter: "blur(16px) saturate(1.2)",
-          borderBottom: "1px solid var(--border)",
-        }}
-      >
-        <div
-          style={{
-            maxWidth: 720,
-            margin: "0 auto",
-            padding: "12px 24px",
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
+      <div className="nav-bar">
+        <div className="nav-inner" style={{ maxWidth: 720 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
             <span className="heading-display" style={{ fontSize: 20 }}>
               <span style={{ color: "var(--text-primary)" }}>Hel</span>
@@ -197,8 +179,8 @@ export default function SettingsPage() {
 
         {/* Profile section */}
         <div
-          className="card anim-up"
-          style={{ padding: "28px 32px", marginBottom: 20 }}
+          className="card anim-up settings-card"
+          style={{ marginBottom: 20 }}
         >
           <h2
             className="heading-display"
@@ -264,8 +246,8 @@ export default function SettingsPage() {
 
         {/* Security section */}
         <div
-          className="card anim-up delay-1"
-          style={{ padding: "28px 32px", marginBottom: 20 }}
+          className="card anim-up delay-1 settings-card"
+          style={{ marginBottom: 20 }}
         >
           <h2
             className="heading-display"
@@ -352,8 +334,7 @@ export default function SettingsPage() {
 
         {/* Account section */}
         <div
-          className="card anim-up delay-2"
-          style={{ padding: "28px 32px" }}
+          className="card anim-up delay-2 settings-card"
         >
           <h2
             className="heading-display"

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -77,7 +77,7 @@ export default function AddressSearch({ onCreateProject }: { onCreateProject: (b
           </>
         )}
 
-        <div style={{ display: "flex", gap: 8, maxWidth: 520, margin: "0 auto" }}>
+        <div className="address-search-bar">
           <input
             className="input"
             placeholder={t('search.placeholder')}
@@ -100,11 +100,8 @@ export default function AddressSearch({ onCreateProject }: { onCreateProject: (b
         </div>
 
         {result && (
-          <div className="anim-up" style={{
+          <div className="anim-up building-result-grid" style={{
             marginTop: 28,
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr",
-            gap: 24,
             textAlign: "left",
           }}>
             {/* 3D Preview */}
@@ -144,10 +141,7 @@ export default function AddressSearch({ onCreateProject }: { onCreateProject: (b
                 </div>
               </div>
 
-              <div style={{
-                display: "grid",
-                gridTemplateColumns: "1fr 1fr 1fr",
-                gap: 10,
+              <div className="building-info-grid" style={{
                 marginBottom: 16,
                 flex: 1,
               }}>

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -260,13 +260,7 @@ export default function BomPanel({
 
   return (
     <div
-      style={{
-        width: 360,
-        borderLeft: "1px solid var(--border)",
-        display: "flex",
-        flexDirection: "column",
-        background: "var(--bg-secondary)",
-      }}
+      className="editor-bom-panel"
     >
       <div style={{ padding: "16px 20px", borderBottom: "1px solid var(--border)" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>

--- a/web/src/components/FeatureHighlights.tsx
+++ b/web/src/components/FeatureHighlights.tsx
@@ -19,12 +19,9 @@ export default function FeatureHighlights() {
       padding: "56px 24px",
       borderBottom: "1px solid var(--border)",
     }}>
-      <div style={{
+      <div className="feature-grid" style={{
         maxWidth: 960,
         margin: "0 auto",
-        display: "grid",
-        gridTemplateColumns: "repeat(3, 1fr)",
-        gap: 32,
       }}>
         {features.map((f, i) => (
           <div key={i} className="anim-up" style={{ animationDelay: `${i * 0.1}s`, textAlign: "center" }}>

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -32,22 +32,9 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
   }
 
   return (
-    <div style={{
-      minHeight: "100vh",
-      display: "grid",
-      gridTemplateColumns: "1fr 1fr",
-      position: "relative",
-    }}>
+    <div className="login-grid">
       {/* Left: Brand panel */}
-      <div style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        padding: "60px 80px",
-        position: "relative",
-        overflow: "hidden",
-        background: "linear-gradient(160deg, #1a1510 0%, #12110f 100%)",
-      }}>
+      <div className="login-brand">
         {/* Decorative diagonal lines */}
         <div style={{
           position: "absolute",
@@ -117,15 +104,7 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
       </div>
 
       {/* Right: Login form */}
-      <div style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "60px 40px",
-        background: "var(--bg-secondary)",
-        borderLeft: "1px solid var(--border)",
-        position: "relative",
-      }}>
+      <div className="login-form-panel">
         <div style={{ position: "absolute", top: 16, right: 16 }}>
           <LanguageSwitcher />
         </div>

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -18,14 +18,10 @@ export default function ProjectCard({
 
   return (
     <div
-      className="card anim-up"
+      className="card anim-up project-card-grid"
       style={{
         animationDelay: `${index * 0.04}s`,
         padding: "22px 28px",
-        display: "grid",
-        gridTemplateColumns: "1fr auto",
-        gap: 16,
-        alignItems: "center",
         cursor: "pointer",
       }}
       onMouseEnter={(e) => {
@@ -55,7 +51,7 @@ export default function ProjectCard({
           </span>
         </div>
       </div>
-      <div style={{ display: "flex", gap: 6 }} onClick={(e) => e.stopPropagation()}>
+      <div className="project-card-actions" onClick={(e) => e.stopPropagation()}>
         <button className="btn btn-ghost" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => (window.location.href = `/project/${project.id}`)}>
           {t('project.open')}
         </button>

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -16,6 +16,7 @@ export default function ProjectList() {
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { toast } = useToast();
   const { t, locale } = useTranslation();
 
@@ -102,22 +103,8 @@ export default function ProjectList() {
   return (
     <div style={{ minHeight: "100vh" }}>
       {/* Top bar */}
-      <div style={{
-        position: "sticky",
-        top: 0,
-        zIndex: 50,
-        background: "rgba(18,17,15,0.85)",
-        backdropFilter: "blur(16px) saturate(1.2)",
-        borderBottom: "1px solid var(--border)",
-      }}>
-        <div style={{
-          maxWidth: 1080,
-          margin: "0 auto",
-          padding: "12px 24px",
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}>
+      <div className="nav-bar">
+        <div className="nav-inner" style={{ maxWidth: 1080 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
             <span className="heading-display" style={{ fontSize: 20 }}>
               <span style={{ color: "var(--text-primary)" }}>Hel</span>
@@ -126,7 +113,7 @@ export default function ProjectList() {
             <div style={{ width: 1, height: 20, background: "var(--border-strong)", margin: "0 4px" }} />
             <span className="label-mono">{t('nav.projects')}</span>
           </div>
-          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <div className="nav-links">
             <LanguageSwitcher />
             <button className="btn btn-ghost" style={{ fontSize: 12 }} onClick={() => (window.location.href = "/admin")}>
               {t('nav.admin')}
@@ -135,6 +122,28 @@ export default function ProjectList() {
               {t('nav.logout')}
             </button>
           </div>
+          <button
+            className="nav-hamburger"
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            aria-label="Menu"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              {mobileMenuOpen ? (
+                <><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></>
+              ) : (
+                <><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="18" x2="21" y2="18" /></>
+              )}
+            </svg>
+          </button>
+        </div>
+        <div className={`nav-mobile-menu ${mobileMenuOpen ? "open" : ""}`}>
+          <LanguageSwitcher />
+          <button className="btn btn-ghost" style={{ fontSize: 12, width: "100%", justifyContent: "flex-start" }} onClick={() => (window.location.href = "/admin")}>
+            {t('nav.admin')}
+          </button>
+          <button className="btn btn-ghost" style={{ fontSize: 12, width: "100%", justifyContent: "flex-start" }} onClick={() => { setToken(null); window.location.reload(); }}>
+            {t('nav.logout')}
+          </button>
         </div>
       </div>
 

--- a/web/src/components/TemplateGrid.tsx
+++ b/web/src/components/TemplateGrid.tsx
@@ -30,11 +30,7 @@ export default function TemplateGrid({
         {t('project.orStartFromTemplate')}
       </div>
       {loading ? (
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
-          gap: 12,
-        }}>
+        <div className="template-grid">
           {[0, 1, 2, 3].map((i) => (
             <div
               key={i}
@@ -57,11 +53,7 @@ export default function TemplateGrid({
           ))}
         </div>
       ) : templates.length > 0 ? (
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))",
-          gap: 12,
-        }}>
+        <div className="template-grid">
           {templates.map((tmpl, i) => (
             <button
               key={tmpl.id}


### PR DESCRIPTION
## Summary
- Add responsive CSS media queries (768px, 480px breakpoints) to `globals.css` with CSS classes for layout components
- Login page 2-column grid stacks vertically on mobile (brand panel on top, form below)
- Project editor stacks viewport/BOM/chat panels vertically on mobile instead of side-by-side
- Nav bar shows hamburger menu on mobile, hiding desktop nav links
- Template cards, project cards, building result grid, and feature highlights all stack to single column on small screens
- Settings page cards get reduced padding on mobile

## Test plan
- [ ] Open login page on mobile viewport (< 768px) -- brand panel should stack above login form
- [ ] Open project list -- nav bar should show hamburger icon, clicking it reveals menu items
- [ ] Open project editor on mobile -- viewport should take full width, BOM panel below
- [ ] Verify template cards stack in single column on mobile
- [ ] Verify project cards stack action buttons below content on mobile
- [ ] Run `npx tsc --noEmit` -- no TypeScript errors
- [ ] Verify desktop layout is unchanged at widths > 768px

Generated with [Claude Code](https://claude.com/claude-code)