### PR TITLE
Add error boundary and crash recovery to 3D editor

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -11,6 +11,7 @@ import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import SceneEditor from "@/components/SceneEditor";
 import BomPanel from "@/components/BomPanel";
 import ChatPanel from "@/components/ChatPanel";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import type { Material, BomItem, Project } from "@/types";
 
 const Viewport3D = dynamic(() => import("@/components/Viewport3D"), {
@@ -66,6 +67,7 @@ export default function ProjectPage() {
   const [wireframe, setWireframe] = useState(false);
   const [objectCount, setObjectCount] = useState(0);
   const [sceneError, setSceneError] = useState<string | null>(null);
+  const [viewportKey, setViewportKey] = useState(0);
   const viewportRef = useRef<HTMLDivElement>(null);
 
   const historyRef = useRef<string[]>([]);
@@ -229,6 +231,13 @@ export default function ProjectPage() {
     },
     [pushHistory]
   );
+
+  const handleViewportReset = useCallback(() => {
+    setSceneJs(DEFAULT_SCENE);
+    pushHistory(DEFAULT_SCENE);
+    setSceneError(null);
+    setViewportKey((k) => k + 1);
+  }, [pushHistory]);
 
   const addBomItem = useCallback(
     (materialId: string, quantity: number) => {
@@ -531,12 +540,108 @@ export default function ProjectPage() {
               paddingBottom: showCode ? 0 : 8,
             }}
           >
-            <Viewport3D
-              sceneJs={sceneJs}
-              wireframe={wireframe}
-              onObjectCount={setObjectCount}
-              onError={setSceneError}
-            />
+            <ErrorBoundary
+              key={viewportKey}
+              onReset={handleViewportReset}
+              fallback={({ error, reset }) => (
+                <div
+                  style={{
+                    width: "100%",
+                    height: "100%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    background: "#1a1816",
+                    borderRadius: "var(--radius-md)",
+                  }}
+                >
+                  <div style={{ textAlign: "center", padding: 32, maxWidth: 420 }}>
+                    <div
+                      style={{
+                        width: 48,
+                        height: 48,
+                        margin: "0 auto 16px",
+                        borderRadius: "50%",
+                        background: "rgba(224,108,117,0.12)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <svg
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#e06c75"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                        <line x1="12" y1="8" x2="12" y2="12" />
+                        <line x1="12" y1="16" x2="12.01" y2="16" />
+                      </svg>
+                    </div>
+                    <h3
+                      style={{
+                        color: "var(--text-primary, #e0dcd4)",
+                        fontSize: 16,
+                        fontWeight: 600,
+                        fontFamily: "var(--font-display)",
+                        marginBottom: 8,
+                      }}
+                    >
+                      {t('editor.viewportCrashTitle')}
+                    </h3>
+                    <p
+                      style={{
+                        color: "var(--text-muted, #8a857d)",
+                        fontSize: 13,
+                        lineHeight: 1.5,
+                        marginBottom: 8,
+                      }}
+                    >
+                      {t('editor.viewportCrashMessage')}
+                    </p>
+                    <p
+                      style={{
+                        color: "var(--danger, #e06c75)",
+                        fontSize: 12,
+                        fontFamily: "var(--font-mono)",
+                        marginBottom: 20,
+                        wordBreak: "break-word",
+                      }}
+                    >
+                      {error.message}
+                    </p>
+                    <button
+                      className="btn btn-primary"
+                      onClick={reset}
+                      style={{
+                        padding: "8px 20px",
+                        background: "linear-gradient(135deg, #c4915c 0%, #a67745 100%)",
+                        color: "#fff",
+                        border: "none",
+                        borderRadius: 6,
+                        cursor: "pointer",
+                        fontSize: 13,
+                        fontWeight: 600,
+                      }}
+                    >
+                      {t('editor.resetScene')}
+                    </button>
+                  </div>
+                </div>
+              )}
+            >
+              <Viewport3D
+                sceneJs={sceneJs}
+                wireframe={wireframe}
+                onObjectCount={setObjectCount}
+                onError={setSceneError}
+              />
+            </ErrorBoundary>
           </div>
 
           {/* Collapsible Code Editor */}

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Component, type ReactNode, type ErrorInfo } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  onReset?: () => void;
+  fallback?: (props: { error: Error; reset: () => void }) => ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("[ErrorBoundary] Caught error:", error, errorInfo);
+  }
+
+  reset = () => {
+    this.props.onReset?.();
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      if (this.props.fallback) {
+        return this.props.fallback({ error: this.state.error, reset: this.reset });
+      }
+
+      return (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "#1a1816",
+            borderRadius: "var(--radius-md)",
+          }}
+        >
+          <div style={{ textAlign: "center", padding: 32, maxWidth: 400 }}>
+            <div
+              style={{
+                width: 48,
+                height: 48,
+                margin: "0 auto 16px",
+                borderRadius: "50%",
+                background: "rgba(224,108,117,0.12)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#e06c75"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="12" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+            </div>
+            <h3
+              style={{
+                color: "var(--text-primary, #e0dcd4)",
+                fontSize: 16,
+                fontWeight: 600,
+                marginBottom: 8,
+              }}
+            >
+              3D Error
+            </h3>
+            <p
+              style={{
+                color: "var(--text-muted, #8a857d)",
+                fontSize: 13,
+                lineHeight: 1.5,
+                marginBottom: 20,
+              }}
+            >
+              {this.state.error.message}
+            </p>
+            <button
+              className="btn btn-primary"
+              onClick={this.reset}
+              style={{
+                padding: "8px 20px",
+                background: "linear-gradient(135deg, #c4915c 0%, #a67745 100%)",
+                color: "#fff",
+                border: "none",
+                borderRadius: 6,
+                cursor: "pointer",
+                fontSize: 13,
+                fontWeight: 600,
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -119,6 +119,9 @@ const translations = {
       backToProjects: 'Takaisin projekteihin',
       loadingProject: 'Ladataan...',
       chatError: 'Jokin meni pieleen. Yrita uudelleen.',
+      viewportCrashTitle: '3D-nakyma kaatui',
+      viewportCrashMessage: 'Kohtauksen komentosarjassa tapahtui virhe. Voit nollata kohtauksen ja aloittaa alusta.',
+      resetScene: 'Nollaa kohtaus',
     },
     settings: {
       title: 'Asetukset',
@@ -309,6 +312,9 @@ const translations = {
       backToProjects: 'Back to projects',
       loadingProject: 'Loading...',
       chatError: 'Something went wrong. Please try again.',
+      viewportCrashTitle: '3D editor crashed',
+      viewportCrashMessage: 'A runtime error occurred in the scene script. You can reset the scene and start fresh.',
+      resetScene: 'Reset Scene',
     },
     settings: {
       title: 'Settings',


### PR DESCRIPTION
## Summary
- Add a React `ErrorBoundary` component (`web/src/components/ErrorBoundary.tsx`) that catches Three.js rendering crashes
- Wrap the `Viewport3D` component in the error boundary on the project editor page
- When the 3D editor crashes, show a friendly error message with the error details and a **Reset Scene** button that clears `scene_js` back to the default template and remounts the viewport
- Add i18n keys for `viewportCrashTitle`, `viewportCrashMessage`, and `resetScene` in both `fi` and `en` locales

Closes #65

## Test plan
- [ ] Introduce a runtime error in scene_js (e.g. `throw new Error("test")`) and verify the error boundary catches it
- [ ] Verify the fallback UI shows the localized crash title, explanation, and error message
- [ ] Click "Reset Scene" and verify the viewport remounts with the default scene
- [ ] Verify no type errors with `cd web && npx tsc --noEmit`
- [ ] Test in both fi and en locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)