### PR TITLE
Add custom confirmation dialog replacing native confirm()

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -125,6 +125,11 @@ body {
   90% { transform: translate(-1%, 7%); }
 }
 
+@keyframes dialogSlideUp {
+  from { opacity: 0; transform: translateY(16px) scale(0.97); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
 .anim-up { animation: fadeUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both; }
 .anim-fade { animation: fadeIn 0.4s ease both; }
 .anim-slide-r { animation: slideRight 0.4s cubic-bezier(0.16, 1, 0.3, 1) both; }

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { api, setToken, getToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import ConfirmDialog from "@/components/ConfirmDialog";
 
 interface UserProfile {
   id: string;
@@ -373,43 +374,29 @@ export default function SettingsPage() {
             </p>
           </div>
 
-          {!showDeleteConfirm ? (
-            <button
-              className="btn btn-danger"
-              onClick={() => setShowDeleteConfirm(true)}
-              style={{ padding: "11px 24px" }}
-            >
-              {t("settings.deleteAccount")}
-            </button>
-          ) : (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 12,
-              }}
-            >
-              <button
-                className="btn btn-danger"
-                onClick={handleDeleteAccount}
-                disabled={deletingAccount}
-                style={{ padding: "11px 24px" }}
-              >
-                {deletingAccount
-                  ? t("auth.loading")
-                  : t("settings.deleteAccountConfirm")}
-              </button>
-              <button
-                className="btn btn-ghost"
-                onClick={() => setShowDeleteConfirm(false)}
-                style={{ padding: "11px 24px" }}
-              >
-                {t("nav.back")}
-              </button>
-            </div>
-          )}
+          <button
+            className="btn btn-danger"
+            onClick={() => setShowDeleteConfirm(true)}
+            style={{ padding: "11px 24px" }}
+          >
+            {t("settings.deleteAccount")}
+          </button>
         </div>
       </div>
+
+      <ConfirmDialog
+        open={showDeleteConfirm}
+        title={t("dialog.deleteAccountTitle")}
+        message={t("dialog.deleteAccountMessage")}
+        confirmText={t("settings.deleteAccount")}
+        cancelText={t("dialog.cancel")}
+        variant="danger"
+        onConfirm={() => {
+          setShowDeleteConfirm(false);
+          handleDeleteAccount();
+        }}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
     </div>
   );
 }

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: "default" | "danger";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Focus trap: cycle between cancel and confirm buttons
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!open) return;
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+
+      if (e.key === "Enter") {
+        // Only confirm on Enter if focus is not on the cancel button
+        if (document.activeElement !== cancelBtnRef.current) {
+          e.preventDefault();
+          onConfirm();
+          return;
+        }
+      }
+
+      if (e.key === "Tab") {
+        const focusable = [cancelBtnRef.current, confirmBtnRef.current].filter(
+          Boolean
+        ) as HTMLElement[];
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [open, onCancel, onConfirm]
+  );
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener("keydown", handleKeyDown);
+      // Focus the cancel button by default (safer default)
+      requestAnimationFrame(() => cancelBtnRef.current?.focus());
+    }
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, handleKeyDown]);
+
+  // Prevent body scroll when open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const isDanger = variant === "danger";
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 9999,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+        animation: "fadeIn 0.15s ease both",
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      {/* Backdrop */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: "rgba(0, 0, 0, 0.6)",
+          backdropFilter: "blur(4px)",
+        }}
+      />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby="confirm-dialog-message"
+        style={{
+          position: "relative",
+          width: "100%",
+          maxWidth: 420,
+          background: "var(--bg-elevated)",
+          border: "1px solid var(--border-strong)",
+          borderRadius: "var(--radius-lg)",
+          padding: "28px 28px 24px",
+          boxShadow: "0 16px 48px rgba(0, 0, 0, 0.4)",
+          animation: "dialogSlideUp 0.25s cubic-bezier(0.16, 1, 0.3, 1) both",
+        }}
+      >
+        <h2
+          id="confirm-dialog-title"
+          className="heading-display"
+          style={{
+            fontSize: 18,
+            margin: "0 0 8px",
+            color: "var(--text-primary)",
+          }}
+        >
+          {title}
+        </h2>
+
+        <p
+          id="confirm-dialog-message"
+          style={{
+            fontSize: 14,
+            lineHeight: 1.6,
+            color: "var(--text-secondary)",
+            margin: "0 0 24px",
+          }}
+        >
+          {message}
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            gap: 10,
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            ref={cancelBtnRef}
+            className="btn btn-ghost"
+            onClick={onCancel}
+            style={{ padding: "10px 20px", fontSize: 13 }}
+          >
+            {cancelText}
+          </button>
+          <button
+            ref={confirmBtnRef}
+            className={`btn ${isDanger ? "btn-danger" : "btn-primary"}`}
+            onClick={onConfirm}
+            style={{
+              padding: "10px 20px",
+              fontSize: 13,
+              fontWeight: 600,
+              ...(isDanger
+                ? {
+                    background: "var(--danger)",
+                    color: "#fff",
+                    border: "1px solid var(--danger)",
+                  }
+                : {}),
+            }}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectCard } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import ConfirmDialog from "@/components/ConfirmDialog";
 import ProjectCard from "@/components/ProjectCard";
 import TemplateGrid from "@/components/TemplateGrid";
 import type { Project, Template } from "@/types";
