### PR TITLE
Fix settings page navigation: add links from all pages

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -14,6 +14,7 @@ import BomPanel from "@/components/BomPanel";
 import ChatPanel from "@/components/ChatPanel";
 import KeyboardShortcutsHelp from "@/components/KeyboardShortcutsHelp";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import Link from "next/link";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
 import type { Material, BomItem, Project } from "@/types";
@@ -503,6 +504,17 @@ export default function ProjectPage() {
               <line x1="8" y1="16" x2="16" y2="16" />
             </svg>
           </button>
+          <Link
+            href="/settings"
+            className="btn btn-ghost"
+            title={t('nav.settings')}
+            style={{ padding: "6px 8px", textDecoration: "none", display: "inline-flex", alignItems: "center" }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </Link>
           <ThemeToggle />
             <LanguageSwitcher />
         </div>

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import { resetOnboarding } from "@/components/OnboardingTour";
+import Link from "next/link";
 
 interface UserProfile {
   id: string;
@@ -158,13 +159,16 @@ export default function SettingsPage() {
           <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
             <ThemeToggle />
             <LanguageSwitcher />
-            <button
+            <Link
+              href="/"
               className="btn btn-ghost"
-              style={{ fontSize: 12 }}
-              onClick={() => (window.location.href = "/")}
+              style={{ fontSize: 12, textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4 }}
             >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
               {t("settings.backToProjects")}
-            </button>
+            </Link>
           </div>
         </div>
       </div>

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -10,6 +10,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import ProjectCard from "@/components/ProjectCard";
 import TemplateGrid from "@/components/TemplateGrid";
+import Link from "next/link";
 import type { Project, Template } from "@/types";
 
 type SortKey = "modified" | "created" | "name" | "cost";
@@ -163,6 +164,13 @@ export default function ProjectList() {
           <div className="nav-links">
             <ThemeToggle />
             <LanguageSwitcher />
+            <Link href="/settings" className="btn btn-ghost" style={{ fontSize: 12, textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+              </svg>
+              {t('nav.settings')}
+            </Link>
             <button className="btn btn-ghost" style={{ fontSize: 12 }} onClick={() => (window.location.href = "/admin")}>
               {t('nav.admin')}
             </button>
@@ -187,6 +195,13 @@ export default function ProjectList() {
         <div className={`nav-mobile-menu ${mobileMenuOpen ? "open" : ""}`}>
           <ThemeToggle />
             <LanguageSwitcher />
+          <Link href="/settings" className="btn btn-ghost" style={{ fontSize: 12, width: "100%", justifyContent: "flex-start", textDecoration: "none", display: "flex", alignItems: "center", gap: 4 }}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+            {t('nav.settings')}
+          </Link>
           <button className="btn btn-ghost" style={{ fontSize: 12, width: "100%", justifyContent: "flex-start" }} onClick={() => (window.location.href = "/admin")}>
             {t('nav.admin')}
           </button>

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
+import Link from "next/link";
 
 function UserAvatar({ name, onClick }: { name: string; onClick?: () => void }) {
   const initials = name
@@ -77,21 +78,21 @@ export default function UserMenu({ userName }: { userName: string }) {
             >
               {userName}
             </div>
-            <button
-              onClick={() => {
-                window.location.href = "/settings";
-              }}
+            <Link
+              href="/settings"
+              onClick={() => setOpen(false)}
               style={{
+                display: "block",
                 width: "100%",
                 padding: "8px 12px",
                 background: "none",
-                border: "none",
                 color: "var(--text-primary)",
                 fontSize: 13,
                 cursor: "pointer",
                 textAlign: "left",
                 borderRadius: "var(--radius-sm)",
                 fontFamily: "inherit",
+                textDecoration: "none",
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.background = "var(--bg-tertiary)";
@@ -101,7 +102,7 @@ export default function UserMenu({ userName }: { userName: string }) {
               }}
             >
               {t("nav.settings")}
-            </button>
+            </Link>
             <button
               onClick={() => {
                 setToken(null);


### PR DESCRIPTION
## Summary
- Add a gear icon + "Settings" / "Asetukset" link to the `ProjectList` nav bar (both desktop and mobile hamburger menu)
- Add a settings gear icon to the project editor page header (next to theme/language toggles)
- Replace the "Back to projects" button on the settings page with a `next/link` `<Link>` component and back-chevron icon
- Fix `UserMenu.tsx` to use `next/link` instead of `window.location.href` for client-side navigation

All navigation now uses `next/link` for proper client-side routing. Existing i18n keys (`nav.settings`, `settings.backToProjects`) are reused -- no new translations needed.

Closes #97

## Test plan
- [ ] Navigate to project list page and verify "Settings" link with gear icon appears in desktop nav (between language switcher and Admin)
- [ ] Open mobile hamburger menu and verify "Settings" link appears there too
- [ ] Click settings link from project list -- should navigate to `/settings` without full page reload
- [ ] On the settings page, verify "Back to projects" link with chevron navigates back to `/`
- [ ] Open a project editor and verify the settings gear icon appears in the header toolbar
- [ ] Click the gear icon from editor -- should navigate to `/settings`
- [ ] Verify both Finnish and English locales display correct labels
- [ ] Run `npx tsc --noEmit` -- zero type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)