### PR TITLE
Landing page trust layer: partner logos, usage stats, and social proof

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1107,6 +1107,108 @@ select:focus {
   font-size: 10px;
 }
 
+/* Trust layer */
+.trust-layer {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.trust-partners {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.trust-partners-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.trust-logo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.trust-logo {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.trust-logo:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-strong);
+}
+
+.trust-stats-bar {
+  display: flex;
+  gap: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.trust-stat {
+  flex: 1;
+  text-align: center;
+  padding: 12px 8px;
+  background: var(--bg-tertiary);
+  border-right: 1px solid var(--border);
+}
+
+.trust-stat:last-child {
+  border-right: none;
+}
+
+.trust-stat-value {
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--amber);
+  letter-spacing: -0.02em;
+  display: block;
+}
+
+.trust-stat-label {
+  font-size: 9px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-top: 2px;
+  display: block;
+}
+
+.trust-proof {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: var(--forest-dim);
+  border: 1px solid rgba(74, 124, 89, 0.15);
+}
+
+.trust-proof-text {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
 .login-form-panel {
   display: flex;
   align-items: center;

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "@/components/LocaleProvider";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import TrustLayer from "@/components/TrustLayer";
 import type { BuildingResult } from "@/types";
 
 export default function LoginForm({
@@ -111,21 +112,12 @@ export default function LoginForm({
             ))}
           </div>
 
-          {/* Trust stats */}
-          <div className="anim-up delay-3 brand-stats">
-            {[
-              { value: "1 200+", label: t('brand.trustProducts') || "Products" },
-              { value: "6", label: t('brand.trustSuppliers') || "Suppliers" },
-              { value: "100%", label: t('brand.trustFree') || "Free" },
-            ].map((stat, i) => (
-              <div key={i} className="brand-stat">
-                <div className="brand-stat-value">{stat.value}</div>
-                <div className="brand-stat-label">{stat.label}</div>
-              </div>
-            ))}
+          {/* Trust layer: partner logos, stats, social proof */}
+          <div className="anim-up delay-3">
+            <TrustLayer />
           </div>
 
-          <div className="anim-up delay-3">
+          <div className="anim-up delay-3" style={{ marginTop: 16 }}>
             <div className="label-mono brand-tagline">
               {t('brand.tagline')}
             </div>

--- a/web/src/components/TrustLayer.tsx
+++ b/web/src/components/TrustLayer.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useTranslation } from "@/components/LocaleProvider";
+
+/** SVG text logos for partner/data source brands — no external images needed */
+const PARTNERS = [
+  { name: "K-Rauta", width: 70 },
+  { name: "Stark", width: 50 },
+  { name: "Ruukki", width: 55 },
+  { name: "DVV", width: 35 },
+  { name: "MML", width: 40 },
+  { name: "Sarokas", width: 60 },
+];
+
+export default function TrustLayer() {
+  const { locale } = useTranslation();
+
+  const stats = [
+    {
+      value: "1 200+",
+      label: locale === "fi" ? "Tuotetta" : "Products",
+    },
+    {
+      value: "6",
+      label: locale === "fi" ? "Toimittajaa" : "Suppliers",
+    },
+    {
+      value: "100%",
+      label: locale === "fi" ? "Ilmainen" : "Free",
+    },
+    {
+      value: "GDPR",
+      label: locale === "fi" ? "Tietosuoja" : "Compliant",
+    },
+  ];
+
+  return (
+    <div className="trust-layer">
+      {/* Partner logos */}
+      <div className="trust-partners">
+        <span className="trust-partners-label">
+          {locale === "fi" ? "TIETOLAHTEET JA TOIMITTAJAT" : "DATA SOURCES & SUPPLIERS"}
+        </span>
+        <div className="trust-logo-row">
+          {PARTNERS.map((p) => (
+            <span
+              key={p.name}
+              className="trust-logo"
+              style={{ minWidth: p.width }}
+            >
+              {p.name}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Stats bar */}
+      <div className="trust-stats-bar">
+        {stats.map((s, i) => (
+          <div key={i} className="trust-stat">
+            <span className="trust-stat-value">{s.value}</span>
+            <span className="trust-stat-label">{s.label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Social proof */}
+      <div className="trust-proof">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="var(--forest)"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ flexShrink: 0 }}
+        >
+          <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+        </svg>
+        <span className="trust-proof-text">
+          {locale === "fi"
+            ? "Virallinen rakennusdata DVV:lta ja MML:lta. Ei analytiikkaevasteita. Tietosi EU:ssa."
+            : "Official building data from DVV and MML. No analytics cookies. Your data stays in the EU."}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the simple stats bar on the landing page with a comprehensive trust layer component
- Partner/data source badges: K-Rauta, Stark, Ruukki, DVV, MML, Sarokas with hover effects
- Unified stats bar showing 1200+ products, 6 suppliers, 100% free, GDPR compliant
- Social proof banner with green shield icon: official data sources, no analytics cookies, EU data residency
- Full fi/en localization

## Test plan
- [ ] Verify partner logos render correctly on the landing page brand panel
- [ ] Check hover effects on partner badges (border highlight, text color change)
- [ ] Verify stats bar shows all 4 metrics with amber accent
- [ ] Verify social proof banner renders with green shield icon
- [ ] Switch language to English and verify all text is translated
- [ ] Test on mobile viewport width -- layout should stack naturally
- [ ] Run `npx tsc --noEmit` -- passes clean

Closes #181

Generated with [Claude Code](https://claude.com/claude-code)