### PR TITLE
Bento grid feature showcase: modular card layout replacing flat feature grid

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1862,12 +1862,42 @@ select:focus {
   gap: 20px;
 }
 
-/* Feature highlights grid */
+/* Feature highlights grid (legacy) */
 .feature-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 24px;
 }
+
+/* Bento grid feature showcase */
+.bento-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto auto;
+  grid-template-areas:
+    "model ai bom"
+    "export export share";
+  gap: 16px;
+}
+
+.bento-card {
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bento-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-subtle);
+}
+
+.bento-model { grid-area: model; }
+.bento-ai { grid-area: ai; }
+.bento-bom { grid-area: bom; }
+.bento-export { grid-area: export; }
+.bento-share { grid-area: share; }
 
 /* Settings */
 .settings-card {
@@ -1987,6 +2017,21 @@ select:focus {
   .feature-grid {
     grid-template-columns: 1fr;
     gap: 16px;
+  }
+
+  .bento-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "model"
+      "ai"
+      "bom"
+      "export"
+      "share";
+    gap: 12px;
+  }
+
+  .bento-card {
+    padding: 18px;
   }
 
   .settings-card {

--- a/web/src/components/FeatureHighlights.tsx
+++ b/web/src/components/FeatureHighlights.tsx
@@ -2,47 +2,171 @@
 
 import { useTranslation } from "@/components/LocaleProvider";
 
+interface BentoCard {
+  icon: string;
+  title: string;
+  desc: string;
+  /** Grid area name */
+  area: string;
+  /** Accent color for icon background */
+  accent?: string;
+}
+
 export default function FeatureHighlights() {
   const { locale } = useTranslation();
-  const features = locale === 'fi' ? [
-    { icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16", title: "3D-malli osoitteesta", desc: "Syota kotiosoitteesi ja nae talosi kolmiulotteisena mallina hetkessa" },
-    { icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", title: "Muuta puhumalla", desc: "Kuvaile muutos suomeksi — \"lisaa terassi taakse\" — AI toteuttaa" },
-    { icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6", title: "Automaattinen materiaaliluettelo", desc: "Reaaliaikaiset hinnat K-Raudasta ja Sarokkaasta, suoraan projektiisi" },
-  ] : [
-    { icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16", title: "3D model from address", desc: "Enter your home address and see your house as a 3D model instantly" },
-    { icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", title: "Modify by chatting", desc: "Describe changes in plain language — \"add a terrace in the back\" — AI executes" },
-    { icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6", title: "Automatic bill of materials", desc: "Real-time prices from K-Rauta and Stark, directly in your project" },
-  ];
+
+  const cards: BentoCard[] = locale === "fi"
+    ? [
+        {
+          area: "model",
+          icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16",
+          title: "3D-malli osoitteesta",
+          desc: "Syota kotiosoitteesi ja nae talosi kolmiulotteisena mallina hetkessa. DVV:n ja MML:n virallinen rakennusdata.",
+          accent: "var(--amber)",
+        },
+        {
+          area: "ai",
+          icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z",
+          title: "Muuta puhumalla",
+          desc: "Kuvaile muutos suomeksi — \"lisaa terassi taakse\" — AI toteuttaa sen kohtauskoodiksi.",
+          accent: "var(--forest)",
+        },
+        {
+          area: "bom",
+          icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6",
+          title: "Automaattinen materiaaliluettelo",
+          desc: "Reaaliaikaiset hinnat K-Raudasta ja Sarokkaasta, suoraan projektiisi. Vertaile hintoja ja vie PDF.",
+          accent: "var(--amber-dim)",
+        },
+        {
+          area: "export",
+          icon: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6M16 13H8M16 17H8M10 9H8",
+          title: "PDF-kustannusarvio",
+          desc: "Ammattimainen kustannusarvio PDF:na yhdella napautuksella.",
+        },
+        {
+          area: "share",
+          icon: "M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8M16 6l-4-4-4 4M12 2v13",
+          title: "Jaa projekti",
+          desc: "Luo jakolinkki ja laheta suunnittelijalle tai puolisolle.",
+        },
+      ]
+    : [
+        {
+          area: "model",
+          icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16",
+          title: "3D model from address",
+          desc: "Enter your home address and see your house as a 3D model instantly. Official building data from DVV and MML.",
+          accent: "var(--amber)",
+        },
+        {
+          area: "ai",
+          icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z",
+          title: "Modify by chatting",
+          desc: "Describe changes in plain language — \"add a terrace in the back\" — AI writes the scene code.",
+          accent: "var(--forest)",
+        },
+        {
+          area: "bom",
+          icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6",
+          title: "Automatic bill of materials",
+          desc: "Real-time prices from K-Rauta and Stark, directly in your project. Compare prices and export to PDF.",
+          accent: "var(--amber-dim)",
+        },
+        {
+          area: "export",
+          icon: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6M16 13H8M16 17H8M10 9H8",
+          title: "PDF cost estimate",
+          desc: "Professional cost estimate as PDF with one click.",
+        },
+        {
+          area: "share",
+          icon: "M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8M16 6l-4-4-4 4M12 2v13",
+          title: "Share project",
+          desc: "Create a share link and send it to your designer or partner.",
+        },
+      ];
 
   return (
-    <section style={{
-      padding: "40px 24px",
-      borderBottom: "1px solid var(--border)",
-    }}>
-      <h2 className="sr-only">{locale === 'fi' ? 'Ominaisuudet' : 'Features'}</h2>
-      <div className="feature-grid" style={{
-        maxWidth: 960,
-        margin: "0 auto",
-      }}>
-        {features.map((f, i) => (
-          <div key={i} className="anim-up" style={{ animationDelay: `${i * 0.1}s`, textAlign: "center" }}>
-            <div style={{
-              width: 44,
-              height: 44,
-              borderRadius: 8,
-              background: "var(--bg-tertiary)",
-              border: "1px solid var(--border)",
-              display: "inline-flex",
-              alignItems: "center",
-              justifyContent: "center",
-              marginBottom: 14,
-            }}>
-              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--text-secondary)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" role="img" aria-label={f.title}>
-                <path d={f.icon} />
+    <section
+      style={{
+        padding: "48px 24px",
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
+      <h2 className="sr-only">
+        {locale === "fi" ? "Ominaisuudet" : "Features"}
+      </h2>
+      <div
+        className="bento-grid"
+        style={{
+          maxWidth: 960,
+          margin: "0 auto",
+        }}
+      >
+        {cards.map((card, i) => (
+          <div
+            key={card.area}
+            className={`bento-card anim-up bento-${card.area}`}
+            style={{
+              animationDelay: `${i * 0.08}s`,
+            }}
+          >
+            <div
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: 10,
+                background: card.accent
+                  ? `${card.accent}15`
+                  : "var(--bg-tertiary)",
+                border: `1px solid ${
+                  card.accent
+                    ? `${card.accent}25`
+                    : "var(--border)"
+                }`,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                marginBottom: 14,
+                flexShrink: 0,
+              }}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={card.accent || "var(--text-secondary)"}
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label={card.title}
+              >
+                <path d={card.icon} />
               </svg>
             </div>
-            <h3 style={{ fontSize: 14, fontWeight: 600, marginBottom: 6 }}>{f.title}</h3>
-            <p style={{ color: "var(--text-muted)", fontSize: 13, lineHeight: 1.5 }}>{f.desc}</p>
+            <h3
+              style={{
+                fontSize: 15,
+                fontWeight: 600,
+                marginBottom: 6,
+                color: "var(--text-primary)",
+              }}
+            >
+              {card.title}
+            </h3>
+            <p
+              style={{
+                color: "var(--text-muted)",
+                fontSize: 13,
+                lineHeight: 1.55,
+                margin: 0,
+              }}
+            >
+              {card.desc}
+            </p>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Replaces the flat 3-column feature grid with a bento-style asymmetric layout (3 cards top row, 2 spanning bottom row)
- Adds two new feature cards: PDF cost estimate and project sharing
- Each card has a contextual accent color on its icon (amber for 3D model, green for AI, etc.) with hover effects
- Responsive: collapses to single-column on mobile breakpoint
- Updated descriptions with more detail (DVV/MML data source mention, PDF export, share links)

## Test plan
- [ ] Verify the bento grid renders correctly on desktop (3+2 layout)
- [ ] Resize to mobile and verify single-column stack
- [ ] Check hover effects on each card (border highlight + shadow)
- [ ] Switch between fi/en and verify all card texts are translated
- [ ] Run `npx tsc --noEmit` -- passes clean

Closes #214

Generated with [Claude Code](https://claude.com/claude-code)