### PR TITLE
Add building data confidence indicator and data source attribution

### DIFF
--- a/api/src/routes/building.ts
+++ b/api/src/routes/building.ts
@@ -208,13 +208,21 @@ router.get("/", (req: Request, res: Response) => {
   // Try to match against demo buildings
   for (const building of demoBuildings) {
     if (matchesDemoAddress(address, building.address)) {
-      return res.json(building);
+      return res.json({
+        ...building,
+        confidence: "verified" as const,
+        data_sources: ["Helsinki CityGML", "K-Rauta hinnat 04/2026"],
+      });
     }
   }
 
   // Fallback: generate generic building
   const generic = generateGenericBuilding(address);
-  return res.json(generic);
+  return res.json({
+    ...generic,
+    confidence: "estimated" as const,
+    data_sources: ["Yleinen kerrostalomalli"],
+  });
 });
 
 export default router;

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -30,6 +30,51 @@ const HEATING_LABELS: Record<string, Record<string, string>> = {
   en: { kaukolampo: "District heating", sahko: "Electric", maalampopumppu: "Ground source heat pump", oljy: "Oil" },
 };
 
+function DataSourcesSection({ label, sources }: { label: string; sources: string[] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <button
+        onClick={() => setOpen(!open)}
+        style={{
+          background: "none",
+          border: "none",
+          color: "var(--text-muted)",
+          cursor: "pointer",
+          fontSize: 11,
+          fontFamily: "var(--font-mono)",
+          letterSpacing: "0.05em",
+          padding: "4px 0",
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+        }}
+      >
+        <span style={{
+          display: "inline-block",
+          transition: "transform 0.15s ease",
+          transform: open ? "rotate(90deg)" : "rotate(0deg)",
+          fontSize: 9,
+        }}>&#9654;</span>
+        {label}
+      </button>
+      {open && (
+        <div style={{
+          paddingLeft: 16,
+          paddingTop: 4,
+          fontSize: 12,
+          color: "var(--text-secondary)",
+          lineHeight: 1.6,
+        }}>
+          {sources.map((src, i) => (
+            <div key={i}>{src}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function AddressSearch({ onCreateProject }: { onCreateProject: (building: BuildingResult) => Promise<void> | void }) {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
@@ -129,9 +174,25 @@ export default function AddressSearch({ onCreateProject }: { onCreateProject: (b
                   <h3 className="heading-display" style={{ fontSize: 20, marginBottom: 6 }}>
                     {result.address}
                   </h3>
-                  <span className="badge badge-amber">
-                    {buildingTypeLabels[result.building_info.type] || result.building_info.type}
-                  </span>
+                  <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                    <span className="badge badge-amber">
+                      {buildingTypeLabels[result.building_info.type] || result.building_info.type}
+                    </span>
+                    <span
+                      className="badge"
+                      style={{
+                        background: result.confidence === "verified"
+                          ? "rgba(76,135,80,0.15)"
+                          : "rgba(196,145,92,0.15)",
+                        color: result.confidence === "verified"
+                          ? "var(--forest, #4c8750)"
+                          : "var(--amber)",
+                        border: `1px solid ${result.confidence === "verified" ? "rgba(76,135,80,0.3)" : "rgba(196,145,92,0.3)"}`,
+                      }}
+                    >
+                      {result.confidence === "verified" ? t('search.verified') : t('search.estimated')}
+                    </span>
+                  </div>
                 </div>
                 <div style={{
                   fontFamily: "var(--font-mono)",
@@ -166,6 +227,13 @@ export default function AddressSearch({ onCreateProject }: { onCreateProject: (b
                   </div>
                 ))}
               </div>
+
+              {result.data_sources && result.data_sources.length > 0 && (
+                <DataSourcesSection
+                  label={t('search.dataSources')}
+                  sources={result.data_sources}
+                />
+              )}
 
               {createError && (
                 <div style={{ padding: "10px 14px", marginBottom: 10, background: "rgba(220,50,50,0.1)", border: "1px solid rgba(220,50,50,0.3)", borderRadius: "var(--radius-sm)", color: "#dc3232", fontSize: 13 }}>

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -55,6 +55,9 @@ const translations = {
       material: 'Materiaali',
       heating: 'Lammitys',
       bomRows: 'BOM-rivit',
+      verified: 'Tarkistettu',
+      estimated: 'Arvioitu',
+      dataSources: 'Tietolahteet',
     },
     project: {
       myProjects: 'Omat projektit',
@@ -267,6 +270,9 @@ const translations = {
       material: 'Material',
       heating: 'Heating',
       bomRows: 'BOM rows',
+      verified: 'Verified',
+      estimated: 'Estimated',
+      dataSources: 'Data sources',
     },
     project: {
       myProjects: 'My projects',

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -24,6 +24,8 @@ export interface BuildingResult {
     roof_material?: string;
     units?: number;
   };
+  confidence: "verified" | "estimated" | "template";
+  data_sources: string[];
   scene_js: string;
   bom_suggestion: { material_id: string; quantity: number; unit: string }[];
 }


### PR DESCRIPTION
## Summary
- API returns `confidence` ("verified"/"estimated") and `data_sources` array for building lookups — demo addresses (Ribbingintie, Uunimaentie) are marked verified with Helsinki CityGML + K-Rauta sources; generic fallbacks are marked estimated
- UI shows a color-coded confidence badge (green "Tarkistettu" / amber "Arvioitu") next to the building type badge, plus a collapsible "Tietolahteet / Data sources" section below the info grid
- Full i18n support (Finnish + English) for all new user-facing strings

Closes #75

## Test plan
- [ ] Search for "Ribbingintie 109" — verify green "Tarkistettu" badge and data sources: Helsinki CityGML, K-Rauta hinnat 04/2026
- [ ] Search for "Uunimaentie 1" — same verified behavior
- [ ] Search for any other Helsinki address — verify amber "Arvioitu" badge and data source: Yleinen kerrostalomalli
- [ ] Toggle locale to English — verify badge shows "Verified"/"Estimated" and section title shows "Data sources"
- [ ] Click the data sources disclosure triangle — verify it expands/collapses correctly
- [ ] Run `cd web && npx tsc --noEmit` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)