### PR TITLE
Auto-generate project thumbnails from 3D viewport

### DIFF
--- a/api/src/routes/projects.ts
+++ b/api/src/routes/projects.ts
@@ -9,7 +9,7 @@ router.use(requireAuth);
 
 router.get("/", async (req, res) => {
   const result = await query(
-    `SELECT id, name, description, is_public, created_at, updated_at,
+    `SELECT id, name, description, is_public, created_at, updated_at, thumbnail_url,
       (SELECT COALESCE(SUM(pb.quantity * p.unit_price * m.waste_factor), 0)
        FROM project_bom pb
        JOIN pricing p ON pb.material_id = p.material_id AND p.is_primary = true
@@ -114,6 +114,25 @@ router.put("/:id/bom", async (req, res) => {
   } catch (err: any) {
     res.status(500).json({ error: "Failed to save BOM", detail: err.message });
   }
+});
+
+router.put("/:id/thumbnail", async (req, res) => {
+  const { thumbnail } = req.body;
+  if (!thumbnail || typeof thumbnail !== "string") {
+    return res.status(400).json({ error: "thumbnail (base64 data URL) is required" });
+  }
+  // Limit thumbnail size to 200KB of base64 data
+  if (thumbnail.length > 200 * 1024) {
+    return res.status(400).json({ error: "Thumbnail too large (max 200KB)" });
+  }
+  const result = await query(
+    "UPDATE projects SET thumbnail_url = $1, updated_at = now() WHERE id = $2 AND user_id = $3 RETURNING id",
+    [thumbnail, req.params.id, req.user!.id]
+  );
+  if (result.rows.length === 0) {
+    return res.status(404).json({ error: "Project not found" });
+  }
+  res.json({ ok: true });
 });
 
 router.post("/:id/duplicate", async (req, res) => {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -87,6 +87,7 @@ export default function ProjectPage() {
   const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const bomChangedRef = useRef(false);
   const initialLoadDoneRef = useRef(false);
+  const captureThumbRef = useRef<(() => string | null) | null>(null);
 
   const pushHistory = useCallback((code: string) => {
     const history = historyRef.current;
@@ -173,6 +174,11 @@ export default function ProjectPage() {
           )
         );
         bomChangedRef.current = false;
+      }
+      // Capture and save thumbnail in the background (non-blocking)
+      const thumbDataUrl = captureThumbRef.current?.();
+      if (thumbDataUrl) {
+        savePromises.push(api.saveThumbnail(projectId, thumbDataUrl));
       }
       await Promise.all(savePromises);
       setLastSaved(new Date().toLocaleTimeString());
@@ -607,6 +613,7 @@ export default function ProjectPage() {
                 wireframe={wireframe}
                 onObjectCount={setObjectCount}
                 onError={setSceneError}
+                captureRef={captureThumbRef}
               />
             </ErrorBoundary>
           </div>

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -21,37 +21,81 @@ export default function ProjectCard({
       className="card card-interactive anim-up project-card-grid"
       style={{
         animationDelay: `${index * 0.04}s`,
-        padding: "22px 28px",
+        padding: 0,
+        cursor: "pointer",
+        overflow: "hidden",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.borderColor = "var(--amber-border)";
+        e.currentTarget.style.boxShadow = "var(--shadow-amber)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.borderColor = "var(--border)";
+        e.currentTarget.style.boxShadow = "none";
       }}
       onClick={() => (window.location.href = `/project/${project.id}`)}
     >
-      <div style={{ minWidth: 0 }}>
-        <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
-          <h3 className="heading-display" style={{ fontSize: 18 }}>{project.name}</h3>
-          {project.estimated_cost > 0 && (
-            <span className="badge badge-amber">
-              {Number(project.estimated_cost).toFixed(0)} &euro;
-            </span>
-          )}
-        </div>
-        <div style={{ display: "flex", alignItems: "center", gap: 12, color: "var(--text-muted)", fontSize: 13 }}>
-          <span>{project.description || t('project.emptyDescription')}</span>
-          <span style={{ opacity: 0.5 }}>&middot;</span>
-          <span style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
-            {new Date(project.updated_at).toLocaleDateString(locale === 'fi' ? 'fi-FI' : 'en-GB')}
-          </span>
-        </div>
+      {/* Thumbnail or placeholder */}
+      <div style={{
+        height: 120,
+        background: project.thumbnail_url
+          ? `url(${project.thumbnail_url}) center/cover no-repeat`
+          : "linear-gradient(135deg, #1a1d22 0%, #111113 50%, #1f1e1c 100%)",
+        position: "relative",
+        borderBottom: "1px solid var(--border)",
+      }}>
+        {!project.thumbnail_url && (
+          <div style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}>
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" strokeWidth="1" strokeLinecap="round" strokeLinejoin="round" style={{ opacity: 0.3 }}>
+              <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+              <polyline points="9 22 9 12 15 12 15 22" />
+            </svg>
+          </div>
+        )}
+        <div style={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: 40,
+          background: "linear-gradient(transparent, var(--bg-secondary))",
+        }} />
       </div>
-      <div className="project-card-actions" onClick={(e) => e.stopPropagation()}>
-        <button className="btn btn-ghost" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => (window.location.href = `/project/${project.id}`)}>
-          {t('project.open')}
-        </button>
-        <button className="btn btn-ghost" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => onDuplicate(project.id)}>
-          {t('project.copy')}
-        </button>
-        <button className="btn btn-danger" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => onDelete(project.id)}>
-          {t('project.delete')}
-        </button>
+      <div style={{ padding: "14px 22px 18px" }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
+            <h3 className="heading-display" style={{ fontSize: 18 }}>{project.name}</h3>
+            {project.estimated_cost > 0 && (
+              <span className="badge badge-amber">
+                {Number(project.estimated_cost).toFixed(0)} &euro;
+              </span>
+            )}
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, color: "var(--text-muted)", fontSize: 13 }}>
+            <span>{project.description || t('project.emptyDescription')}</span>
+            <span style={{ opacity: 0.5 }}>&middot;</span>
+            <span style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
+              {new Date(project.updated_at).toLocaleDateString(locale === 'fi' ? 'fi-FI' : 'en-GB')}
+            </span>
+          </div>
+        </div>
+        <div className="project-card-actions" onClick={(e) => e.stopPropagation()} style={{ marginTop: 10 }}>
+          <button className="btn btn-ghost" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => (window.location.href = `/project/${project.id}`)}>
+            {t('project.open')}
+          </button>
+          <button className="btn btn-ghost" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => onDuplicate(project.id)}>
+            {t('project.copy')}
+          </button>
+          <button className="btn btn-danger" style={{ padding: "6px 12px", fontSize: 12 }} onClick={() => onDelete(project.id)}>
+            {t('project.delete')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -11,6 +11,7 @@ interface Viewport3DProps {
   wireframe?: boolean;
   onObjectCount?: (count: number) => void;
   onError?: (error: string | null) => void;
+  captureRef?: React.MutableRefObject<(() => string | null) | null>;
 }
 
 interface CameraPreset {
@@ -222,6 +223,7 @@ export default function Viewport3D({
   wireframe = false,
   onObjectCount,
   onError,
+  captureRef,
 }: Viewport3DProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -440,6 +442,32 @@ export default function Viewport3D({
         }
       };
   }, []);
+
+  // Expose thumbnail capture function via captureRef
+  useEffect(() => {
+    if (!captureRef) return;
+    captureRef.current = () => {
+      const renderer = rendererRef.current;
+      const scene = sceneRef.current;
+      const camera = cameraRef.current;
+      if (!renderer || !scene || !camera) return null;
+      renderer.render(scene, camera);
+      const canvas = renderer.domElement;
+      // Create a small thumbnail (320x180) to keep payload under 200KB
+      const thumbW = 320;
+      const thumbH = 180;
+      const offscreen = document.createElement("canvas");
+      offscreen.width = thumbW;
+      offscreen.height = thumbH;
+      const ctx = offscreen.getContext("2d");
+      if (!ctx) return null;
+      ctx.drawImage(canvas, 0, 0, thumbW, thumbH);
+      return offscreen.toDataURL("image/webp", 0.7);
+    };
+    return () => {
+      captureRef.current = null;
+    };
+  }, [captureRef]);
 
   return (
     <div

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -109,6 +109,11 @@ export const api = {
     apiFetch(`/projects/${id}`, { method: "DELETE" }),
   duplicateProject: (id: string) =>
     apiFetch(`/projects/${id}/duplicate`, { method: "POST" }),
+  saveThumbnail: (id: string, thumbnail: string) =>
+    apiFetch(`/projects/${id}/thumbnail`, {
+      method: "PUT",
+      body: JSON.stringify({ thumbnail }),
+    }),
 
   getMaterials: () => apiFetch("/materials"),
   getMaterial: (id: string) => apiFetch(`/materials/${id}`),

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Project {
   updated_at: string;
   scene_js?: string | null;
   display_scale?: number;
+  thumbnail_url?: string | null;
   bom?: BomItem[];
 }
 


### PR DESCRIPTION
## Summary
- Captures a 320x180 WebP thumbnail from the Three.js viewport each time a project is saved
- New `PUT /projects/:id/thumbnail` API endpoint stores the base64 data URL (max 200KB)
- Project list query now includes `thumbnail_url`
- `ProjectCard` displays the thumbnail as a background image with a gradient overlay for text readability, with a house icon placeholder when no thumbnail exists
- `Viewport3D` exposes a capture function via a `captureRef` prop — renders one clean frame and downscales to a compact WebP

## Test plan
- [ ] Open a project, edit the scene, and save — verify the save still works and a thumbnail is generated
- [ ] Navigate back to the project list — verify the saved project shows its thumbnail
- [ ] Projects without thumbnails show a house icon placeholder
- [ ] Thumbnail data URL stays under 200KB (320x180 WebP at quality 0.7)
- [ ] CI passes (tsc, vitest, build)

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)