### PR TITLE
Improve scrollbar styling: thin, rounded, amber hover

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -246,12 +246,22 @@
   color: var(--text-muted);
 }
 
+[data-theme="light"] * {
+  scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+}
+
 [data-theme="light"] ::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.12);
+  background: rgba(0, 0, 0, 0.1);
+  background-clip: padding-box;
+  border: 1px solid transparent;
+  border-radius: 99px;
 }
 
 [data-theme="light"] ::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(180, 83, 9, 0.25);
+  background-clip: padding-box;
+  border: 1px solid transparent;
+  border-radius: 99px;
 }
 
 /* 3D viewport stays dark */
@@ -292,10 +302,34 @@ body {
   color: var(--text-primary);
 }
 
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--bg-hover); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+/* Scrollbar — thin, rounded, amber hover */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  background-clip: padding-box;
+  border: 1px solid transparent;
+  border-radius: 99px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--amber-dim, rgba(229, 160, 75, 0.25));
+  background-clip: padding-box;
+  border: 1px solid transparent;
+  border-radius: 99px;
+}
 
 /* === Animations === */
 


### PR DESCRIPTION
## Summary
- Thin 6px scrollbars with pill-shaped (99px radius) thumbs and visual inset via `background-clip: padding-box`
- Default thumb uses subtle `rgba(255,255,255,0.08)`; hover transitions to amber accent (`var(--amber-dim)`)
- Firefox support via `scrollbar-width: thin` and `scrollbar-color`
- Light theme overrides with appropriate opacity-based dark colors and amber hover

Closes #272

## Test plan
- [ ] Verify scrollbar appearance in dark theme (thin, rounded, subtle default)
- [ ] Hover over scrollbar thumb and confirm amber accent
- [ ] Switch to light theme and verify light-appropriate colors
- [ ] Test in Firefox to confirm `scrollbar-width: thin` takes effect
- [ ] Check `.chat-messages-scroll` and `.editor-bom-panel` overflow areas inherit global styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)