### PR TITLE
Add light theme toggle with system preference detection

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/ToastProvider";
 import { SkeletonTableRow } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 type Tab = "materials" | "suppliers" | "pricing";
 
@@ -415,7 +416,8 @@ export default function AdminPage() {
           </p>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          <LanguageSwitcher />
+          <ThemeToggle />
+            <LanguageSwitcher />
           <button
             className="btn btn-ghost"
             onClick={() => (window.location.href = "/")}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -52,6 +52,73 @@
 
   --grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
 }
+/* Light theme overrides */
+[data-theme="light"] {
+  --bg-primary: #faf8f5;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f5f3f0;
+  --bg-elevated: #ffffff;
+  --bg-hover: #edeae6;
+  --bg-surface: #f8f6f3;
+
+  --text-primary: #12110f;
+  --text-secondary: #3a3632;
+  --text-muted: #8a8480;
+
+  --amber-glow: rgba(196, 145, 92, 0.1);
+  --amber-border: rgba(196, 145, 92, 0.25);
+
+  --forest-dim: rgba(74, 124, 89, 0.1);
+  --danger-dim: rgba(199, 95, 95, 0.08);
+
+  --border: rgba(0, 0, 0, 0.07);
+  --border-strong: rgba(0, 0, 0, 0.12);
+
+  --shadow-subtle: 0 1px 3px rgba(0,0,0,0.06);
+  --shadow-md: 0 4px 20px rgba(0,0,0,0.08);
+  --shadow-lg: 0 12px 40px rgba(0,0,0,0.1);
+  --shadow-amber: 0 4px 30px rgba(196,145,92,0.06);
+  --shadow-sm: var(--shadow-subtle);
+
+  --grain: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.015'/%3E%3C/svg%3E");
+}
+
+[data-theme="light"] .card {
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+}
+
+[data-theme="light"] .btn-ghost:hover {
+  border-color: rgba(0,0,0,0.15);
+}
+
+[data-theme="light"] ::selection {
+  background: rgba(196, 145, 92, 0.2);
+  color: #12110f;
+}
+
+[data-theme="light"] .badge-muted {
+  background: rgba(0,0,0,0.04);
+}
+
+[data-theme="light"] .badge-amber {
+  color: var(--amber-dim);
+}
+
+[data-theme="light"] .nav-bar {
+  background: rgba(250,248,245,0.85);
+}
+
+/* Keep 3D viewport dark regardless of theme */
+.viewport-always-dark {
+  --bg-primary: #12110f;
+  --bg-secondary: #1a1816;
+  --bg-tertiary: #221f1c;
+  --text-primary: #ede8e0;
+  --text-secondary: #a8a099;
+  --text-muted: #6f6860;
+  --border: rgba(255, 255, 255, 0.06);
+  --border-strong: rgba(255, 255, 255, 0.1);
+}
 
 *, *::before, *::after {
   box-sizing: border-box;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { ToastProvider } from "@/components/ToastProvider";
 import { LocaleProvider } from "@/components/LocaleProvider";
+import { ThemeProvider } from "@/components/ThemeProvider";
 
 export const metadata: Metadata = {
   title: {
@@ -74,20 +75,24 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="fi">
+    <html lang="fi" data-theme="dark" suppressHydrationWarning>
       <head>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        <style
-          dangerouslySetInnerHTML={{ __html: "html{background:#12110f}" }}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem("helscoop-theme");var d=t==="light"?"light":t==="auto"?window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light":"dark";document.documentElement.setAttribute("data-theme",d);document.documentElement.style.background=d==="light"?"#faf8f5":"#12110f"}catch(e){}})()`
+          }}
         />
       </head>
       <body className="grain">
-        <LocaleProvider>
-          <ToastProvider>{children}</ToastProvider>
-        </LocaleProvider>
+        <ThemeProvider>
+          <LocaleProvider>
+            <ToastProvider>{children}</ToastProvider>
+          </LocaleProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectEditor } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import SceneEditor from "@/components/SceneEditor";
 import BomPanel from "@/components/BomPanel";
 import ChatPanel from "@/components/ChatPanel";
