### PR TITLE
Auto-resizing textarea for chat input

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1711,7 +1711,7 @@ select:focus {
 
 .chat-input-bar {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 8px;
   padding: 10px 14px;
   background: rgba(24, 24, 27, 0.55);
@@ -1753,8 +1753,12 @@ select:focus {
   background: transparent;
   color: var(--text-primary);
   font-size: 13px;
+  line-height: 1.4;
   outline: none;
   font-family: inherit;
+  resize: none;
+  max-height: 96px;
+  overflow-y: auto;
 }
 .chat-input::placeholder {
   color: var(--text-muted);

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { api } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
@@ -47,7 +47,7 @@ export default function ChatPanel({
   const [expanded, setExpanded] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const usedSuggestionRef = useRef(false);
   const { toast } = useToast();
   const { t } = useTranslation();
@@ -64,6 +64,17 @@ export default function ChatPanel({
       setExpanded(true);
     }
   }, [messages, expanded]);
+
+  const autoResizeTextarea = useCallback(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 96) + "px"; // ~4 lines max
+  }, []);
+
+  useEffect(() => {
+    autoResizeTextarea();
+  }, [input, autoResizeTextarea]);
 
   function handleApplyClick(code: string) {
     track("chat_code_applied", {} as Record<string, never>);
@@ -89,6 +100,7 @@ export default function ChatPanel({
     const newMessages = [...messages, userMsg];
     setMessages(newMessages);
     setInput("");
+    if (inputRef.current) inputRef.current.style.height = "auto";
     setLoading(true);
 
     try {
@@ -253,12 +265,21 @@ export default function ChatPanel({
           <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
           <polyline points="9 22 9 12 15 12 15 22" />
         </svg>
-        <input
+        <textarea
           ref={inputRef}
           className="chat-input"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && !e.shiftKey && send()}
+          rows={1}
+          onChange={(e) => {
+            setInput(e.target.value);
+            autoResizeTextarea();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send();
+            }
+          }}
           onFocus={() => setInputFocused(true)}
           onBlur={() => setInputFocused(false)}
           placeholder={messages.length === 0 ? t('editor.describeChange') : t('editor.describeChange')}


### PR DESCRIPTION
## Summary
- Replace single-line `<input>` with auto-resizing `<textarea>` in ChatPanel
- Starts at 1 row, expands up to ~4 lines (96px max) based on content
- Enter sends message, Shift+Enter inserts newline
- Textarea shrinks back when text is deleted
- CSS: `resize: none`, `align-items: flex-end` on input bar, smooth overflow

Closes #283

## Test plan
- [ ] Type a single line — input should look the same as before
- [ ] Type multiple lines — textarea should expand up to 4 lines
- [ ] Delete lines — textarea should shrink back
- [ ] Press Enter — message should send (no newline inserted)
- [ ] Press Shift+Enter — newline should be inserted
- [ ] After sending, textarea resets to 1-line height
- [ ] Test in dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)