### PR TITLE
Chat panel polish: shimmer loading, message grouping, prominent apply

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -876,13 +876,26 @@ select:focus {
   animation: chatMsgIn 0.25s ease-out both;
 }
 
+.chat-msg-grouped {
+  padding-top: 0;
+}
+
+.chat-msg-grouped.chat-msg-ai {
+  margin-top: -2px;
+}
+
+.chat-msg-avatar-spacer {
+  width: 28px;
+  flex-shrink: 0;
+}
+
 .chat-msg-user {
   justify-content: flex-end;
 }
 
 .chat-msg-user .chat-msg-content {
-  background: var(--amber-glow);
-  color: var(--amber);
+  background: rgba(229, 160, 75, 0.12);
+  color: var(--amber-light);
   border: 1px solid var(--amber-border);
   border-radius: 10px 10px 2px 10px;
 }
@@ -903,35 +916,78 @@ select:focus {
 }
 
 .chat-msg-avatar {
-  width: 22px;
-  height: 22px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
-  background: var(--amber-glow);
+  background: linear-gradient(135deg, rgba(229, 160, 75, 0.15), rgba(229, 160, 75, 0.08));
   color: var(--amber);
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
   margin-top: 2px;
+  transition: box-shadow 0.3s ease;
+}
+
+.chat-avatar-active {
+  box-shadow: 0 0 8px rgba(229, 160, 75, 0.2);
+}
+
+/* Shimmer loading bar replacing typing dots */
+.chat-shimmer-bar {
+  width: 60%;
+  height: 3px;
+  border-radius: 2px;
+  background: linear-gradient(90deg,
+    rgba(229, 160, 75, 0.1) 0%,
+    rgba(229, 160, 75, 0.4) 50%,
+    rgba(229, 160, 75, 0.1) 100%
+  );
+  background-size: 200% 100%;
+  animation: chatShimmer 1.5s ease-in-out infinite;
+  margin: 8px 0;
+}
+
+@keyframes chatShimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Full-width apply bar for code blocks */
+.chat-apply-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
 }
 
 .chat-apply-btn {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 4px;
-  margin-top: 4px;
-  padding: 3px 8px;
-  background: rgba(34, 197, 94, 0.1);
-  color: #22c55e;
-  border: 1px solid rgba(34, 197, 94, 0.2);
+  gap: 5px;
+  flex: 1;
+  justify-content: center;
+  padding: 6px 12px;
+  background: var(--amber);
+  color: var(--bg-primary);
+  border: none;
   border-radius: var(--radius-sm);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s;
 }
 .chat-apply-btn:hover {
-  background: rgba(34, 197, 94, 0.2);
+  background: var(--amber-light);
+  box-shadow: 0 0 12px rgba(229, 160, 75, 0.25);
+}
+
+.chat-apply-hint {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
 }
 
 .chat-input-bar {
@@ -945,9 +1001,18 @@ select:focus {
   transition: border-color 0.12s ease, box-shadow 0.12s ease;
 }
 
+.chat-input-bar-focused,
 .chat-input-bar:focus-within {
   border-color: var(--amber-border);
   box-shadow: 0 0 0 2px var(--amber-glow);
+  background: linear-gradient(var(--bg-tertiary), var(--bg-tertiary)) padding-box,
+              linear-gradient(90deg, var(--amber-border), transparent, var(--amber-border)) border-box;
+  animation: inputGlowSweep 2s ease-in-out infinite;
+}
+
+@keyframes inputGlowSweep {
+  0%, 100% { box-shadow: 0 0 0 2px var(--amber-glow); }
+  50% { box-shadow: 0 0 0 2px rgba(229, 160, 75, 0.15), 0 0 8px rgba(229, 160, 75, 0.08); }
 }
 .chat-embedded .chat-messages-area + .chat-input-bar,
 .chat-embedded .chat-expand-btn + .chat-input-bar {

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import type { ChatMessage } from "@/types";
+
+/** Check if two messages are from the same role and should be visually grouped */
+function shouldGroup(current: ChatMessage, prev: ChatMessage | undefined): boolean {
+  if (!prev) return false;
+  return current.role === prev.role;
+}
 
 export default function ChatPanel({
   sceneJs,
@@ -21,6 +27,7 @@ export default function ChatPanel({
   const [pendingCode, setPendingCode] = useState<string | null>(null);
   const [skipConfirm, setSkipConfirm] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const [inputFocused, setInputFocused] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const usedSuggestionRef = useRef(false);
@@ -84,6 +91,14 @@ export default function ChatPanel({
     return match ? match[1].trim() : null;
   }
 
+  /** Count scene.add calls in code to show preview hint */
+  const countSceneObjects = useMemo(() => {
+    return (code: string): number => {
+      const matches = code.match(/scene\.add\(/g);
+      return matches ? matches.length : 0;
+    };
+  }, []);
+
   return (
     <div className="chat-embedded">
       {/* Messages area - expands when there are messages */}
@@ -104,31 +119,42 @@ export default function ChatPanel({
               const textContent = msg.content
                 .replace(/```(?:javascript|js)?\n[\s\S]*?```/g, "")
                 .trim();
+              const grouped = shouldGroup(msg, messages[i - 1]);
 
               return (
                 <div
                   key={i}
-                  className={`chat-msg ${msg.role === "user" ? "chat-msg-user" : "chat-msg-ai"}`}
+                  className={`chat-msg ${msg.role === "user" ? "chat-msg-user" : "chat-msg-ai"}${grouped ? " chat-msg-grouped" : ""}`}
                 >
-                  {msg.role === "assistant" && (
-                    <div className="chat-msg-avatar">
-                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                        <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                  {msg.role === "assistant" && !grouped && (
+                    <div className={`chat-msg-avatar${loading && i === messages.length - 1 ? " chat-avatar-active" : ""}`}>
+                      {/* Nordic-inspired geometric house icon */}
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                        <polyline points="9 22 9 12 15 12 15 22" />
                       </svg>
                     </div>
+                  )}
+                  {msg.role === "assistant" && grouped && (
+                    <div className="chat-msg-avatar-spacer" />
                   )}
                   <div className="chat-msg-content">
                     {textContent && <span>{textContent}</span>}
                     {code && (
-                      <button
-                        className="chat-apply-btn"
-                        onClick={() => handleApplyClick(code)}
-                      >
-                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                          <polyline points="20 6 9 17 4 12" />
-                        </svg>
-                        {t('editor.applyToScene')}
-                      </button>
+                      <div className="chat-apply-bar">
+                        <button
+                          className="chat-apply-btn"
+                          onClick={() => handleApplyClick(code)}
+                        >
+                          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                            <polyline points="20 6 9 17 4 12" />
+                          </svg>
+                          {t('editor.applyToScene')}
+                        </button>
+                        <span className="chat-apply-hint">
+                          {countSceneObjects(code)} {countSceneObjects(code) === 1 ? "object" : "objects"}
+                        </span>
+                      </div>
                     )}
                   </div>
                 </div>
@@ -136,15 +162,14 @@ export default function ChatPanel({
             })}
             {loading && (
               <div className="chat-msg chat-msg-ai">
-                <div className="chat-msg-avatar">
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                <div className="chat-msg-avatar chat-avatar-active">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                    <polyline points="9 22 9 12 15 12 15 22" />
                   </svg>
                 </div>
                 <div className="chat-msg-content">
-                  <div className="typing-dots">
-                    <span /><span /><span />
-                  </div>
+                  <div className="chat-shimmer-bar" />
                 </div>
               </div>
             )}
@@ -195,9 +220,10 @@ export default function ChatPanel({
       )}
 
       {/* Input bar - always visible */}
-      <div className="chat-input-bar">
+      <div className={`chat-input-bar${inputFocused ? " chat-input-bar-focused" : ""}`}>
         <svg className="chat-input-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+          <polyline points="9 22 9 12 15 12 15 22" />
         </svg>
         <input
           ref={inputRef}
@@ -205,6 +231,8 @@ export default function ChatPanel({
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && send()}
+          onFocus={() => setInputFocused(true)}
+          onBlur={() => setInputFocused(false)}
           placeholder={messages.length === 0 ? t('editor.describeChange') : t('editor.describeChange')}
           disabled={loading}
         />


### PR DESCRIPTION
## Summary
- Replaces typing dots with thin amber shimmer bar for streaming state indicator
- Upgrades AI avatar to 28px with gradient background, active glow, and Nordic house icon
- Groups consecutive messages from same role (collapsed avatar, tighter spacing)
- Makes "Apply to Scene" a full-width amber primary button with object count hint
- Adds subtle glow sweep animation on input bar when focused

## Test plan
- [ ] Send a chat message and verify shimmer bar appears during AI response
- [ ] Send multiple messages and verify consecutive same-role messages are grouped
- [ ] Verify Apply to Scene button is full-width amber bar below code blocks
- [ ] Verify input bar shows glow animation on focus
- [ ] Run `cd web && npx tsc --noEmit` -- passes cleanly

Closes #180

Generated with [Claude Code](https://claude.com/claude-code)