### PR TITLE
Polish tooltip appearance: arrow indicator, max-width, and word-wrap

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3255,3 +3255,53 @@ select:focus {
   animation-duration: 0.25s;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 }
+
+/* ── Custom tooltips via data-tooltip attribute ─────────────────── */
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: var(--font-body);
+  font-weight: 500;
+  white-space: normal;
+  max-width: 220px;
+  word-wrap: break-word;
+  text-align: center;
+  line-height: 1.4;
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border-strong);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 10000;
+}
+
+[data-tooltip]::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: var(--bg-elevated);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 10000;
+}
+
+[data-tooltip]:hover::after,
+[data-tooltip]:hover::before {
+  opacity: 1;
+}

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -665,7 +665,7 @@ export default function ProjectPage() {
 
       {/* Header */}
       <div className="editor-header">
-        <button className="btn btn-ghost" onClick={() => router.push("/")} style={{ padding: "6px 10px" }} title={t('nav.back')} aria-label={t('nav.back')}>
+        <button className="btn btn-ghost" onClick={() => router.push("/")} style={{ padding: "6px 10px" }} data-tooltip={t('nav.back')} aria-label={t('nav.back')}>
           <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="15 18 9 12 15 6" />
           </svg>
@@ -691,7 +691,7 @@ export default function ProjectPage() {
             className="btn btn-ghost"
             onClick={undo}
             disabled={!canUndo}
-            title={t('editor.undoShortcut')}
+            data-tooltip={t('editor.undoShortcut')}
             aria-label={t('editor.undoShortcut')}
             style={{ padding: "5px 7px", opacity: canUndo ? 1 : 0.3 }}
           >
@@ -704,7 +704,7 @@ export default function ProjectPage() {
             className="btn btn-ghost"
             onClick={redo}
             disabled={!canRedo}
-            title={t('editor.redoShortcut')}
+            data-tooltip={t('editor.redoShortcut')}
             aria-label={t('editor.redoShortcut')}
             style={{ padding: "5px 7px", opacity: canRedo ? 1 : 0.3 }}
           >
@@ -715,7 +715,7 @@ export default function ProjectPage() {
           </button>
           <button
             className="btn btn-ghost"
-            title={t('project.copy')}
+            data-tooltip={t('project.copy')}
             onClick={async () => {
               try {
                 const dup = await api.duplicateProject(projectId);
@@ -735,7 +735,7 @@ export default function ProjectPage() {
           <div style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
           <button
             className="btn btn-ghost"
-            title={t('editor.share')}
+            data-tooltip={t('editor.share')}
             aria-label={t('editor.share')}
             onClick={async () => {
               if (!shareToken) {
@@ -766,7 +766,7 @@ export default function ProjectPage() {
             )}
           </button>
           <div style={{ position: "relative" }} data-tour="export-btn">
-            <button className="btn btn-ghost" title={t('editor.export')} aria-label={t('editor.export')} onClick={() => setShowExportMenu(v => !v)} style={{ padding: "5px 7px", display: "flex", alignItems: "center", gap: 4 }}>
+            <button className="btn btn-ghost" data-tooltip={t('editor.export')} aria-label={t('editor.export')} onClick={() => setShowExportMenu(v => !v)} style={{ padding: "5px 7px", display: "flex", alignItems: "center", gap: 4 }}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                 <polyline points="7 10 12 15 17 10" />

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -209,7 +209,7 @@ function CameraToolbar({
             className="viewport-cam-btn"
             data-active={i === activePreset}
             onClick={() => handlePreset(preset, i)}
-            title={t(preset.key)}
+            data-tooltip={t(preset.key)}
           >
             {t(preset.key)}
           </button>
@@ -218,7 +218,7 @@ function CameraToolbar({
           className="viewport-cam-btn"
           data-active={screenshotDataUrl !== null}
           onClick={handleScreenshot}
-          title={`${t("editor.screenshot")} (Cmd+Shift+S)`}
+          data-tooltip={`${t("editor.screenshot")} (Cmd+Shift+S)`}
         >
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" />


### PR DESCRIPTION
## Summary
- Add CSS-only custom tooltip system using `[data-tooltip]` attribute with `::after` (text) and `::before` (arrow caret) pseudo-elements
- Set `max-width: 220px` and `word-wrap: break-word` for long tooltip text, with dark bg/light text styling using design system CSS variables
- Convert all `title="..."` attributes to `data-tooltip="..."` in the editor header buttons (`page.tsx`) and viewport camera bar (`Viewport3D.tsx`) to replace native browser tooltips

Closes #288

## Test plan
- [ ] Hover over Back, Undo, Redo, Duplicate, Share, and Export buttons in the editor header and verify styled tooltips appear above with arrow indicator
- [ ] Hover over camera preset buttons and screenshot button in the 3D viewport bar and verify tooltips render correctly
- [ ] Confirm no native browser double-tooltip appears (no `title` attribute alongside `data-tooltip`)
- [ ] Toggle to light theme and verify tooltip styling adapts (uses CSS variables)
- [ ] Resize browser window and verify tooltips with long text wrap within 220px max-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)