### PR TITLE
Transactional email: password reset, verification, and alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         working-directory: api
         run: npm ci
 
+      - name: Link node_modules for migration script
+        run: ln -s ${{ github.workspace }}/api/node_modules ${{ github.workspace }}/db/node_modules
+
       - name: Run migrations
         working-directory: api
         run: npm run db:migrate

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16,6 +16,7 @@
         "jsonwebtoken": "^9.0.2",
         "pdfkit": "^0.18.0",
         "pg": "^8.12.0",
+        "resend": "^6.12.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -871,6 +872,12 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1729,6 +1736,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/finalhandler": {
       "version": "1.3.2",
@@ -2593,6 +2606,12 @@
         "browserify-zlib": "^0.2.0"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -2734,6 +2753,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.0.tgz",
+      "integrity": "sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -3026,6 +3066,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3066,6 +3116,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/tiny-inflate": {
@@ -3229,6 +3289,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.2",
     "pdfkit": "^0.18.0",
     "pg": "^8.12.0",
+    "resend": "^6.12.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/api/src/__tests__/api.test.ts
+++ b/api/src/__tests__/api.test.ts
@@ -21,6 +21,16 @@ describe("API structure", () => {
     expect(auth.requireAdmin).toBeTypeOf("function");
     expect(auth.login).toBeTypeOf("function");
     expect(auth.register).toBeTypeOf("function");
+    expect(auth.verifyEmail).toBeTypeOf("function");
+    expect(auth.resendVerification).toBeTypeOf("function");
+  });
+
+  it("email module exports required functions", async () => {
+    const email = await import("../email");
+    expect(email.sendEmail).toBeTypeOf("function");
+    expect(email.sendPasswordResetEmail).toBeTypeOf("function");
+    expect(email.sendVerificationEmail).toBeTypeOf("function");
+    expect(email.sendPriceAlertEmail).toBeTypeOf("function");
   });
 
   it("db module exports pool and query", async () => {
@@ -94,6 +104,17 @@ describe("SQL migrations", () => {
     }
   });
 
+  it("006_email_verification.sql has required columns", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const sqlPath = path.resolve(__dirname, "../../../db/migrations/006_email_verification.sql");
+    const sql = fs.readFileSync(sqlPath, "utf-8");
+
+    expect(sql).toContain("email_verified");
+    expect(sql).toContain("verification_token");
+    expect(sql).toContain("verification_token_expires");
+  });
+
   it("seed has pricing entries for key materials", async () => {
     const fs = await import("fs");
     const path = await import("path");
@@ -164,6 +185,7 @@ describe("Web app", () => {
       "../../../web/src/app/project/[id]/page.tsx",
       "../../../web/src/app/admin/page.tsx",
       "../../../web/src/lib/api.ts",
+      "../../../web/src/app/verify-email/page.tsx",
     ];
 
     for (const page of pages) {
@@ -184,6 +206,7 @@ describe("Web app", () => {
       "updateProject", "deleteProject", "duplicateProject",
       "getMaterials", "getSuppliers", "getStalePrices",
       "exportBOM", "chat",
+      "verifyEmail", "resendVerification",
     ];
 
     for (const method of requiredMethods) {

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -3,6 +3,7 @@ import { Request, Response, NextFunction } from "express";
 import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import { query } from "./db";
+import { sendPasswordResetEmail, sendVerificationEmail } from "./email";
 
 const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
 
@@ -63,14 +64,28 @@ export async function register(
   name: string
 ) {
   const hash = await bcrypt.hash(password, 10);
+
+  // Generate email verification token
+  const verificationToken = crypto.randomUUID();
+  const verificationExpires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
+
   const result = await query(
-    "INSERT INTO users (email, name, password_hash) VALUES ($1, $2, $3) RETURNING id, email, name, role",
-    [email, name, hash]
+    `INSERT INTO users (email, name, password_hash, email_verified, verification_token, verification_token_expires)
+     VALUES ($1, $2, $3, false, $4, $5)
+     RETURNING id, email, name, role`,
+    [email, name, hash, verificationToken, verificationExpires.toISOString()]
   );
+
+  // Send verification email (fire-and-forget — don't block registration)
+  sendVerificationEmail(email, verificationToken).catch((err) => {
+    console.error("[AUTH] Failed to send verification email:", err);
+  });
+
   return result.rows[0];
 }
 
-// Generate a reset token for the given email. Returns the token if user exists, null otherwise.
+// Generate a reset token for the given email. Sends a reset email if user exists.
+// Returns the token if user exists, null otherwise.
 export async function forgotPassword(email: string): Promise<string | null> {
   const result = await query("SELECT id FROM users WHERE email = $1", [email]);
   if (result.rows.length === 0) return null;
@@ -83,7 +98,46 @@ export async function forgotPassword(email: string): Promise<string | null> {
     [token, expires.toISOString(), email]
   );
 
+  // Send the reset email
+  await sendPasswordResetEmail(email, token);
+
   return token;
+}
+
+// Verify an email address using the verification token. Returns true on success.
+export async function verifyEmail(token: string): Promise<boolean> {
+  const result = await query(
+    "SELECT id FROM users WHERE verification_token = $1 AND verification_token_expires > NOW()",
+    [token]
+  );
+  if (result.rows.length === 0) return false;
+
+  await query(
+    "UPDATE users SET email_verified = true, verification_token = NULL, verification_token_expires = NULL WHERE id = $1",
+    [result.rows[0].id]
+  );
+
+  return true;
+}
+
+// Resend verification email for a user. Returns true if email was sent.
+export async function resendVerification(userId: string): Promise<boolean> {
+  const result = await query(
+    "SELECT email, email_verified FROM users WHERE id = $1",
+    [userId]
+  );
+  if (result.rows.length === 0) return false;
+  if (result.rows[0].email_verified) return false; // Already verified
+
+  const token = crypto.randomUUID();
+  const expires = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+  await query(
+    "UPDATE users SET verification_token = $1, verification_token_expires = $2 WHERE id = $3",
+    [token, expires.toISOString(), userId]
+  );
+
+  return sendVerificationEmail(result.rows[0].email, token);
 }
 
 // Validate a reset token and update the user's password. Returns true on success.

--- a/api/src/email.ts
+++ b/api/src/email.ts
@@ -1,0 +1,188 @@
+/**
+ * Transactional email service using Resend.
+ *
+ * Environment variables:
+ *   RESEND_API_KEY  - Resend API key (required for production)
+ *   EMAIL_FROM      - Sender address (default: noreply@helscoop.fi)
+ *   APP_URL         - Frontend URL for links in emails (default: http://localhost:3000)
+ */
+import { Resend } from "resend";
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY || "";
+const EMAIL_FROM = process.env.EMAIL_FROM || "Helscoop <noreply@helscoop.fi>";
+const APP_URL = process.env.APP_URL || "http://localhost:3000";
+
+// Initialize Resend client (no-ops gracefully if no API key)
+const resend = RESEND_API_KEY ? new Resend(RESEND_API_KEY) : null;
+
+// ---------------------------------------------------------------------------
+// Core send function
+// ---------------------------------------------------------------------------
+
+interface SendEmailOpts {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export async function sendEmail({ to, subject, html }: SendEmailOpts): Promise<boolean> {
+  if (!resend) {
+    console.log(`[EMAIL_DEV] Would send to=${to} subject="${subject}"`);
+    console.log(`[EMAIL_DEV] ${html.substring(0, 200)}...`);
+    return true; // Don't fail in dev
+  }
+
+  try {
+    const { error } = await resend.emails.send({
+      from: EMAIL_FROM,
+      to,
+      subject,
+      html,
+    });
+
+    if (error) {
+      console.error(`[EMAIL] Failed to send to ${to}:`, error);
+      return false;
+    }
+
+    console.log(`[EMAIL] Sent "${subject}" to ${to}`);
+    return true;
+  } catch (err) {
+    console.error(`[EMAIL] Error sending to ${to}:`, err);
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Email templates
+// ---------------------------------------------------------------------------
+
+function wrapTemplate(content: string): string {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body { margin: 0; padding: 0; background: #0f0f0f; font-family: 'Inter', -apple-system, sans-serif; }
+    .container { max-width: 560px; margin: 0 auto; padding: 40px 24px; }
+    .header { text-align: center; padding-bottom: 32px; border-bottom: 2px solid #c4915c; margin-bottom: 32px; }
+    .logo { font-size: 24px; font-weight: 700; color: #c4915c; text-decoration: none; letter-spacing: -0.5px; }
+    .content { color: #e0e0e0; font-size: 15px; line-height: 1.6; }
+    .content h2 { color: #ffffff; font-size: 20px; margin: 0 0 16px; }
+    .content p { margin: 0 0 16px; }
+    .btn { display: inline-block; background: #c4915c; color: #0f0f0f !important; text-decoration: none; padding: 12px 32px; border-radius: 6px; font-weight: 600; font-size: 15px; margin: 8px 0 24px; }
+    .btn:hover { background: #d4a06c; }
+    .footer { margin-top: 40px; padding-top: 24px; border-top: 1px solid #2a2a2a; color: #666; font-size: 12px; text-align: center; }
+    .footer a { color: #888; }
+    .code { background: #1a1a1a; border: 1px solid #333; padding: 12px 16px; border-radius: 6px; font-family: monospace; font-size: 14px; color: #c4915c; letter-spacing: 2px; text-align: center; margin: 16px 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <a href="${APP_URL}" class="logo">Helscoop</a>
+    </div>
+    <div class="content">
+      ${content}
+    </div>
+    <div class="footer">
+      <p>&copy; ${new Date().getFullYear()} Helscoop &mdash; Finnish house renovation platform</p>
+      <p>Tama viesti lahetettiin osoitteesta <a href="${APP_URL}">${APP_URL}</a></p>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Password reset email
+// ---------------------------------------------------------------------------
+
+export async function sendPasswordResetEmail(to: string, token: string): Promise<boolean> {
+  const resetUrl = `${APP_URL}/reset-password?token=${token}`;
+
+  const html = wrapTemplate(`
+    <h2>Salasanan nollaus / Password Reset</h2>
+    <p>Sait taman viestin, koska pyysit salasanan nollausta Helscoop-tilillesi.</p>
+    <p>You received this email because you requested a password reset for your Helscoop account.</p>
+    <p style="text-align: center;">
+      <a href="${resetUrl}" class="btn">Nollaa salasana / Reset Password</a>
+    </p>
+    <p>Jos painike ei toimi, kopioi tama linkki selaimeen:<br>
+    <span style="color: #888; word-break: break-all; font-size: 13px;">${resetUrl}</span></p>
+    <p style="color: #888; font-size: 13px;">Linkki on voimassa 1 tunnin. Jos et pyytanyt nollausta, voit jattaa taman viestin huomiotta.<br>
+    This link expires in 1 hour. If you did not request this, you can safely ignore this email.</p>
+  `);
+
+  return sendEmail({ to, subject: "Helscoop: Salasanan nollaus / Password Reset", html });
+}
+
+// ---------------------------------------------------------------------------
+// Email verification
+// ---------------------------------------------------------------------------
+
+export async function sendVerificationEmail(to: string, token: string): Promise<boolean> {
+  const verifyUrl = `${APP_URL}/verify-email?token=${token}`;
+
+  const html = wrapTemplate(`
+    <h2>Vahvista sahkopostiosoitteesi / Verify Your Email</h2>
+    <p>Tervetuloa Helscoopiin! Vahvista sahkopostiosoitteesi klikkaamalla alla olevaa painiketta.</p>
+    <p>Welcome to Helscoop! Please verify your email address by clicking the button below.</p>
+    <p style="text-align: center;">
+      <a href="${verifyUrl}" class="btn">Vahvista sahkoposti / Verify Email</a>
+    </p>
+    <p>Jos painike ei toimi, kopioi tama linkki selaimeen:<br>
+    <span style="color: #888; word-break: break-all; font-size: 13px;">${verifyUrl}</span></p>
+    <p style="color: #888; font-size: 13px;">Linkki on voimassa 24 tuntia.<br>
+    This link expires in 24 hours.</p>
+  `);
+
+  return sendEmail({ to, subject: "Helscoop: Vahvista sahkopostisi / Verify Your Email", html });
+}
+
+// ---------------------------------------------------------------------------
+// Price alert email
+// ---------------------------------------------------------------------------
+
+interface PriceAlertItem {
+  materialName: string;
+  oldPrice: number;
+  newPrice: number;
+  supplier: string;
+  link: string;
+}
+
+export async function sendPriceAlertEmail(to: string, items: PriceAlertItem[]): Promise<boolean> {
+  const rows = items.map(item => {
+    const pctDrop = Math.round((1 - item.newPrice / item.oldPrice) * 100);
+    return `<tr>
+      <td style="padding: 8px 12px; border-bottom: 1px solid #2a2a2a;">${item.materialName}</td>
+      <td style="padding: 8px 12px; border-bottom: 1px solid #2a2a2a; text-decoration: line-through; color: #888;">${item.oldPrice.toFixed(2)} &euro;</td>
+      <td style="padding: 8px 12px; border-bottom: 1px solid #2a2a2a; color: #4ade80; font-weight: 600;">${item.newPrice.toFixed(2)} &euro; (-${pctDrop}%)</td>
+      <td style="padding: 8px 12px; border-bottom: 1px solid #2a2a2a;"><a href="${item.link}" style="color: #c4915c;">${item.supplier}</a></td>
+    </tr>`;
+  }).join("");
+
+  const html = wrapTemplate(`
+    <h2>Hintahälytys / Price Drop Alert</h2>
+    <p>Hyvät uutiset! Seuraamiesi materiaalien hinnat ovat laskeneet:</p>
+    <p>Good news! Prices have dropped on materials you're tracking:</p>
+    <table style="width: 100%; border-collapse: collapse; margin: 16px 0;">
+      <thead>
+        <tr style="text-align: left; color: #888; font-size: 12px; text-transform: uppercase; letter-spacing: 1px;">
+          <th style="padding: 8px 12px; border-bottom: 2px solid #333;">Materiaali</th>
+          <th style="padding: 8px 12px; border-bottom: 2px solid #333;">Vanha</th>
+          <th style="padding: 8px 12px; border-bottom: 2px solid #333;">Uusi</th>
+          <th style="padding: 8px 12px; border-bottom: 2px solid #333;">Kauppa</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+    <p style="text-align: center;">
+      <a href="${APP_URL}" class="btn">Avaa Helscoop / Open Helscoop</a>
+    </p>
+  `);
+
+  return sendEmail({ to, subject: "Helscoop: Hinnat laskeneet! / Prices Dropped!", html });
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -4,7 +4,7 @@ import helmet from "helmet";
 import jwt from "jsonwebtoken";
 import rateLimit from "express-rate-limit";
 import bcrypt from "bcryptjs";
-import { login, register, signToken, requireAuth, forgotPassword, resetPassword, AuthUser } from "./auth";
+import { login, register, signToken, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, AuthUser } from "./auth";
 import { query } from "./db";
 import materialsRouter from "./routes/materials";
 import projectsRouter from "./routes/projects";
@@ -157,7 +157,7 @@ app.post("/auth/register", authLimiter, async (req, res) => {
 
 app.get("/auth/me", authenticatedLimiter, requireAuth, async (req, res) => {
   const result = await query(
-    "SELECT id, email, name, role FROM users WHERE id = $1",
+    "SELECT id, email, name, role, email_verified FROM users WHERE id = $1",
     [req.user!.id]
   );
   if (result.rows.length === 0) {
@@ -265,11 +265,8 @@ app.post("/auth/forgot-password", authLimiter, async (req, res) => {
     return res.status(400).json({ error: "Invalid email format" });
   }
   try {
-    const token = await forgotPassword(email);
-    if (token) {
-      // MVP: log the reset link instead of sending email
-      console.log("Password reset link: /reset-password?token=" + token);
-    }
+    // forgotPassword now sends the reset email directly
+    await forgotPassword(email);
   } catch (e) {
     // Log but don't reveal errors to the client
     console.error("Forgot password error:", e);
@@ -295,6 +292,38 @@ app.post("/auth/reset-password", authLimiter, async (req, res) => {
   } catch (e) {
     console.error("Reset password error:", e);
     res.status(500).json({ error: "Failed to reset password" });
+  }
+});
+
+// Email verification endpoint
+app.get("/auth/verify-email", authLimiter, async (req, res) => {
+  const token = req.query.token as string;
+  if (!token) {
+    return res.status(400).json({ error: "Verification token is required" });
+  }
+  try {
+    const success = await verifyEmail(token);
+    if (!success) {
+      return res.status(400).json({ error: "Invalid or expired verification token" });
+    }
+    res.json({ message: "Email verified successfully" });
+  } catch (e) {
+    console.error("Email verification error:", e);
+    res.status(500).json({ error: "Failed to verify email" });
+  }
+});
+
+// Resend verification email
+app.post("/auth/resend-verification", authenticatedLimiter, requireAuth, async (req, res) => {
+  try {
+    const sent = await resendVerification(req.user!.id);
+    if (!sent) {
+      return res.status(400).json({ error: "Email already verified or user not found" });
+    }
+    res.json({ message: "Verification email sent" });
+  } catch (e) {
+    console.error("Resend verification error:", e);
+    res.status(500).json({ error: "Failed to resend verification email" });
   }
 });
 

--- a/db/migrations/006_email_verification.sql
+++ b/db/migrations/006_email_verification.sql
@@ -1,0 +1,11 @@
+-- Add email verification fields to users table
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_token TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS verification_token_expires TIMESTAMPTZ;
+
+-- Existing users are considered verified (grandfathered in)
+UPDATE users SET email_verified = true WHERE email_verified = false;
+
+-- Index for token lookup
+CREATE INDEX IF NOT EXISTS idx_users_verification_token ON users(verification_token) WHERE verification_token IS NOT NULL;

--- a/web/src/app/verify-email/page.tsx
+++ b/web/src/app/verify-email/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { api } from "@/lib/api";
+
+function VerifyEmailContent() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("error");
+      setErrorMsg("Vahvistustunniste puuttuu / Missing verification token");
+      return;
+    }
+
+    api.verifyEmail(token)
+      .then(() => setStatus("success"))
+      .catch((err) => {
+        setStatus("error");
+        setErrorMsg(err instanceof Error ? err.message : "Vahvistus epaonnistui / Verification failed");
+      });
+  }, [token]);
+
+  return (
+    <div style={{
+      minHeight: "100vh",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      padding: "40px 24px",
+      background: "var(--bg-primary)",
+    }}>
+      <div className="card anim-up" style={{
+        width: "100%",
+        maxWidth: 420,
+        padding: "40px 36px",
+        textAlign: "center",
+      }}>
+        {status === "loading" && (
+          <>
+            <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
+              Vahvistetaan...
+            </h1>
+            <p style={{ color: "var(--text-muted)", fontSize: 14 }}>
+              Odota hetki / Please wait...
+            </p>
+          </>
+        )}
+
+        {status === "success" && (
+          <>
+            <div style={{ fontSize: 48, marginBottom: 16 }}>&#10003;</div>
+            <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
+              Sahkoposti vahvistettu!
+            </h1>
+            <p style={{ color: "var(--text-muted)", fontSize: 14, marginBottom: 24, lineHeight: 1.6 }}>
+              Sahkopostiosoitteesi on nyt vahvistettu. Voit jatkaa Helscoopiin.
+              <br />
+              Your email has been verified. You can continue to Helscoop.
+            </p>
+            <a
+              href="/"
+              className="btn btn-primary"
+              style={{ textDecoration: "none", padding: "13px 32px", fontSize: 14 }}
+            >
+              Jatka / Continue
+            </a>
+          </>
+        )}
+
+        {status === "error" && (
+          <>
+            <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
+              Vahvistus epaonnistui
+            </h1>
+            <div style={{
+              padding: "10px 14px",
+              borderRadius: "var(--radius-sm)",
+              background: "var(--danger-dim)",
+              color: "var(--danger)",
+              fontSize: 13,
+              border: "1px solid rgba(199,95,95,0.12)",
+              marginBottom: 24,
+            }}>
+              {errorMsg}
+            </div>
+            <a
+              href="/"
+              className="btn btn-ghost"
+              style={{ fontSize: 13, textDecoration: "none" }}
+            >
+              Takaisin etusivulle / Back to home
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <Suspense fallback={
+      <div style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-primary)",
+        color: "var(--text-muted)",
+      }}>
+        Ladataan... / Loading...
+      </div>
+    }>
+      <VerifyEmailContent />
+    </Suspense>
+  );
+}

--- a/web/src/components/EmailVerificationBanner.tsx
+++ b/web/src/components/EmailVerificationBanner.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+
+interface Props {
+  emailVerified: boolean;
+}
+
+export default function EmailVerificationBanner({ emailVerified }: Props) {
+  const [resending, setResending] = useState(false);
+  const [resent, setResent] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  if (emailVerified || dismissed) return null;
+
+  async function handleResend() {
+    setResending(true);
+    try {
+      await api.resendVerification();
+      setResent(true);
+    } catch {
+      // Silently fail — user can try again
+    }
+    setResending(false);
+  }
+
+  return (
+    <div style={{
+      background: "var(--amber-glow, rgba(196,145,92,0.08))",
+      border: "1px solid var(--amber-border, rgba(196,145,92,0.2))",
+      borderRadius: "var(--radius-sm, 6px)",
+      padding: "12px 16px",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      gap: 12,
+      fontSize: 13,
+      color: "var(--text-primary)",
+      marginBottom: 16,
+    }}>
+      <span>
+        Vahvista sahkopostiosoitteesi. Tarkista postilaatikkosi.
+        {" / "}
+        Please verify your email. Check your inbox.
+      </span>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexShrink: 0 }}>
+        {resent ? (
+          <span style={{ color: "var(--success, #4ade80)", fontSize: 12 }}>
+            Lahetetty! / Sent!
+          </span>
+        ) : (
+          <button
+            onClick={handleResend}
+            disabled={resending}
+            className="btn btn-ghost"
+            style={{ fontSize: 12, padding: "4px 12px" }}
+          >
+            {resending ? "..." : "Laheta uudelleen / Resend"}
+          </button>
+        )}
+        <button
+          onClick={() => setDismissed(true)}
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--text-muted)",
+            cursor: "pointer",
+            fontSize: 16,
+            padding: "0 4px",
+            lineHeight: 1,
+          }}
+          aria-label="Sulje / Dismiss"
+        >
+          x
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -94,6 +94,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ token, password }),
     }),
+  verifyEmail: (token: string) =>
+    apiFetch(`/auth/verify-email?token=${encodeURIComponent(token)}`),
+  resendVerification: () =>
+    apiFetch("/auth/resend-verification", { method: "POST" }),
 
   getProjects: () => apiFetch("/projects"),
   getProject: (id: string) => apiFetch(`/projects/${id}`),


### PR DESCRIPTION
## Summary
- Add email service using Resend (free tier: 3k/month) with branded dark-theme HTML templates in Finnish/English
- Fix broken password reset flow: replaces `console.log` with actual email delivery via Resend
- Add email verification on registration: verification token, `GET /auth/verify-email` endpoint, frontend verify page, and `EmailVerificationBanner` component
- Include price drop alert email template (ready for future cron integration)
- Graceful dev mode: logs emails to console when `RESEND_API_KEY` is not set

Closes #151

## Test plan
- [ ] Register a new user and verify a verification email is sent (or logged in dev)
- [ ] Click the verification link and confirm email is marked verified
- [ ] Visit `/verify-email?token=invalid` and confirm error message
- [ ] Use "Resend" button on the verification banner
- [ ] Request password reset and confirm email is sent (not just logged)
- [ ] Complete password reset flow end-to-end
- [ ] Verify `/auth/me` returns `email_verified` field
- [ ] Verify existing users are grandfathered as verified (migration 006)
- [ ] Run `cd api && npx vitest run src/__tests__/api.test.ts` -- all 18 tests pass
- [ ] Run `cd web && npx tsc --noEmit` -- type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)