### PR TITLE
Add confirmation dialog before applying AI scene code

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
+import ConfirmDialog from "@/components/ConfirmDialog";
 import type { ChatMessage } from "@/types";
 
 export default function ChatPanel({
@@ -16,8 +17,29 @@ export default function ChatPanel({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+  const [pendingCode, setPendingCode] = useState<string | null>(null);
+  const [skipConfirm, setSkipConfirm] = useState(false);
   const { toast } = useToast();
   const { t } = useTranslation();
+
+  function handleApplyClick(code: string) {
+    if (skipConfirm) {
+      onApplyCode(code);
+      return;
+    }
+    setPendingCode(code);
+  }
+
+  function handleConfirmApply() {
+    if (pendingCode) {
+      onApplyCode(pendingCode);
+      setPendingCode(null);
+    }
+  }
+
+  function handleCancelApply() {
+    setPendingCode(null);
+  }
 
   async function send() {
     if (!input.trim() || loading) return;
@@ -125,7 +147,7 @@ export default function ChatPanel({
               {code && (
                 <button
                   className="btn"
-                  onClick={() => onApplyCode(code)}
+                  onClick={() => handleApplyClick(code)}
                   style={{
                     marginTop: 6,
                     padding: "4px 10px",
@@ -179,6 +201,51 @@ export default function ChatPanel({
           </svg>
         </button>
       </div>
+      <ConfirmDialog
+        open={pendingCode !== null}
+        title={t('editor.confirmApplyTitle') || "Apply AI-generated code?"}
+        message={
+          (t('editor.confirmApplyMessage') ||
+            "This will replace your current scene script with the AI-generated code.") +
+          "\n\n" +
+          (t('editor.confirmApplyUndo') || "You can undo with") +
+          ` ${navigator.platform?.includes("Mac") ? "Cmd" : "Ctrl"}+Z`
+        }
+        confirmText={t('editor.applyToScene') || "Apply to scene"}
+        cancelText={t('editor.cancel') || "Cancel"}
+        onConfirm={handleConfirmApply}
+        onCancel={handleCancelApply}
+      />
+      {pendingCode !== null && (
+        <div
+          style={{
+            position: "fixed",
+            bottom: 80,
+            right: 24,
+            zIndex: 10000,
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "6px 12px",
+            background: "var(--bg-elevated)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--radius-md)",
+            fontSize: 12,
+            color: "var(--text-secondary)",
+          }}
+        >
+          <input
+            type="checkbox"
+            id="skip-confirm"
+            checked={skipConfirm}
+            onChange={(e) => setSkipConfirm(e.target.checked)}
+            style={{ accentColor: "var(--accent)" }}
+          />
+          <label htmlFor="skip-confirm" style={{ cursor: "pointer" }}>
+            {t('editor.dontAskAgain') || "Don't ask again this session"}
+          </label>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -151,6 +151,11 @@ const translations = {
       estimatedTotal: 'ARVIOITU KOKONAISHINTA',
       inclVat: 'sis. ALV 25.5%',
       costBreakdown: 'KUSTANNUSERITTELY',
+      confirmApplyTitle: 'Aseta AI:n generoima koodi?',
+      confirmApplyMessage: 'Tama korvaa nykyisen kohtauskomentosarjasi AI:n generoimalla koodilla.',
+      confirmApplyUndo: 'Voit kumota toiminnon nappaimilla',
+      cancel: 'Peruuta',
+      dontAskAgain: 'Ala kysy uudelleen taman istunnon aikana',
     },
     shortcuts: {
       title: 'Pikanappaimet',
@@ -414,6 +419,11 @@ const translations = {
       estimatedTotal: 'ESTIMATED TOTAL',
       inclVat: 'incl. VAT 25.5%',
       costBreakdown: 'COST BREAKDOWN',
+      confirmApplyTitle: 'Apply AI-generated code?',
+      confirmApplyMessage: 'This will replace your current scene script with the AI-generated code.',
+      confirmApplyUndo: 'You can undo with',
+      cancel: 'Cancel',
+      dontAskAgain: "Don't ask again this session",
     },
     shortcuts: {
       title: 'Keyboard shortcuts',


### PR DESCRIPTION
## Summary
- Shows a confirmation modal when clicking "Apply to scene" in the AI chat panel, warning that the current scene will be replaced
- Displays the platform-appropriate undo shortcut (Cmd+Z / Ctrl+Z) prominently in the dialog
- Includes a "Don't ask again this session" checkbox for power users who want to skip confirmation
- Adds Finnish and English translations for all new UI strings

Closes #110

## Test plan
- [ ] Send an AI chat message that returns a code block
- [ ] Click "Apply to scene" and verify confirmation modal appears
- [ ] Click Cancel and verify scene is unchanged
- [ ] Click Apply and verify code is applied to scene
- [ ] Check "Don't ask again" and verify subsequent Apply clicks skip the dialog
- [ ] Verify dialog shows correct undo shortcut for Mac vs Windows/Linux
- [ ] Test with Finnish locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)