### PR TITLE
GDPR compliance: privacy policy, ToS, and consent

### DIFF
--- a/api/src/__tests__/e2e.test.ts
+++ b/api/src/__tests__/e2e.test.ts
@@ -28,7 +28,7 @@ describe.skipIf(!process.env.E2E)("E2E Integration Tests", () => {
   it("registers a new user", async () => {
     const { status, body } = await apiFetch("/auth/register", {
       method: "POST",
-      body: JSON.stringify({ email: testEmail, password: "testpass123", name: "E2E Test" }),
+      body: JSON.stringify({ email: testEmail, password: "testpass123", name: "E2E Test", acceptedTerms: true }),
     });
     expect(status).toBe(201);
     expect(body.token).toBeTruthy();
@@ -39,7 +39,7 @@ describe.skipIf(!process.env.E2E)("E2E Integration Tests", () => {
   it("rejects duplicate registration", async () => {
     const { status } = await apiFetch("/auth/register", {
       method: "POST",
-      body: JSON.stringify({ email: testEmail, password: "testpass123", name: "Dup" }),
+      body: JSON.stringify({ email: testEmail, password: "testpass123", name: "Dup", acceptedTerms: true }),
     });
     expect(status).toBe(409);
   });

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -61,7 +61,8 @@ export async function login(email: string, password: string) {
 export async function register(
   email: string,
   password: string,
-  name: string
+  name: string,
+  acceptedTerms?: boolean
 ) {
   const hash = await bcrypt.hash(password, 10);
 
@@ -70,10 +71,10 @@ export async function register(
   const verificationExpires = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
 
   const result = await query(
-    `INSERT INTO users (email, name, password_hash, email_verified, verification_token, verification_token_expires)
-     VALUES ($1, $2, $3, false, $4, $5)
+    `INSERT INTO users (email, name, password_hash, email_verified, verification_token, verification_token_expires, accepted_terms_at)
+     VALUES ($1, $2, $3, false, $4, $5, $6)
      RETURNING id, email, name, role`,
-    [email, name, hash, verificationToken, verificationExpires.toISOString()]
+    [email, name, hash, verificationToken, verificationExpires.toISOString(), acceptedTerms ? new Date().toISOString() : null]
   );
 
   // Send verification email (fire-and-forget — don't block registration)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -182,7 +182,7 @@ app.post("/auth/login", authLimiter, async (req, res) => {
 });
 
 app.post("/auth/register", authLimiter, async (req, res) => {
-  const { email, password, name } = req.body;
+  const { email, password, name, acceptedTerms } = req.body;
   if (!email || !password || !name) {
     return res.status(400).json({ error: "Email, password, and name are required" });
   }
@@ -195,9 +195,12 @@ app.post("/auth/register", authLimiter, async (req, res) => {
   if (name.length > 200) {
     return res.status(400).json({ error: "Name must be 200 characters or fewer" });
   }
+  if (!acceptedTerms) {
+    return res.status(400).json({ error: "You must accept the Terms of Service and Privacy Policy" });
+  }
   const sanitizedName = sanitize(name);
   try {
-    const user = await register(email, password, sanitizedName);
+    const user = await register(email, password, sanitizedName, true);
     res.status(201).json({ token: signToken(user), user });
   } catch (e: unknown) {
     console.error("Registration error:", e);

--- a/db/migrations/007_accepted_terms.sql
+++ b/db/migrations/007_accepted_terms.sql
@@ -1,0 +1,2 @@
+-- Track when users accepted Terms of Service and Privacy Policy
+ALTER TABLE users ADD COLUMN accepted_terms_at TIMESTAMPTZ;

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -51,7 +51,7 @@ test.describe("Authentication", () => {
   test("logs in with valid credentials", async ({ page }) => {
     const email = `e2e-login-${Date.now()}@test.com`;
     await page.request.post(`${API_URL}/auth/register`, {
-      data: { email, password: testPassword, name: "Login Test" },
+      data: { email, password: testPassword, name: "Login Test", acceptedTerms: true },
     });
 
     await page.goto("/");
@@ -97,7 +97,7 @@ test.describe("Authentication", () => {
   test("persists login across page reload", async ({ page }) => {
     const email = `e2e-persist-${Date.now()}@test.com`;
     const res = await page.request.post(`${API_URL}/auth/register`, {
-      data: { email, password: testPassword, name: "Persist Test" },
+      data: { email, password: testPassword, name: "Persist Test", acceptedTerms: true },
     });
     const { token } = await res.json();
 

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -21,7 +21,7 @@ export async function registerUser(
   };
 
   const res = await page.request.post(`${API_URL}/auth/register`, {
-    data: { email: user.email, password: user.password, name: user.name },
+    data: { email: user.email, password: user.password, name: user.name, acceptedTerms: true },
   });
   const body = await res.json();
   user.token = body.token;

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -974,3 +974,100 @@ body {
   white-space: nowrap;
   border-width: 0;
 }
+
+/* Legal pages (privacy, terms) */
+.legal-content h2 {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-top: 32px;
+  margin-bottom: 12px;
+}
+
+.legal-content h2:first-child {
+  margin-top: 0;
+}
+
+.legal-content p {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.legal-content ul {
+  padding-left: 20px;
+  margin-bottom: 12px;
+}
+
+.legal-content li {
+  font-size: 14px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.legal-content strong {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+/* Terms checkbox */
+.terms-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.terms-checkbox input[type="checkbox"] {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-tertiary);
+  cursor: pointer;
+  flex-shrink: 0;
+  margin-top: 1px;
+  position: relative;
+  transition: all 0.15s ease;
+}
+
+.terms-checkbox input[type="checkbox"]:checked {
+  background: var(--amber);
+  border-color: var(--amber);
+}
+
+.terms-checkbox input[type="checkbox"]:checked::after {
+  content: '';
+  position: absolute;
+  left: 5px;
+  top: 2px;
+  width: 5px;
+  height: 9px;
+  border: solid var(--bg-primary);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+
+.terms-checkbox input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
+.terms-checkbox-label {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.terms-checkbox-label a {
+  color: var(--amber);
+  text-decoration: none;
+}
+
+.terms-checkbox-label a:hover {
+  text-decoration: underline;
+}

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "@/components/LocaleProvider";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
+
+function PrivacyContentFi() {
+  return (
+    <>
+      <h2>1. Rekisterinpitaja</h2>
+      <p>
+        Helscoop<br />
+        Sahkoposti: privacy@helscoop.fi
+      </p>
+
+      <h2>2. Keratyt tiedot</h2>
+      <p>Keramme seuraavia henkilotietoja:</p>
+      <ul>
+        <li><strong>Tilin tiedot:</strong> nimi, sahkopostiosoite, salattu salasana</li>
+        <li><strong>Projektin tiedot:</strong> 3D-kohtauskoodit, materiaalilistat, projektin nimet ja kuvaukset</li>
+        <li><strong>Rakennushaut:</strong> hakemasi osoitteet (rakennustietojen hakua varten)</li>
+        <li><strong>Tekniset tiedot:</strong> IP-osoite (nopeusrajoitusta varten), istuntotunnus</li>
+      </ul>
+
+      <h2>3. Tietojen tallentaminen</h2>
+      <p>
+        Henkilotietosi tallennetaan PostgreSQL-tietokantaan. Salasanat tallennetaan bcrypt-algoritmilla salattuina.
+        Palvelua isannoidaan EU:n alueella.
+      </p>
+
+      <h2>4. Tietojen sailytysaika</h2>
+      <p>
+        Henkilotietojasi sailytetaan niin kauan kuin tilisi on aktiivinen. Voit milloin tahansa poistaa
+        tilisi Asetukset-sivulta, jolloin kaikki tietosi poistetaan pysyvasti.
+      </p>
+
+      <h2>5. Rekisteroidyn oikeudet</h2>
+      <p>Sinulla on oikeus:</p>
+      <ul>
+        <li>Paasta kaikkiin henkilotietoihisi (Asetukset-sivu)</li>
+        <li>Oikaista tietojasi (nimi, sahkoposti Asetukset-sivulta)</li>
+        <li>Poistaa kaikki tietosi (tilin poisto Asetukset-sivulta)</li>
+        <li>Vastustaa tietojenkasittelya</li>
+        <li>Siirtaa tietosi toiseen palveluun</li>
+        <li>Tehda valitus tietosuojaviranomaiselle</li>
+      </ul>
+
+      <h2>6. Kolmannet osapuolet</h2>
+      <p>Kaytamme seuraavia kolmannen osapuolen palveluita:</p>
+      <ul>
+        <li><strong>Claude AI (Anthropic):</strong> AI-avustaja kohtausten muokkaamiseen. Chat-viestit lahetetaan Anthropicin API:lle.</li>
+        <li><strong>DVV / Maanmittauslaitos:</strong> Rakennustietojen haku julkisista rekistereista.</li>
+        <li><strong>K-Rauta, Sarokas, Ruukki:</strong> Materiaalien hintatiedot haetaan naiden toimittajien verkkosivuilta.</li>
+      </ul>
+
+      <h2>7. Evasteet</h2>
+      <p>
+        Helscoop ei kayta analytiikka- tai mainosevasteita. Kaytamme ainoastaan
+        valttamatonta istuntotunnistetta (JWT localStorage-muistissa), joka on
+        tarpeen kirjautumisen yllapitamiseksi.
+      </p>
+
+      <h2>8. Yhteydenotto</h2>
+      <p>
+        Tietosuojaa koskevissa kysymyksissa voit ottaa yhteytta: privacy@helscoop.fi
+      </p>
+    </>
+  );
+}
+
+function PrivacyContentEn() {
+  return (
+    <>
+      <h2>1. Data controller</h2>
+      <p>
+        Helscoop<br />
+        Email: privacy@helscoop.fi
+      </p>
+
+      <h2>2. Data we collect</h2>
+      <p>We collect the following personal data:</p>
+      <ul>
+        <li><strong>Account information:</strong> name, email address, encrypted password</li>
+        <li><strong>Project data:</strong> 3D scene code, bill-of-materials lists, project names and descriptions</li>
+        <li><strong>Building lookups:</strong> addresses you search (for building data retrieval)</li>
+        <li><strong>Technical data:</strong> IP address (for rate limiting), session identifier</li>
+      </ul>
+
+      <h2>3. Data storage</h2>
+      <p>
+        Your personal data is stored in a PostgreSQL database. Passwords are encrypted using the bcrypt algorithm.
+        The service is hosted within the EU.
+      </p>
+
+      <h2>4. Data retention</h2>
+      <p>
+        Your personal data is retained as long as your account is active. You can delete your account
+        at any time from the Settings page, which permanently removes all your data.
+      </p>
+
+      <h2>5. Your rights</h2>
+      <p>You have the right to:</p>
+      <ul>
+        <li>Access all your personal data (Settings page)</li>
+        <li>Rectify your data (name, email from Settings)</li>
+        <li>Delete all your data (account deletion from Settings)</li>
+        <li>Object to data processing</li>
+        <li>Data portability</li>
+        <li>Lodge a complaint with a supervisory authority</li>
+      </ul>
+
+      <h2>6. Third parties</h2>
+      <p>We use the following third-party services:</p>
+      <ul>
+        <li><strong>Claude AI (Anthropic):</strong> AI assistant for scene editing. Chat messages are sent to Anthropic&apos;s API.</li>
+        <li><strong>DVV / National Land Survey:</strong> Building data from Finnish public registries.</li>
+        <li><strong>K-Rauta, Sarokas, Ruukki:</strong> Material pricing scraped from supplier websites.</li>
+      </ul>
+
+      <h2>7. Cookies</h2>
+      <p>
+        Helscoop does not use analytics or advertising cookies. We only use an essential session
+        token (JWT in localStorage) required to maintain your login session.
+      </p>
+
+      <h2>8. Contact</h2>
+      <p>
+        For privacy-related questions, contact us at: privacy@helscoop.fi
+      </p>
+    </>
+  );
+}
+
+export default function PrivacyPage() {
+  const { locale, t } = useTranslation();
+
+  return (
+    <div style={{ minHeight: "100vh" }}>
+      {/* Top bar */}
+      <div className="nav-bar">
+        <div className="nav-inner" style={{ maxWidth: 720 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <Link href="/" style={{ textDecoration: "none" }}>
+              <span className="heading-display" style={{ fontSize: 20 }}>
+                <span style={{ color: "var(--text-primary)" }}>Hel</span>
+                <span style={{ color: "var(--amber)" }}>scoop</span>
+              </span>
+            </Link>
+            <div
+              style={{
+                width: 1,
+                height: 20,
+                background: "var(--border-strong)",
+                margin: "0 4px",
+              }}
+            />
+            <span className="label-mono">{t("legal.privacyTitle")}</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <ThemeToggle />
+            <LanguageSwitcher />
+            <Link
+              href="/"
+              className="btn btn-ghost"
+              style={{
+                fontSize: 12,
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+              {t("legal.backToHome")}
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{ maxWidth: 720, margin: "0 auto", padding: "40px 24px 80px" }}
+      >
+        <div className="anim-up" style={{ marginBottom: 40 }}>
+          <h1
+            className="heading-display"
+            style={{ fontSize: 36, marginBottom: 6 }}
+          >
+            {t("legal.privacyTitle")}
+          </h1>
+          <p style={{ color: "var(--text-muted)", fontSize: 14 }}>
+            {t("legal.lastUpdated", { date: "2026-04-19" })}
+          </p>
+        </div>
+
+        <div className="card anim-up legal-content" style={{ padding: "32px 28px" }}>
+          {locale === "fi" ? <PrivacyContentFi /> : <PrivacyContentEn />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -387,9 +387,59 @@ export default function SettingsPage() {
           </button>
         </div>
 
-        {/* Account section */}
+        {/* Legal links section */}
         <div
           className="card anim-up delay-3 settings-card"
+          style={{ marginBottom: 20 }}
+        >
+          <h2
+            className="heading-display"
+            style={{ fontSize: 20, marginBottom: 4 }}
+          >
+            {t("legal.privacyPolicy")} & {t("legal.termsOfService")}
+          </h2>
+          <p
+            style={{
+              color: "var(--text-muted)",
+              fontSize: 14,
+              marginBottom: 24,
+            }}
+          >
+            GDPR
+          </p>
+
+          <div style={{ display: "flex", gap: 12 }}>
+            <Link
+              href="/privacy"
+              className="btn btn-ghost"
+              style={{ padding: "11px 24px", textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 6 }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+              {t("legal.privacyPolicy")}
+            </Link>
+            <Link
+              href="/terms"
+              className="btn btn-ghost"
+              style={{ padding: "11px 24px", textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 6 }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                <polyline points="14 2 14 8 20 8" />
+                <line x1="16" y1="13" x2="8" y2="13" />
+                <line x1="16" y1="17" x2="8" y2="17" />
+                <polyline points="10 9 9 9 8 9" />
+              </svg>
+              {t("legal.termsOfService")}
+            </Link>
+          </div>
+        </div>
+
+        {/* Account section */}
+        <div
+          className="card anim-up delay-4 settings-card"
         >
           <h2
             className="heading-display"

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -8,5 +8,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
+    {
+      url: "https://helscoop.fi/privacy",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: "https://helscoop.fi/terms",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
   ];
 }

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "@/components/LocaleProvider";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { ThemeToggle } from "@/components/ThemeToggle";
+
+function TermsContentFi() {
+  return (
+    <>
+      <h2>1. Palvelun kuvaus</h2>
+      <p>
+        Helscoop on parametrinen suunnittelutyokalu, joka auttaa kayttajia visualisoimaan
+        ja suunnittelemaan rakennusremontteja 3D-mallinnuksen avulla. Palvelu tarjoaa
+        reaaliaikaiset materiaalihinnat suomalaisilta toimittajilta.
+      </p>
+
+      <h2>2. Hyvaksyttava kaytto</h2>
+      <p>Sitoudut olemaan:</p>
+      <ul>
+        <li>Kayttamatta palvelua laittomiin tarkoituksiin</li>
+        <li>Yrittamatta haitata palvelun toimintaa tai muiden kayttajien kokemusta</li>
+        <li>Kayttamatta automaattisia tyokaluja palvelun tietojen keraamiseen (scraping)</li>
+        <li>Jakamasta tilisi tunnuksia kolmansille osapuolille</li>
+      </ul>
+
+      <h2>3. Immateriaalioikeudet</h2>
+      <p>
+        <strong>Sinun sisaltosi:</strong> Omistat kaikki luomasi projektit, 3D-kohtaukset ja
+        materiaalilistat. Helscoop ei vaadi oikeuksia sisaltoosi.
+      </p>
+      <p>
+        <strong>Palvelun sisalto:</strong> Helscoopin ohjelmisto, kayttoliittyma ja tavaramerkki
+        kuuluvat Helscoopille.
+      </p>
+
+      <h2>4. AI-generoitu sisalto</h2>
+      <p>
+        Helscoopin AI-avustaja tuottaa 3D-kohtauskoodia koneoppimismallien avulla.
+        AI-generoitu koodi tarjotaan sellaisenaan, eika sen toiminnallisuutta tai
+        turvallisuutta taata. Kayttaja on vastuussa AI-generoidun koodin tarkistamisesta
+        ja kayttamisesta.
+      </p>
+
+      <h2>5. Hintatietojen tarkkuus</h2>
+      <p>
+        Materiaalien hinnat haetaan automaattisesti toimittajien verkkosivuilta.
+        Helscoop ei takaa hintojen tarkkuutta, ajantasaisuutta tai saatavuutta.
+        Hinnat ovat suuntaa antavia, ja lopulliset hinnat tulee vahvistaa
+        suoraan toimittajalta.
+      </p>
+
+      <h2>6. Vastuunrajoitus</h2>
+      <p>
+        Helscoop tarjotaan sellaisenaan. Emme vastaa:
+      </p>
+      <ul>
+        <li>Rakennustietojen oikeellisuudesta (tiedot haetaan julkisista rekistereista)</li>
+        <li>AI-avustajan tuottaman koodin toiminnallisuudesta tai virheettomyydesta</li>
+        <li>Hintatietojen tarkkuudesta tai ajantasaisuudesta</li>
+        <li>Palvelun kayttoon perustuvista suunnittelupaatosten seurauksista</li>
+        <li>Palvelun keskeytyksista tai tietojen menetyksesta</li>
+      </ul>
+
+      <h2>7. Tilin irtisanominen</h2>
+      <p>
+        Voit poistaa tilisi milloin tahansa Asetukset-sivulta. Pidatamme oikeuden
+        sulkea tilin, joka rikkoo naita kayttoehtoja.
+      </p>
+
+      <h2>8. Ehtojen muutokset</h2>
+      <p>
+        Pidatamme oikeuden muuttaa naita ehtoja. Olennaisista muutoksista
+        ilmoitetaan sahkopostitse. Palvelun kayton jatkaminen muutosten jalkeen
+        merkitsee uusien ehtojen hyvaksymista.
+      </p>
+
+      <h2>9. Sovellettava laki</h2>
+      <p>
+        Naihin ehtoihin sovelletaan Suomen lakia. Riidat ratkaistaan
+        Helsingin karajaoikeudessa.
+      </p>
+    </>
+  );
+}
+
+function TermsContentEn() {
+  return (
+    <>
+      <h2>1. Service description</h2>
+      <p>
+        Helscoop is a parametric design tool that helps users visualize and plan building
+        renovations using 3D modeling. The service provides real-time material pricing
+        from Finnish suppliers.
+      </p>
+
+      <h2>2. Acceptable use</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use the service for any unlawful purpose</li>
+        <li>Attempt to disrupt the service or other users&apos; experience</li>
+        <li>Use automated tools to scrape data from the service</li>
+        <li>Share your account credentials with third parties</li>
+      </ul>
+
+      <h2>3. Intellectual property</h2>
+      <p>
+        <strong>Your content:</strong> You own all projects, 3D scenes, and material lists you create.
+        Helscoop does not claim any rights to your content.
+      </p>
+      <p>
+        <strong>Service content:</strong> Helscoop&apos;s software, user interface, and trademarks
+        belong to Helscoop.
+      </p>
+
+      <h2>4. AI-generated content</h2>
+      <p>
+        Helscoop&apos;s AI assistant generates 3D scene code using machine learning models.
+        AI-generated code is provided as-is, and its functionality or safety is not
+        guaranteed. Users are responsible for reviewing and using AI-generated code.
+      </p>
+
+      <h2>5. Price data accuracy</h2>
+      <p>
+        Material prices are automatically scraped from supplier websites.
+        Helscoop does not guarantee the accuracy, currency, or availability of prices.
+        Prices are indicative, and final prices should be confirmed directly
+        with the supplier.
+      </p>
+
+      <h2>6. Limitation of liability</h2>
+      <p>
+        Helscoop is provided as-is. We are not liable for:
+      </p>
+      <ul>
+        <li>Accuracy of building data (sourced from public registries)</li>
+        <li>Functionality or correctness of AI-generated code</li>
+        <li>Accuracy or currency of pricing data</li>
+        <li>Consequences of design decisions based on the service</li>
+        <li>Service interruptions or data loss</li>
+      </ul>
+
+      <h2>7. Account termination</h2>
+      <p>
+        You can delete your account at any time from the Settings page. We reserve the right
+        to terminate accounts that violate these terms.
+      </p>
+
+      <h2>8. Changes to terms</h2>
+      <p>
+        We reserve the right to modify these terms. Material changes will be communicated
+        via email. Continued use of the service after changes constitutes acceptance
+        of the new terms.
+      </p>
+
+      <h2>9. Governing law</h2>
+      <p>
+        These terms are governed by Finnish law. Disputes shall be resolved
+        in the District Court of Helsinki.
+      </p>
+    </>
+  );
+}
+
+export default function TermsPage() {
+  const { locale, t } = useTranslation();
+
+  return (
+    <div style={{ minHeight: "100vh" }}>
+      {/* Top bar */}
+      <div className="nav-bar">
+        <div className="nav-inner" style={{ maxWidth: 720 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <Link href="/" style={{ textDecoration: "none" }}>
+              <span className="heading-display" style={{ fontSize: 20 }}>
+                <span style={{ color: "var(--text-primary)" }}>Hel</span>
+                <span style={{ color: "var(--amber)" }}>scoop</span>
+              </span>
+            </Link>
+            <div
+              style={{
+                width: 1,
+                height: 20,
+                background: "var(--border-strong)",
+                margin: "0 4px",
+              }}
+            />
+            <span className="label-mono">{t("legal.termsTitle")}</span>
+          </div>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <ThemeToggle />
+            <LanguageSwitcher />
+            <Link
+              href="/"
+              className="btn btn-ghost"
+              style={{
+                fontSize: 12,
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+              }}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+              {t("legal.backToHome")}
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{ maxWidth: 720, margin: "0 auto", padding: "40px 24px 80px" }}
+      >
+        <div className="anim-up" style={{ marginBottom: 40 }}>
+          <h1
+            className="heading-display"
+            style={{ fontSize: 36, marginBottom: 6 }}
+          >
+            {t("legal.termsTitle")}
+          </h1>
+          <p style={{ color: "var(--text-muted)", fontSize: 14 }}>
+            {t("legal.lastUpdated", { date: "2026-04-19" })}
+          </p>
+        </div>
+
+        <div className="card anim-up legal-content" style={{ padding: "32px 28px" }}>
+          {locale === "fi" ? <TermsContentFi /> : <TermsContentEn />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { api, setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
@@ -12,6 +13,7 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [isRegister, setIsRegister] = useState(false);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const { t } = useTranslation();
@@ -19,10 +21,14 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    if (isRegister && !acceptedTerms) {
+      setError(t('auth.acceptTermsRequired'));
+      return;
+    }
     setLoading(true);
     try {
       const result = isRegister
-        ? await api.register(email, password, name)
+        ? await api.register(email, password, name, acceptedTerms)
         : await api.login(email, password);
       setToken(result.token);
       onLogin();
@@ -160,6 +166,22 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
               )}
             </div>
 
+            {isRegister && (
+              <label className="terms-checkbox">
+                <input
+                  type="checkbox"
+                  checked={acceptedTerms}
+                  onChange={(e) => setAcceptedTerms(e.target.checked)}
+                />
+                <span className="terms-checkbox-label">
+                  {t('auth.acceptTerms')}{' '}
+                  <Link href="/terms" target="_blank">{t('auth.termsOfService')}</Link>
+                  {' '}{t('auth.and')}{' '}
+                  <Link href="/privacy" target="_blank">{t('auth.privacyPolicy')}</Link>
+                </span>
+              </label>
+            )}
+
             {error && (
               <div style={{
                 padding: "10px 14px",
@@ -187,7 +209,7 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
 
           <div style={{ textAlign: "center" }}>
             <button
-              onClick={() => { setIsRegister(!isRegister); setError(""); }}
+              onClick={() => { setIsRegister(!isRegister); setError(""); setAcceptedTerms(false); }}
               style={{
                 background: "none",
                 border: "none",
@@ -199,6 +221,38 @@ export default function LoginForm({ onLogin, pendingBuilding }: { onLogin: () =>
             >
               {isRegister ? t('auth.hasAccount') : t('auth.noAccount')}
             </button>
+          </div>
+
+          {/* Footer links to legal pages */}
+          <div style={{
+            marginTop: 24,
+            textAlign: "center",
+            display: "flex",
+            justifyContent: "center",
+            gap: 16,
+          }}>
+            <Link
+              href="/privacy"
+              style={{
+                color: "var(--text-muted)",
+                fontSize: 12,
+                textDecoration: "none",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {t('legal.privacyPolicy')}
+            </Link>
+            <Link
+              href="/terms"
+              style={{
+                color: "var(--text-muted)",
+                fontSize: 12,
+                textDecoration: "none",
+                fontFamily: "var(--font-body)",
+              }}
+            >
+              {t('legal.termsOfService')}
+            </Link>
           </div>
         </div>
       </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -72,10 +72,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ email, password }),
     }),
-  register: (email: string, password: string, name: string) =>
+  register: (email: string, password: string, name: string, acceptedTerms?: boolean) =>
     apiFetch("/auth/register", {
       method: "POST",
-      body: JSON.stringify({ email, password, name }),
+      body: JSON.stringify({ email, password, name, acceptedTerms }),
     }),
   me: () => apiFetch("/auth/me"),
   updateProfile: (data: { name?: string; email?: string }) =>

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -27,6 +27,11 @@ const translations = {
       hasAccount: 'Onko jo tili? Kirjaudu',
       loading: 'Ladataan...',
       loginFailed: 'Kirjautuminen ei onnistunut',
+      acceptTerms: 'Hyvaksyn',
+      termsOfService: 'kayttoehtojen',
+      and: 'ja',
+      privacyPolicy: 'tietosuojaselosteen',
+      acceptTermsRequired: 'Sinun on hyvaksyttava kayttoehdot ja tietosuojaseloste',
     },
     brand: {
       tagline: 'N\u00c4E TALOSI \u00b7 MUUTA \u00b7 RAKENNA',
@@ -272,6 +277,14 @@ const translations = {
       restartTourDesc: 'Nayta Helscoopin esittelykierros uudelleen',
       tourRestarted: 'Kierros nollattu — naet sen seuraavalla sivulatauksella',
     },
+    legal: {
+      privacyTitle: 'Tietosuojaseloste',
+      termsTitle: 'Kayttoehdot',
+      lastUpdated: 'Viimeksi paivitetty: {{date}}',
+      backToHome: 'Takaisin etusivulle',
+      privacyPolicy: 'Tietosuojaseloste',
+      termsOfService: 'Kayttoehdot',
+    },
   },
   en: {
     nav: {
@@ -299,6 +312,11 @@ const translations = {
       hasAccount: 'Already have an account? Sign in',
       loading: 'Loading...',
       loginFailed: 'Login failed',
+      acceptTerms: 'I agree to the',
+      termsOfService: 'Terms of Service',
+      and: 'and',
+      privacyPolicy: 'Privacy Policy',
+      acceptTermsRequired: 'You must accept the Terms of Service and Privacy Policy',
     },
     brand: {
       tagline: 'SEE YOUR HOUSE \u00b7 CHANGE IT \u00b7 BUILD',
@@ -543,6 +561,14 @@ const translations = {
       restartTour: 'Restart tour',
       restartTourDesc: 'Show the Helscoop introduction tour again',
       tourRestarted: 'Tour reset — you will see it on next page load',
+    },
+    legal: {
+      privacyTitle: 'Privacy Policy',
+      termsTitle: 'Terms of Service',
+      lastUpdated: 'Last updated: {{date}}',
+      backToHome: 'Back to home',
+      privacyPolicy: 'Privacy Policy',
+      termsOfService: 'Terms of Service',
     },
   },
 } as const;


### PR DESCRIPTION
## Summary
- Adds `/privacy` and `/terms` pages with full bilingual (fi/en) content covering data collection, storage, retention, user rights, third parties, cookies, acceptable use, IP ownership, AI disclaimers, price accuracy, and liability
- Registration form now requires ToS/privacy policy acceptance checkbox; API enforces `acceptedTerms: true`
- Database migration adds `accepted_terms_at` timestamp column to users table
- Footer links on login form + legal links section on Settings page
- Sitemap updated with new pages

Closes #165

## Test plan
- [ ] Verify `/privacy` page renders correctly in both Finnish and English
- [ ] Verify `/terms` page renders correctly in both Finnish and English
- [ ] Verify registration form shows ToS checkbox and blocks submission without acceptance
- [ ] Verify API rejects registration without `acceptedTerms: true`
- [ ] Verify footer links on login page navigate to privacy/terms
- [ ] Verify Settings page shows legal links section
- [ ] CI passes (tsc --noEmit, vitest, e2e tests with updated registration payloads)

Generated with [Claude Code](https://claude.com/claude-code)