@@ -415,7 +416,8 @@ export default function ProjectPage() {
             </svg>
             {t('editor.assistant')}
           </button>
-          <LanguageSwitcher />
+          <ThemeToggle />
+            <LanguageSwitcher />
         </div>
       </div>
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { api, setToken, getToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import ConfirmDialog from "@/components/ConfirmDialog";
 
 interface UserProfile {
@@ -154,6 +155,7 @@ export default function SettingsPage() {
             <span className="label-mono">{t("nav.settings")}</span>
           </div>
           <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <ThemeToggle />
             <LanguageSwitcher />
             <button
               className="btn btn-ghost"

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { api, setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import type { BuildingResult } from "@/types";
 
 export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () => void; pendingBuilding: BuildingResult | null }) {
@@ -106,7 +107,8 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
       {/* Right: Login form */}
       <div className="login-form-panel">
         <div style={{ position: "absolute", top: 16, right: 16 }}>
-          <LanguageSwitcher />
+          <ThemeToggle />
+            <LanguageSwitcher />
         </div>
         <div className="anim-up delay-1" style={{ width: "100%", maxWidth: 380 }}>
           <div style={{ marginBottom: 36 }}>

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -6,6 +6,7 @@ import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectCard } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import ProjectCard from "@/components/ProjectCard";
 import TemplateGrid from "@/components/TemplateGrid";
@@ -160,6 +161,7 @@ export default function ProjectList() {
             <span className="label-mono">{t('nav.projects')}</span>
           </div>
           <div className="nav-links">
+            <ThemeToggle />
             <LanguageSwitcher />
             <button className="btn btn-ghost" style={{ fontSize: 12 }} onClick={() => (window.location.href = "/admin")}>
               {t('nav.admin')}
@@ -183,7 +185,8 @@ export default function ProjectList() {
           </button>
         </div>
         <div className={`nav-mobile-menu ${mobileMenuOpen ? "open" : ""}`}>
-          <LanguageSwitcher />
+          <ThemeToggle />
+            <LanguageSwitcher />
           <button className="btn btn-ghost" style={{ fontSize: 12, width: "100%", justifyContent: "flex-start" }} onClick={() => (window.location.href = "/admin")}>
             {t('nav.admin')}
           </button>

--- a/web/src/components/ThemeProvider.tsx
+++ b/web/src/components/ThemeProvider.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+type ThemeChoice = "dark" | "light" | "auto";
+
+interface ThemeContextValue {
+  theme: ThemeChoice;
+  resolved: "dark" | "light";
+  toggle: () => void;
+  setTheme: (t: ThemeChoice) => void;
+}
+
+const STORAGE_KEY = "helscoop-theme";
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: "dark",
+  resolved: "dark",
+  toggle: () => {},
+  setTheme: () => {},
+});
+
+function resolveTheme(
+  choice: ThemeChoice,
+  prefersDark: boolean
+): "dark" | "light" {
+  if (choice === "auto") return prefersDark ? "dark" : "light";
+  return choice;
+}
+
+const CYCLE: ThemeChoice[] = ["dark", "light", "auto"];
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeChoice>("dark");
+  const [prefersDark, setPrefersDark] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY) as ThemeChoice | null;
+    if (stored && CYCLE.includes(stored)) {
+      setThemeState(stored);
+    }
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    setPrefersDark(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setPrefersDark(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  const resolved = resolveTheme(theme, prefersDark);
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", resolved);
+  }, [resolved]);
+
+  const setTheme = useCallback((t: ThemeChoice) => {
+    setThemeState(t);
+    localStorage.setItem(STORAGE_KEY, t);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setThemeState((prev) => {
+      const idx = CYCLE.indexOf(prev);
+      const next = CYCLE[(idx + 1) % CYCLE.length];
+      localStorage.setItem(STORAGE_KEY, next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolved, toggle, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useTheme } from "@/components/ThemeProvider";
+
+export function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+
+  const label =
+    theme === "dark" ? "Dark" : theme === "light" ? "Light" : "Auto";
+
+  return (
+    <button
+      onClick={toggle}
+      title={`Theme: ${label}`}
+      aria-label={`Theme: ${label}`}
+      style={{
+        background: "rgba(196,145,92,0.08)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+        padding: "4px 8px",
+        cursor: "pointer",
+        fontSize: 11,
+        fontFamily: "var(--font-mono)",
+        fontWeight: 600,
+        letterSpacing: "0.05em",
+        color: "var(--text-secondary)",
+        display: "flex",
+        alignItems: "center",
+        gap: 5,
+        transition: "border-color 0.15s, color 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = "var(--amber-border)";
+        e.currentTarget.style.color = "var(--amber)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = "var(--border)";
+        e.currentTarget.style.color = "var(--text-secondary)";
+      }}
+    >
+      {theme === "dark" && (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+      {theme === "light" && (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <line x1="12" y1="1" x2="12" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="23" />
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+          <line x1="1" y1="12" x2="3" y2="12" />
+          <line x1="21" y1="12" x2="23" y2="12" />
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        </svg>
+      )}
+      {theme === "auto" && (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+          <line x1="8" y1="21" x2="16" y2="21" />
+          <line x1="12" y1="17" x2="12" y2="21" />
+        </svg>
+      )}
+      <span style={{ fontSize: 10, opacity: 0.8 }}>{label.toUpperCase()}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `ThemeProvider` context with dark/light/auto modes, persisted to `localStorage` ("helscoop-theme")
- Auto mode uses `window.matchMedia('(prefers-color-scheme: dark)')` with live listener for system changes
- `ThemeToggle` button (moon/sun/monitor icons) placed in all nav bars alongside `LanguageSwitcher`
- `[data-theme="light"]` CSS variable overrides in `globals.css` with warm cream/white backgrounds, dark charcoal text, and adjusted shadows
- FOUC prevention via inline `<script>` in `<head>` that reads theme before React hydration
- 3D viewport canvas remains dark regardless of theme (Three.js renders its own background)

## Test plan
- [ ] Toggle through dark -> light -> auto -> dark and verify correct visuals
- [ ] Refresh page and confirm theme persists via localStorage
- [ ] Set to "auto" and toggle system dark mode preference; verify the app follows
- [ ] Verify 3D viewport stays dark in light mode
- [ ] Check all pages: project list, editor, admin, settings, login
- [ ] Test mobile nav hamburger menu includes the toggle
- [ ] Run `npx tsc --noEmit` with no errors

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)