### PR TITLE
Product analytics: Plausible integration with typed event tracking

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -87,6 +87,12 @@ export default function RootLayout({
             __html: `(function(){try{var t=localStorage.getItem("helscoop-theme");var d=t==="light"?"light":t==="auto"?window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light":"dark";document.documentElement.setAttribute("data-theme",d);document.documentElement.style.background=d==="light"?"#fafafa":"#09090b"}catch(e){}})()`
           }}
         />
+        {/* Plausible Analytics — privacy-first, no cookies, GDPR-compliant */}
+        <script
+          defer
+          data-domain="helscoop.fi"
+          src="https://plausible.io/js/script.js"
+        />
       </head>
       <body className="grain">
         <ThemeProvider>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,6 +6,7 @@ import { api, setToken, getToken } from "@/lib/api";
 import LoginForm from "@/components/LoginForm";
 import AddressSearch from "@/components/AddressSearch";
 import ProjectList from "@/components/ProjectList";
+import { useAnalytics } from "@/hooks/useAnalytics";
 import type { BuildingResult } from "@/types";
 
 const BUILDING_TYPE_LABELS: Record<string, Record<string, string>> = {
@@ -17,6 +18,7 @@ export default function Home() {
   const router = useRouter();
   const [loggedIn, setLoggedIn] = useState(false);
   const [pendingBuilding, setPendingBuilding] = useState<BuildingResult | null>(null);
+  const { track } = useAnalytics();
 
   useEffect(() => {
     if (getToken()) {
@@ -33,6 +35,7 @@ export default function Home() {
   }
 
   async function createProjectFromBuilding(building: BuildingResult) {
+    track("project_created", { source: "address", building_type: building.building_info.type });
     const buildingTypeLabels = BUILDING_TYPE_LABELS.fi;
     const project = await api.createProject({
       name: building.address,

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -16,6 +16,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { generateQuotePdf } from "@/lib/pdf";
 import Link from "next/link";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useAnalytics, useEditorSession } from "@/hooks/useAnalytics";
 import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
 import type { Material, BomItem, Project } from "@/types";
 
@@ -62,6 +63,8 @@ export default function ProjectPage() {
   const projectId = params.id as string;
   const { toast } = useToast();
   const { t, locale } = useTranslation();
+  const { track } = useAnalytics();
+  const { markCodeEditor, markChat } = useEditorSession();
 
   const [project, setProject] = useState<Project | null>(null);
   const [materials, setMaterials] = useState<Material[]>([]);
@@ -277,10 +280,11 @@ export default function ProjectPage() {
 
   const handleApplyCode = useCallback(
     (code: string) => {
+      markChat();
       setSceneJs(code);
       pushHistory(code);
     },
-    [pushHistory]
+    [pushHistory, markChat]
   );
 
   /* ── Keyboard shortcuts ──────────────────────────────────────── */
@@ -360,6 +364,7 @@ export default function ProjectPage() {
       if (!mat) return;
       const pricing = mat.pricing?.find((p) => p.is_primary) || mat.pricing?.[0];
       bomChangedRef.current = true;
+      track("bom_item_added", { material_id: materialId, category: mat.category_name || "" });
       setBom((prev) => [
         ...prev,
         {
@@ -374,13 +379,14 @@ export default function ProjectPage() {
         },
       ]);
     },
-    [materials]
+    [materials, track]
   );
 
   const removeBomItem = useCallback((materialId: string) => {
     bomChangedRef.current = true;
+    track("bom_item_removed", { material_id: materialId });
     setBom((prev) => prev.filter((b) => b.material_id !== materialId));
-  }, []);
+  }, [track]);
 
   const updateBomQty = useCallback((materialId: string, qty: number) => {
     bomChangedRef.current = true;
@@ -490,6 +496,7 @@ export default function ProjectPage() {
                   onClick={async () => {
                     setShowExportMenu(false);
                     try {
+                      track("bom_exported", { format: "pdf" });
                       generateQuotePdf({ projectName, projectDescription: projectDesc, bom, locale });
                       toast(t('toast.bomExported'), "success");
                     } catch (err) {
@@ -509,6 +516,7 @@ export default function ProjectPage() {
                   onClick={async () => {
                     setShowExportMenu(false);
                     try {
+                      track("bom_exported", { format: "csv" });
                       await api.exportBOMCsv(projectId, projectName);
                       toast(t('toast.bomExported'), "success");
                     } catch (err) {
@@ -530,6 +538,7 @@ export default function ProjectPage() {
                   onClick={async () => {
                     setShowExportMenu(false);
                     try {
+                      track("bom_exported", { format: "json" });
                       const res = await api.exportBOM(projectId);
                       const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
                       const url = URL.createObjectURL(blob);
@@ -566,7 +575,7 @@ export default function ProjectPage() {
             <button
               className="viewport-toolbar-btn"
               data-active={showCode}
-              onClick={() => setShowCode(!showCode)}
+              onClick={() => { if (!showCode) markCodeEditor(); setShowCode(!showCode); }}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="16 18 22 12 16 6" />

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from "react";
 import dynamic from "next/dynamic";
 import { api } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
+import { useAnalytics } from "@/hooks/useAnalytics";
 import type { BuildingResult } from "@/types";
 
 const Viewport3D = dynamic(() => import("@/components/Viewport3D"), {
@@ -89,6 +90,7 @@ export default function AddressSearch({
   const [result, setResult] = useState<BuildingResult | null>(null);
   const [searched, setSearched] = useState(false);
   const { t, locale } = useTranslation();
+  const { track } = useAnalytics();
 
   const search = useCallback(async () => {
     if (!query.trim() || query.trim().length < 3) return;
@@ -97,11 +99,13 @@ export default function AddressSearch({
     try {
       const data = await api.getBuilding(query.trim());
       setResult(data);
+      track("address_search", { query_length: query.trim().length, had_result: true });
     } catch {
       setResult(null);
+      track("address_search", { query_length: query.trim().length, had_result: false });
     }
     setLoading(false);
-  }, [query]);
+  }, [query, track]);
 
   const buildingTypeLabels = BUILDING_TYPE_LABELS[locale] || BUILDING_TYPE_LABELS.fi;
   const materialLabels = MATERIAL_LABELS[locale] || MATERIAL_LABELS.fi;

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
+import { useAnalytics } from "@/hooks/useAnalytics";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import type { ChatMessage } from "@/types";
 
@@ -22,8 +23,10 @@ export default function ChatPanel({
   const [expanded, setExpanded] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const usedSuggestionRef = useRef(false);
   const { toast } = useToast();
   const { t } = useTranslation();
+  const { track } = useAnalytics();
 
   useEffect(() => {
     if (messagesEndRef.current) {
@@ -38,6 +41,7 @@ export default function ChatPanel({
   }, [messages, expanded]);
 
   function handleApplyClick(code: string) {
+    track("chat_code_applied", {} as Record<string, never>);
     if (skipConfirm) {
       onApplyCode(code);
       return;
@@ -54,6 +58,8 @@ export default function ChatPanel({
 
   async function send() {
     if (!input.trim() || loading) return;
+    track("chat_message_sent", { suggestion_used: usedSuggestionRef.current });
+    usedSuggestionRef.current = false;
     const userMsg: ChatMessage = { role: "user", content: input };
     const newMessages = [...messages, userMsg];
     setMessages(newMessages);
@@ -178,6 +184,7 @@ export default function ChatPanel({
               className="chat-suggestion-chip"
               onClick={() => {
                 setInput(suggestion);
+                usedSuggestionRef.current = true;
                 inputRef.current?.focus();
               }}
             >

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { useState, type ReactNode } from "react";
 import { api, setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
+import { useAnalytics } from "@/hooks/useAnalytics";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import type { BuildingResult } from "@/types";
@@ -24,6 +25,7 @@ export default function LoginForm({
   const [loading, setLoading] = useState(false);
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const { t } = useTranslation();
+  const { track } = useAnalytics();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -38,6 +40,7 @@ export default function LoginForm({
         ? await api.register(email, password, name)
         : await api.login(email, password);
       setToken(result.token);
+      track(isRegister ? "auth_register" : "auth_login", {} as Record<string, never>);
       onLogin();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('auth.loginFailed'));

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -5,6 +5,7 @@ import { api, setToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectCard } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
+import { useAnalytics } from "@/hooks/useAnalytics";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import ConfirmDialog from "@/components/ConfirmDialog";
@@ -32,6 +33,7 @@ export default function ProjectList({
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const { toast } = useToast();
   const { t, locale } = useTranslation();
+  const { track } = useAnalytics();
 
   useEffect(() => {
     let mounted = true;
@@ -56,6 +58,7 @@ export default function ProjectList({
     if (!newName.trim()) return;
     setCreating(true);
     try {
+      track("project_created", { source: "blank" });
       const p = await api.createProject({ name: newName });
       setProjects([p, ...projects]);
       setNewName("");
@@ -69,6 +72,7 @@ export default function ProjectList({
   async function createFromTemplate(tmpl: Template) {
     setCreating(true);
     try {
+      track("project_created", { source: "template" });
       const p = await api.createProject({
         name: tmpl.name,
         description: tmpl.description,

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -1,0 +1,155 @@
+"use client";
+
+/**
+ * Privacy-first analytics hook using Plausible Analytics.
+ *
+ * Plausible is GDPR-compliant by design: no cookies, no personal data,
+ * no consent banner required. All events are anonymous.
+ *
+ * The hook provides a thin `track()` wrapper so we can swap providers
+ * later without touching every component.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+// ── Event name literals ────────────────────────────────────────────
+export type AnalyticsEvent =
+  | "address_search"
+  | "project_created"
+  | "editor_session"
+  | "bom_item_added"
+  | "bom_item_removed"
+  | "bom_exported"
+  | "chat_message_sent"
+  | "chat_code_applied"
+  | "auth_register"
+  | "auth_login"
+  | "page_view";
+
+// ── Property maps per event ────────────────────────────────────────
+export interface AnalyticsEventProps {
+  address_search: { query_length: number; had_result: boolean };
+  project_created: { source: "address" | "template" | "blank"; building_type?: string };
+  editor_session: { duration_s: number; used_code_editor: boolean; used_chat: boolean };
+  bom_item_added: { material_id: string; category?: string };
+  bom_item_removed: { material_id: string };
+  bom_exported: { format: "pdf" | "csv" | "json" };
+  chat_message_sent: { suggestion_used: boolean };
+  chat_code_applied: Record<string, never>;
+  auth_register: Record<string, never>;
+  auth_login: Record<string, never>;
+  page_view: { path: string };
+}
+
+// ── Plausible global type (injected by their <script>) ─────────────
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { props?: Record<string, string | number | boolean> },
+    ) => void;
+  }
+}
+
+// ── The domain we report to — matches the Plausible site ID ────────
+const PLAUSIBLE_DOMAIN = "helscoop.fi";
+
+/**
+ * Whether analytics is enabled.
+ * Disabled during SSR, in dev (localhost), and when Plausible hasn't loaded.
+ * We still accept `track()` calls gracefully (they become no-ops).
+ */
+function isEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  // Disable in dev / localhost
+  if (
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1"
+  ) {
+    return false;
+  }
+  return typeof window.plausible === "function";
+}
+
+/**
+ * Low-level fire-and-forget event dispatch.
+ */
+function sendEvent(
+  name: string,
+  props?: Record<string, string | number | boolean>,
+) {
+  if (!isEnabled()) {
+    // In dev, log to console for debugging
+    if (
+      typeof window !== "undefined" &&
+      (window.location.hostname === "localhost" ||
+        window.location.hostname === "127.0.0.1")
+    ) {
+      // eslint-disable-next-line no-console
+      console.debug(`[analytics] ${name}`, props ?? "");
+    }
+    return;
+  }
+  window.plausible!(name, props ? { props } : undefined);
+}
+
+// ── Public hook ────────────────────────────────────────────────────
+
+export function useAnalytics() {
+  /**
+   * Track a typed analytics event.
+   *
+   * Usage:
+   *   const { track } = useAnalytics();
+   *   track("address_search", { query_length: 12, had_result: true });
+   */
+  const track = useCallback(
+    <E extends AnalyticsEvent>(
+      event: E,
+      props: AnalyticsEventProps[E],
+    ) => {
+      sendEvent(event, props as Record<string, string | number | boolean>);
+    },
+    [],
+  );
+
+  return { track };
+}
+
+/**
+ * Hook to track editor session duration.
+ * Call once per editor mount; it fires `editor_session` on unmount
+ * with the elapsed seconds.
+ */
+export function useEditorSession() {
+  const startRef = useRef(Date.now());
+  const usedCodeRef = useRef(false);
+  const usedChatRef = useRef(false);
+
+  const markCodeEditor = useCallback(() => {
+    usedCodeRef.current = true;
+  }, []);
+
+  const markChat = useCallback(() => {
+    usedChatRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    const start = startRef.current;
+    return () => {
+      const duration_s = Math.round((Date.now() - start) / 1000);
+      if (duration_s < 2) return; // skip bounces
+      sendEvent("editor_session", {
+        duration_s,
+        used_code_editor: usedCodeRef.current,
+        used_chat: usedChatRef.current,
+      });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { markCodeEditor, markChat };
+}
+
+// Re-export domain for the script tag
+export { PLAUSIBLE_DOMAIN };


### PR DESCRIPTION
## Summary
- Integrate Plausible Analytics (privacy-first, GDPR-compliant, no cookies) via script tag in layout.tsx
- Create typed `useAnalytics()` hook with `track()` function and `useEditorSession()` for duration tracking
- Instrument 10 core events across all key user flows: address search, project creation (address/template/blank), editor session duration, BOM add/remove/export (PDF/CSV/JSON), chat messages, code application, auth login/register
- Dev mode: events log to console.debug instead of sending to Plausible

## Test plan
- [ ] Verify Plausible script loads on production domain
- [ ] Check console.debug output in dev for each tracked event
- [ ] Confirm TypeScript compiles cleanly (`cd web && npx tsc --noEmit`)
- [ ] Verify no cookies are set (GDPR compliance)
- [ ] Test each event fires at the right moment

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)