### PR TITLE
Undo action for BOM item removal via toast

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -423,10 +423,30 @@ export default function ProjectPage() {
   );
 
   const removeBomItem = useCallback((materialId: string) => {
+    let removedItem: BomItem | undefined;
+    setBom((prev) => {
+      removedItem = prev.find((b) => b.material_id === materialId);
+      return prev.filter((b) => b.material_id !== materialId);
+    });
     bomChangedRef.current = true;
     track("bom_item_removed", { material_id: materialId });
-    setBom((prev) => prev.filter((b) => b.material_id !== materialId));
-  }, [track]);
+
+    // Show undo toast — if the user clicks "Undo" within 5s, re-add the item
+    if (removedItem) {
+      const item = removedItem;
+      toast(t("toast.materialRemoved"), "info", {
+        duration: 5000,
+        action: {
+          label: t("toast.undo"),
+          onClick: () => {
+            bomChangedRef.current = true;
+            track("bom_item_undo_remove", { material_id: materialId });
+            setBom((prev) => [...prev, item]);
+          },
+        },
+      });
+    }
+  }, [track, toast, t]);
 
   const updateBomQty = useCallback((materialId: string, qty: number) => {
     bomChangedRef.current = true;

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -19,6 +19,7 @@ export type AnalyticsEvent =
   | "editor_session"
   | "bom_item_added"
   | "bom_item_removed"
+  | "bom_item_undo_remove"
   | "bom_exported"
   | "chat_message_sent"
   | "chat_code_applied"
@@ -33,6 +34,7 @@ export interface AnalyticsEventProps {
   editor_session: { duration_s: number; used_code_editor: boolean; used_chat: boolean };
   bom_item_added: { material_id: string; category?: string };
   bom_item_removed: { material_id: string };
+  bom_item_undo_remove: { material_id: string };
   bom_exported: { format: "pdf" | "csv" | "json" };
   chat_message_sent: { suggestion_used: boolean };
   chat_code_applied: Record<string, never>;

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -129,6 +129,8 @@ const translations = {
       loadMaterialsFailed: 'Materiaalien lataus epaonnistui',
       loadSuppliersFailed: 'Toimittajien lataus epaonnistui',
       loadPricingFailed: 'Hintatietojen lataus epaonnistui',
+      materialRemoved: 'Materiaali poistettu',
+      undo: 'Kumoa',
     },
     editor: {
       scene: 'Kohtaus',
@@ -555,6 +557,8 @@ const translations = {
       loadMaterialsFailed: 'Failed to load materials',
       loadSuppliersFailed: 'Failed to load suppliers',
       loadPricingFailed: 'Failed to load pricing',
+      materialRemoved: 'Material removed',
+      undo: 'Undo',
     },
     editor: {
       scene: 'Scene',


### PR DESCRIPTION
## Summary
- When a user removes a BOM item, a toast notification with an "Undo" button now appears for 5 seconds
- Clicking "Undo" restores the removed item to the BOM list
- Added i18n keys for Finnish ("Materiaali poistettu" / "Kumoa") and English ("Material removed" / "Undo")
- Added `bom_item_undo_remove` analytics event for tracking undo usage

## Test plan
- [ ] Remove a BOM item and verify the toast appears with the "Undo" button
- [ ] Click "Undo" within 5 seconds and verify the item is restored
- [ ] Wait 5 seconds without clicking "Undo" and verify the toast auto-dismisses
- [ ] Verify the toast text renders correctly in both Finnish and English
- [ ] Verify `npx tsc --noEmit` passes cleanly

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)