@@ -21,6 +22,7 @@ export default function ProjectList() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("modified");
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const { toast } = useToast();
   const { t, locale } = useTranslation();
 
@@ -76,8 +78,14 @@ export default function ProjectList() {
     setCreating(false);
   }
 
-  async function deleteProject(id: string) {
-    if (!confirm(t('project.deleteConfirm'))) return;
+  function deleteProject(id: string) {
+    setDeleteTarget(id);
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget) return;
+    const id = deleteTarget;
+    setDeleteTarget(null);
     try {
       await api.deleteProject(id);
       setProjects(projects.filter((p) => p.id !== id));
@@ -361,6 +369,17 @@ export default function ProjectList() {
           </>
         )}
       </div>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        title={t('dialog.deleteProjectTitle')}
+        message={t('dialog.deleteProjectMessage')}
+        confirmText={t('project.delete')}
+        cancelText={t('dialog.cancel')}
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -190,6 +190,14 @@ const translations = {
       viewProduct: 'Katso tuote',
       searchMaterials: 'Hae materiaalia...',
     },
+    dialog: {
+      confirm: 'Vahvista',
+      cancel: 'Peruuta',
+      deleteProjectTitle: 'Poista projekti',
+      deleteProjectMessage: 'Haluatko varmasti poistaa taman projektin? Tata toimintoa ei voi kumota.',
+      deleteAccountTitle: 'Poista tili',
+      deleteAccountMessage: 'Haluatko varmasti poistaa tilisi? Kaikki projektisi ja tietosi poistetaan pysyvasti. Tata toimintoa ei voi kumota.',
+    },
     admin: {
       adminPanel: 'Hallintapaneeli',
       adminDesc: 'Materiaalit, toimittajat ja hinnoittelu',
@@ -404,6 +412,14 @@ const translations = {
       lastChecked: 'Checked',
       viewProduct: 'View product',
       searchMaterials: 'Search materials...',
+    },
+    dialog: {
+      confirm: 'Confirm',
+      cancel: 'Cancel',
+      deleteProjectTitle: 'Delete project',
+      deleteProjectMessage: 'Are you sure you want to delete this project? This action cannot be undone.',
+      deleteAccountTitle: 'Delete account',
+      deleteAccountMessage: 'Are you sure you want to delete your account? All your projects and data will be permanently deleted. This cannot be undone.',
     },
     admin: {
       adminPanel: 'Admin panel',


### PR DESCRIPTION
## Summary
- Add reusable `ConfirmDialog` component (`web/src/components/ConfirmDialog.tsx`) — a styled modal overlay with dark theme, danger variant, keyboard accessibility (Escape/Enter/Tab focus trap), backdrop click to close, and smooth fade-in/slide-up animation
- Replace native `confirm()` in `ProjectList.tsx` project deletion with the new dialog
- Replace inline confirm/cancel buttons in `settings/page.tsx` account deletion with the new dialog
- Add `dialog.*` i18n keys (fi/en) for confirm, cancel, delete project, and delete account strings
- Add `dialogSlideUp` keyframe animation to `globals.css`

Closes #74

## Test plan
- [ ] Delete a project from the project list — verify styled modal appears instead of browser confirm()
- [ ] Press Cancel or Escape or click backdrop — verify dialog closes without deleting
- [ ] Press confirm — verify project is deleted and toast appears
- [ ] Go to Settings > Account > Delete account — verify styled modal appears
- [ ] Switch language to Finnish — verify dialog strings are translated
- [ ] Tab through the dialog — verify focus stays trapped between Cancel and Confirm buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)