### PR TITLE
Viewport right-click context menu with radial quick actions

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -808,6 +808,7 @@ export default function ProjectPage() {
                 onError={setSceneError}
                 onWarnings={setSceneWarnings}
                 captureRef={captureThumbRef}
+                onToggleWireframe={() => setWireframe(!wireframe)}
               />
             </ErrorBoundary>
           </div>

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -5,6 +5,7 @@ import * as THREE from "three";
 import { OrbitControls } from "three/addons/controls/OrbitControls.js";
 import { interpretScene, SceneObject } from "@/lib/scene-interpreter";
 import { useTranslation } from "@/components/LocaleProvider";
+import ViewportContextMenu, { type ContextMenuItem } from "@/components/ViewportContextMenu";
 
 interface Viewport3DProps {
   sceneJs: string;
@@ -13,6 +14,8 @@ interface Viewport3DProps {
   onError?: (error: string | null) => void;
   onWarnings?: (warnings: string[]) => void;
   captureRef?: React.MutableRefObject<(() => string | null) | null>;
+  /** Callback to toggle wireframe from context menu */
+  onToggleWireframe?: () => void;
 }
 
 interface CameraPreset {
@@ -229,6 +232,7 @@ export default function Viewport3D({
   onError,
   onWarnings,
   captureRef,
+  onToggleWireframe,
 }: Viewport3DProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
@@ -238,6 +242,8 @@ export default function Viewport3D({
   const objectGroupRef = useRef<THREE.Group | null>(null);
   const animFrameRef = useRef<number>(0);
   const lastValidSceneRef = useRef<string>(sceneJs);
+  const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const { t } = useTranslation();
 
   // Initialize Three.js scene
   useEffect(() => {
@@ -475,9 +481,113 @@ export default function Viewport3D({
     };
   }, [captureRef]);
 
+  // Right-click context menu handler
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+  }, []);
+
+  const closeContextMenu = useCallback(() => {
+    setContextMenuPos(null);
+  }, []);
+
+  // Screenshot handler for context menu
+  const handleScreenshot = useCallback(() => {
+    const renderer = rendererRef.current;
+    const scene = sceneRef.current;
+    const camera = cameraRef.current;
+    if (!renderer || !scene || !camera) return;
+    renderer.render(scene, camera);
+    const canvas = renderer.domElement;
+    const offscreen = document.createElement("canvas");
+    offscreen.width = canvas.width;
+    offscreen.height = canvas.height;
+    const ctx = offscreen.getContext("2d")!;
+    ctx.drawImage(canvas, 0, 0);
+    const fontSize = Math.max(12, Math.round(canvas.height * 0.018));
+    ctx.font = `${fontSize}px "SF Mono", "Fira Code", "Cascadia Code", monospace`;
+    ctx.fillStyle = "rgba(255,255,255,0.25)";
+    ctx.textAlign = "right";
+    ctx.textBaseline = "bottom";
+    ctx.fillText("helscoop.fi", canvas.width - fontSize, canvas.height - fontSize * 0.6);
+    const link = document.createElement("a");
+    link.download = "helscoop-screenshot.png";
+    link.href = offscreen.toDataURL("image/png");
+    link.click();
+  }, []);
+
+  // Build context menu items
+  const contextMenuItems: ContextMenuItem[] = [
+    {
+      id: "camera-front",
+      label: t("editor.cameraFront"),
+      icon: "M3 12h18M12 3v18",
+      onClick: () => {
+        const camera = cameraRef.current;
+        const controls = controlsRef.current;
+        if (camera && controls) animateCamera(camera, controls, [0, 2, 8], [0, 1.5, 0]);
+      },
+    },
+    {
+      id: "camera-side",
+      label: t("editor.cameraSide"),
+      icon: "M12 3v18M21 12H3",
+      onClick: () => {
+        const camera = cameraRef.current;
+        const controls = controlsRef.current;
+        if (camera && controls) animateCamera(camera, controls, [8, 2, 0], [0, 1.5, 0]);
+      },
+    },
+    {
+      id: "camera-top",
+      label: t("editor.cameraTop"),
+      icon: "M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9",
+      onClick: () => {
+        const camera = cameraRef.current;
+        const controls = controlsRef.current;
+        if (camera && controls) animateCamera(camera, controls, [0, 10, 0.01], [0, 0, 0]);
+      },
+    },
+    {
+      id: "camera-iso",
+      label: t("editor.cameraIso"),
+      icon: "M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+      onClick: () => {
+        const camera = cameraRef.current;
+        const controls = controlsRef.current;
+        if (camera && controls) animateCamera(camera, controls, [5, 4, 5], [0, 1.5, 0]);
+      },
+    },
+    {
+      id: "wireframe",
+      label: t("editor.wireframe"),
+      icon: "M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z",
+      active: wireframe,
+      onClick: () => { onToggleWireframe?.(); },
+    },
+    {
+      id: "screenshot",
+      label: t("editor.screenshot"),
+      icon: "M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2zM12 13a4 4 0 1 0 0-8 4 4 0 0 0 0 8z",
+      onClick: handleScreenshot,
+    },
+    {
+      id: "reset-camera",
+      label: t("editor.resetCamera"),
+      icon: "M1 4v6h6M23 20v-6h-6M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15",
+      onClick: () => {
+        const camera = cameraRef.current;
+        const controls = controlsRef.current;
+        if (camera && controls) animateCamera(camera, controls, [5, 4, 5], [0, 1.5, 0]);
+      },
+    },
+  ];
+
   return (
     <div
       ref={containerRef}
+      onContextMenu={handleContextMenu}
       style={{
         width: "100%",
         height: "100%",
@@ -493,6 +603,11 @@ export default function Viewport3D({
         controlsRef={controlsRef}
         rendererRef={rendererRef}
         sceneRef={sceneRef}
+      />
+      <ViewportContextMenu
+        items={contextMenuItems}
+        position={contextMenuPos}
+        onClose={closeContextMenu}
       />
     </div>
   );

--- a/web/src/components/ViewportContextMenu.tsx
+++ b/web/src/components/ViewportContextMenu.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface ContextMenuItem {
+  id: string;
+  label: string;
+  icon: string; // SVG path d attribute
+  onClick: () => void;
+  /** If true, show as active/toggled */
+  active?: boolean;
+}
+
+interface ViewportContextMenuProps {
+  items: ContextMenuItem[];
+  /** Position to open at (clientX, clientY) */
+  position: { x: number; y: number } | null;
+  onClose: () => void;
+}
+
+/** Radius of the radial menu ring in pixels */
+const RING_RADIUS = 72;
+/** Size of each action button */
+const BUTTON_SIZE = 40;
+
+export default function ViewportContextMenu({ items, position, onClose }: ViewportContextMenuProps) {
+  const [visible, setVisible] = useState(false);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (position) {
+      // Trigger enter animation
+      requestAnimationFrame(() => setVisible(true));
+    } else {
+      setVisible(false);
+    }
+  }, [position]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!position) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    window.addEventListener("mousedown", handleClick);
+    return () => {
+      window.removeEventListener("keydown", handleKey);
+      window.removeEventListener("mousedown", handleClick);
+    };
+  }, [position, onClose]);
+
+  if (!position) return null;
+
+  // Calculate adjusted position to keep menu in viewport
+  const menuSize = RING_RADIUS * 2 + BUTTON_SIZE + 20;
+  const halfMenu = menuSize / 2;
+  const adjustedX = Math.max(halfMenu, Math.min(window.innerWidth - halfMenu, position.x));
+  const adjustedY = Math.max(halfMenu, Math.min(window.innerHeight - halfMenu, position.y));
+
+  // Distribute items evenly in a circle
+  const angleStep = (2 * Math.PI) / items.length;
+  // Start from top (-PI/2) and go clockwise
+  const startAngle = -Math.PI / 2;
+
+  return (
+    <div
+      ref={menuRef}
+      style={{
+        position: "fixed",
+        left: adjustedX,
+        top: adjustedY,
+        zIndex: 10001,
+        pointerEvents: "auto",
+        transform: "translate(-50%, -50%)",
+      }}
+    >
+      {/* Center dot */}
+      <div
+        style={{
+          position: "absolute",
+          left: "50%",
+          top: "50%",
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: "var(--amber)",
+          transform: "translate(-50%, -50%)",
+          opacity: visible ? 0.6 : 0,
+          transition: "opacity 0.2s ease",
+        }}
+      />
+
+      {/* Radial items */}
+      {items.map((item, i) => {
+        const angle = startAngle + i * angleStep;
+        const x = Math.cos(angle) * RING_RADIUS;
+        const y = Math.sin(angle) * RING_RADIUS;
+        const isHovered = hoveredId === item.id;
+
+        return (
+          <div
+            key={item.id}
+            style={{
+              position: "absolute",
+              left: `calc(50% + ${x}px)`,
+              top: `calc(50% + ${y}px)`,
+              transform: visible
+                ? `translate(-50%, -50%) scale(1)`
+                : `translate(-50%, -50%) scale(0.3)`,
+              opacity: visible ? 1 : 0,
+              transition: `transform 0.25s cubic-bezier(0.16, 1, 0.3, 1) ${i * 30}ms, opacity 0.2s ease ${i * 30}ms`,
+            }}
+          >
+            <button
+              onClick={() => {
+                item.onClick();
+                onClose();
+              }}
+              onMouseEnter={() => setHoveredId(item.id)}
+              onMouseLeave={() => setHoveredId(null)}
+              style={{
+                width: BUTTON_SIZE,
+                height: BUTTON_SIZE,
+                borderRadius: "50%",
+                border: `1px solid ${item.active ? "var(--amber-border)" : "var(--border-strong)"}`,
+                background: item.active
+                  ? "var(--amber-glow)"
+                  : isHovered
+                  ? "var(--bg-hover)"
+                  : "var(--bg-elevated)",
+                color: item.active ? "var(--amber)" : isHovered ? "var(--text-primary)" : "var(--text-secondary)",
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: 0,
+                boxShadow: isHovered
+                  ? "0 4px 20px rgba(0,0,0,0.5), 0 0 0 1px var(--amber-border)"
+                  : "var(--shadow-md)",
+                backdropFilter: "blur(16px)",
+                transition: "all 0.15s ease",
+                transform: isHovered ? "scale(1.15)" : "scale(1)",
+              }}
+              title={item.label}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d={item.icon} />
+              </svg>
+            </button>
+            {/* Label tooltip */}
+            {isHovered && (
+              <div
+                style={{
+                  position: "absolute",
+                  left: "50%",
+                  top: y < 0 ? -8 : BUTTON_SIZE + 8,
+                  transform: "translateX(-50%)",
+                  whiteSpace: "nowrap",
+                  fontSize: 11,
+                  fontFamily: "var(--font-body)",
+                  fontWeight: 500,
+                  color: "var(--text-primary)",
+                  background: "var(--bg-elevated)",
+                  border: "1px solid var(--border-strong)",
+                  borderRadius: "var(--radius-sm)",
+                  padding: "4px 8px",
+                  boxShadow: "var(--shadow-md)",
+                  pointerEvents: "none",
+                  animation: "fadeIn 0.1s ease",
+                }}
+              >
+                {item.label}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a radial context menu that opens on right-click in the 3D viewport with camera presets (Front, Side, Top, Iso), wireframe toggle, screenshot capture, and camera reset
- Menu items are arranged in a circle with staggered scale-in animations, hover scaling, and tooltip labels
- Wireframe toggle shows active state with amber accent highlighting
- Menu closes on Escape, outside click, or after executing an action

## Test plan
- [ ] Right-click in the 3D viewport and confirm the radial menu appears at cursor position
- [ ] Click each camera preset button (Front, Side, Top, Iso) and verify camera animates smoothly
- [ ] Toggle wireframe from context menu and verify it syncs with the toolbar button state
- [ ] Click screenshot and verify PNG downloads with watermark
- [ ] Test edge cases: right-click near viewport edges (menu should stay within bounds)
- [ ] Press Escape or click outside to dismiss the menu
- [ ] Run `npx tsc --noEmit` -- passes clean

Closes #199

Generated with [Claude Code](https://claude.com/claude-code)