### PR TITLE
Bento grid feature showcase: asymmetric layout with hero card

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2102,7 +2102,8 @@ select:focus {
 
 .feature-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 1fr 1fr;
   gap: 16px;
   max-width: 960px;
   margin: 0 auto;
@@ -2111,16 +2112,47 @@ select:focus {
 .feature-card {
   position: relative;
   padding: 28px 24px 24px;
-  border-radius: var(--radius-lg);
+  border-radius: 16px;
   border: 1px solid var(--border);
-  background: var(--bg-secondary);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  background: linear-gradient(135deg, var(--bg-tertiary), var(--bg-secondary));
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.feature-card--hero {
+  grid-row: 1 / 3;
+  padding: 32px;
+}
+
+.feature-card--hero .feature-card-icon {
+  width: 56px;
+  height: 56px;
+  margin-bottom: 20px;
+}
+
+.feature-card--hero .feature-card-icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+.feature-card--hero .feature-card-title {
+  font-size: 18px;
+  margin-bottom: 10px;
+}
+
+.feature-card--hero .feature-card-desc {
+  font-size: 14px;
+  line-height: 1.6;
 }
 
 .feature-card:hover {
   border-color: var(--amber-border);
   box-shadow: 0 0 24px rgba(229, 160, 75, 0.06), 0 4px 16px rgba(0,0,0,0.2);
-  transform: translateY(-2px);
+  transform: translateY(-4px) scale(1.02);
+}
+
+.feature-card:active {
+  transform: scale(0.98);
+  transition-duration: 0.1s;
 }
 
 .feature-card-step {
@@ -2168,6 +2200,20 @@ select:focus {
 /* Settings */
 .settings-card {
   padding: 24px 28px;
+}
+
+/* ========= TABLET (769-1199px) ========= */
+
+@media (max-width: 1199px) and (min-width: 769px) {
+  .feature-grid {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto;
+  }
+
+  .feature-card--hero {
+    grid-column: 1 / -1;
+    grid-row: auto;
+  }
 }
 
 /* ========= MOBILE (768px) ========= */
@@ -2287,6 +2333,10 @@ select:focus {
   .feature-grid {
     grid-template-columns: 1fr;
     gap: 16px;
+  }
+
+  .feature-card--hero {
+    grid-row: auto;
   }
 
   .landing-footer-inner {

--- a/web/src/components/FeatureHighlights.tsx
+++ b/web/src/components/FeatureHighlights.tsx
@@ -31,13 +31,13 @@ export default function FeatureHighlights() {
   const { ref: sectionRef, inView } = useInView(0.15);
 
   const features = locale === 'fi' ? [
-    { icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16", title: "3D-malli osoitteesta", desc: "Syota kotiosoitteesi ja nae talosi kolmiulotteisena mallina hetkessa" },
-    { icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", title: "Muuta puhumalla", desc: "Kuvaile muutos suomeksi — \"lisaa terassi taakse\" — AI toteuttaa" },
-    { icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6", title: "Automaattinen materiaaliluettelo", desc: "Reaaliaikaiset hinnat K-Raudasta ja Sarokkaasta, suoraan projektiisi" },
+    { icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16", title: "3D-malli osoitteesta", desc: "Syota kotiosoitteesi ja nae talosi kolmiulotteisena mallina hetkessa. Malli luodaan automaattisesti rakennustietorekisterin datan perusteella.", hero: true },
+    { icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", title: "Muuta puhumalla", desc: "Kuvaile muutos suomeksi — \"lisaa terassi taakse\" — AI toteuttaa", hero: false },
+    { icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6", title: "Automaattinen materiaaliluettelo", desc: "Reaaliaikaiset hinnat K-Raudasta ja Sarokkaasta, suoraan projektiisi", hero: false },
   ] : [
-    { icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16", title: "3D model from address", desc: "Enter your home address and see your house as a 3D model instantly" },
-    { icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", title: "Modify by chatting", desc: "Describe changes in plain language — \"add a terrace in the back\" — AI executes" },
-    { icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6", title: "Automatic bill of materials", desc: "Real-time prices from K-Rauta and Stark, directly in your project" },
+    { icon: "M3 21h18M9 8h1M9 12h1M5 21V5l7-3 7 3v16", title: "3D model from address", desc: "Enter your home address and see your house as a 3D model instantly. The model is generated automatically from building registry data.", hero: true },
+    { icon: "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z", title: "Modify by chatting", desc: "Describe changes in plain language — \"add a terrace in the back\" — AI executes", hero: false },
+    { icon: "M9 5H7a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-2M9 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2M9 5h6", title: "Automatic bill of materials", desc: "Real-time prices from K-Rauta and Stark, directly in your project", hero: false },
   ];
 
   return (
@@ -62,11 +62,11 @@ export default function FeatureHighlights() {
         {features.map((f, i) => (
           <div
             key={i}
-            className="feature-card"
+            className={`feature-card${f.hero ? ' feature-card--hero' : ''}`}
             style={{
               opacity: inView ? 1 : 0,
               transform: inView ? 'translateY(0)' : 'translateY(24px)',
-              transition: `opacity 0.5s ease ${0.15 + i * 0.12}s, transform 0.5s cubic-bezier(0.16, 1, 0.3, 1) ${0.15 + i * 0.12}s`,
+              transition: `opacity 0.5s ease ${f.hero ? 0.1 : 0.15 + i * 0.12}s, transform 0.5s cubic-bezier(0.16, 1, 0.3, 1) ${f.hero ? 0.1 : 0.15 + i * 0.12}s`,
             }}
           >
             <div className="feature-card-step">{String(i + 1).padStart(2, '0')}</div>


### PR DESCRIPTION
## Summary
- Replaces the flat 3-column feature grid with an asymmetric bento layout where the primary feature (3D model from address) gets a 2x2 hero card spanning two rows
- Hero card has larger padding, bigger icon, gradient background, and extended description text
- Enhanced hover micro-interactions: translateY(-4px) + scale(1.02) lift, plus active press feedback
- Responsive: tablet shows hero full-width above 2-col grid, mobile stacks single column
- Corner radius bumped to 16px for softer bento aesthetic matching modern SaaS patterns

## Test plan
- [ ] Verify desktop shows 2-column bento: hero card (2x2) left, two smaller cards stacked right
- [ ] Verify tablet (769-1199px) shows hero full-width, two cards below in 2-col
- [ ] Verify mobile (<768px) shows single column stack
- [ ] Hover over cards and verify lift + scale animation
- [ ] Click/tap cards and verify press feedback (scale 0.98)
- [ ] Verify scroll-reveal animations still work with stagger
- [ ] Run `npx tsc --noEmit` -- passes clean

Closes #214

Generated with [Claude Code](https://claude.com/claude-code)