### PR TITLE
Parametric control panel: @param sliders for scene scripts

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -355,6 +355,186 @@ body {
   border-radius: 99px;
 }
 
+/* === Scene Parameters Panel === */
+.scene-params-panel {
+  width: 260px;
+  flex-shrink: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: rgba(17, 17, 19, 0.72);
+  backdrop-filter: blur(20px) saturate(1.3);
+  border-left: 1px solid var(--border);
+  overflow: hidden;
+}
+
+.scene-params-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border);
+}
+
+.scene-params-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-muted);
+  background: var(--bg-hover);
+  padding: 1px 6px;
+  border-radius: 99px;
+  font-variant-numeric: tabular-nums;
+}
+
+.scene-params-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.scene-params-section {
+  border-bottom: 1px solid var(--border);
+}
+
+.scene-params-section:last-child {
+  border-bottom: none;
+}
+
+.scene-params-section-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--font-body);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.scene-params-section-toggle:hover {
+  color: var(--text-primary);
+}
+
+.scene-params-section-count {
+  margin-left: auto;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.scene-params-items {
+  padding: 0 14px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.scene-param-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.scene-param-label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.scene-param-label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scene-param-value {
+  width: 60px;
+  padding: 2px 4px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--amber);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  outline: none;
+  -moz-appearance: textfield;
+}
+
+.scene-param-value::-webkit-inner-spin-button,
+.scene-param-value::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+}
+
+.scene-param-value:focus {
+  border-color: var(--amber-border);
+}
+
+.scene-param-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  background: linear-gradient(
+    to right,
+    var(--amber-dim) 0%,
+    var(--amber-dim) var(--pct, 50%),
+    var(--bg-hover) var(--pct, 50%),
+    var(--bg-hover) 100%
+  );
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+}
+
+.scene-param-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--amber);
+  border: 2px solid var(--bg-primary);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.scene-param-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.3);
+}
+
+.scene-param-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--amber);
+  border: 2px solid var(--bg-primary);
+  cursor: pointer;
+}
+
+[data-theme="light"] .scene-params-panel {
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(20px) saturate(1.3);
+}
+
+[data-theme="light"] .scene-param-value {
+  background: var(--bg-tertiary);
+}
+
 /* === Animations === */
 
 @keyframes fadeUp {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -10,7 +10,9 @@ import { useTranslation } from "@/components/LocaleProvider";
 import SceneEditor from "@/components/SceneEditor";
 import BomPanel from "@/components/BomPanel";
 import ChatPanel from "@/components/ChatPanel";
+import SceneParamsPanel from "@/components/SceneParamsPanel";
 import SceneApiReference from "@/components/SceneApiReference";
+import { parseSceneParams, applyParamToScript } from "@/lib/scene-interpreter";
 import KeyboardShortcutsHelp from "@/components/KeyboardShortcutsHelp";
 import CommandPalette from "@/components/CommandPalette";
 import type { Command } from "@/components/CommandPalette";
@@ -115,6 +117,7 @@ export default function ProjectPage() {
   const [showBom, setShowBom] = useState(true);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
   const [showDocs, setShowDocs] = useState(false);
+  const [showParams, setShowParams] = useState(true);
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showShareDialog, setShowShareDialog] = useState(false);
@@ -313,6 +316,19 @@ export default function ProjectPage() {
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
   }, [bomWidth]);
+
+  const sceneParams = useMemo(() => parseSceneParams(sceneJs), [sceneJs]);
+
+  const handleParamChange = useCallback(
+    (name: string, value: number) => {
+      setSceneJs((prev) => {
+        const updated = applyParamToScript(prev, name, value);
+        pushHistory(updated);
+        return updated;
+      });
+    },
+    [pushHistory]
+  );
 
   const handleSceneChange = useCallback(
     (code: string) => {
@@ -921,6 +937,23 @@ export default function ProjectPage() {
               </svg>
               {t('editor.docs') || "Docs"}
             </button>
+            {sceneParams.length > 0 && (
+              <button
+                className="viewport-toolbar-btn"
+                data-active={showParams}
+                onClick={() => setShowParams(!showParams)}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="4" y1="21" x2="4" y2="14" />
+                  <line x1="4" y1="10" x2="4" y2="3" />
+                  <line x1="12" y1="21" x2="12" y2="12" />
+                  <line x1="12" y1="8" x2="12" y2="3" />
+                  <line x1="20" y1="21" x2="20" y2="16" />
+                  <line x1="20" y1="12" x2="20" y2="3" />
+                </svg>
+                Params
+              </button>
+            )}
             <div style={{ flex: 1 }} />
             <span className="viewport-status" data-error={!!sceneError}>
               {sceneError
@@ -1114,6 +1147,14 @@ export default function ProjectPage() {
             buildingInfo={project?.building_info ?? undefined}
           />
         </div>
+
+        {/* Scene parameters panel */}
+        {showParams && sceneParams.length > 0 && (
+          <SceneParamsPanel
+            params={sceneParams}
+            onParamChange={handleParamChange}
+          />
+        )}
 
         {/* Resize handle + BOM panel */}
         {showBom && (

--- a/web/src/components/SceneParamsPanel.tsx
+++ b/web/src/components/SceneParamsPanel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useCallback, useRef, useMemo } from "react";
+import type { SceneParam } from "@/lib/scene-interpreter";
+
+interface SceneParamsPanelProps {
+  params: SceneParam[];
+  onParamChange: (name: string, value: number) => void;
+}
+
+export default function SceneParamsPanel({
+  params,
+  onParamChange,
+}: SceneParamsPanelProps) {
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const debounceRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const sections = useMemo(() => {
+    const map = new Map<string, SceneParam[]>();
+    for (const p of params) {
+      const list = map.get(p.section) || [];
+      list.push(p);
+      map.set(p.section, list);
+    }
+    return map;
+  }, [params]);
+
+  const handleChange = useCallback(
+    (name: string, value: number) => {
+      if (debounceRefs.current[name]) clearTimeout(debounceRefs.current[name]);
+      debounceRefs.current[name] = setTimeout(() => {
+        onParamChange(name, value);
+      }, 60);
+    },
+    [onParamChange],
+  );
+
+  if (params.length === 0) return null;
+
+  return (
+    <div className="scene-params-panel">
+      <div className="scene-params-header">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="4" y1="21" x2="4" y2="14" />
+          <line x1="4" y1="10" x2="4" y2="3" />
+          <line x1="12" y1="21" x2="12" y2="12" />
+          <line x1="12" y1="8" x2="12" y2="3" />
+          <line x1="20" y1="21" x2="20" y2="16" />
+          <line x1="20" y1="12" x2="20" y2="3" />
+          <line x1="1" y1="14" x2="7" y2="14" />
+          <line x1="9" y1="8" x2="15" y2="8" />
+          <line x1="17" y1="16" x2="23" y2="16" />
+        </svg>
+        <span>Parameters</span>
+        <span className="scene-params-count">{params.length}</span>
+      </div>
+      <div className="scene-params-body">
+        {Array.from(sections.entries()).map(([section, sectionParams]) => (
+          <div key={section} className="scene-params-section">
+            <button
+              className="scene-params-section-toggle"
+              onClick={() =>
+                setCollapsed((prev) => ({
+                  ...prev,
+                  [section]: !prev[section],
+                }))
+              }
+            >
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                style={{
+                  transform: collapsed[section]
+                    ? "rotate(-90deg)"
+                    : "rotate(0deg)",
+                  transition: "transform 0.15s ease",
+                }}
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+              <span>{section}</span>
+              <span className="scene-params-section-count">
+                {sectionParams.length}
+              </span>
+            </button>
+            {!collapsed[section] && (
+              <div className="scene-params-items">
+                {sectionParams.map((p) => (
+                  <ParamSlider
+                    key={p.name}
+                    param={p}
+                    onChange={handleChange}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ParamSlider({
+  param,
+  onChange,
+}: {
+  param: SceneParam;
+  onChange: (name: string, value: number) => void;
+}) {
+  const [localValue, setLocalValue] = useState(param.value);
+
+  const handleInput = (val: number) => {
+    const clamped = Math.min(param.max, Math.max(param.min, val));
+    setLocalValue(clamped);
+    onChange(param.name, clamped);
+  };
+
+  const pct =
+    ((localValue - param.min) / (param.max - param.min)) * 100;
+
+  return (
+    <div className="scene-param-item">
+      <div className="scene-param-label-row">
+        <label className="scene-param-label">{param.label}</label>
+        <input
+          type="number"
+          className="scene-param-value"
+          value={localValue}
+          min={param.min}
+          max={param.max}
+          step={param.step}
+          onChange={(e) => handleInput(parseFloat(e.target.value) || param.min)}
+        />
+      </div>
+      <input
+        type="range"
+        className="scene-param-slider"
+        min={param.min}
+        max={param.max}
+        step={param.step}
+        value={localValue}
+        onChange={(e) => handleInput(parseFloat(e.target.value))}
+        style={
+          {
+            "--pct": `${pct}%`,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}

--- a/web/src/lib/scene-interpreter.ts
+++ b/web/src/lib/scene-interpreter.ts
@@ -366,6 +366,49 @@ function meshToSceneObject(
   };
 }
 
+export interface SceneParam {
+  name: string;
+  section: string;
+  label: string;
+  min: number;
+  max: number;
+  value: number;
+  step: number;
+}
+
+const PARAM_REGEX = /\/\/\s*@param\s+(\w+)\s+"([^"]+)"\s+(.+?)\s+\((\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)\)/;
+const VALUE_REGEX = (name: string) =>
+  new RegExp(`(?:const|let|var)\\s+${name}\\s*=\\s*(-?[\\d.]+)`);
+
+export function parseSceneParams(script: string): SceneParam[] {
+  const params: SceneParam[] = [];
+  const lines = script.split("\n");
+  for (const line of lines) {
+    const m = PARAM_REGEX.exec(line);
+    if (!m) continue;
+    const [, name, section, label, minStr, maxStr] = m;
+    const min = parseFloat(minStr);
+    const max = parseFloat(maxStr);
+    const valMatch = VALUE_REGEX(name).exec(script);
+    const value = valMatch ? parseFloat(valMatch[1]) : min;
+    const range = max - min;
+    const step = range <= 1 ? 1 : range <= 100 ? 1 : range <= 1000 ? 5 : 10;
+    params.push({ name, section, label, min, max, value, step });
+  }
+  return params;
+}
+
+export function applyParamToScript(
+  script: string,
+  paramName: string,
+  newValue: number
+): string {
+  const re = new RegExp(
+    `((?:const|let|var)\\s+${paramName}\\s*=\\s*)(-?[\\d.]+)`
+  );
+  return script.replace(re, `$1${newValue}`);
+}
+
 export function interpretScene(script: string): InterpreterResult {
   const warnings: string[] = [];
 


### PR DESCRIPTION
## Summary
- Parse `// @param name "Section" Label (min-max)` annotations from scene scripts
- Render interactive slider panel grouped by section (Dimensions, Roof, Doors, etc.)
- Real-time scene updates when sliders are adjusted (60ms debounce)
- Toolbar "Params" toggle button — only appears when scene has `@param` annotations
- Compatible with the coop demo's 34 parameters across 7 sections
- Dark and light theme support with amber-themed slider tracks

## New files
- `web/src/components/SceneParamsPanel.tsx` — the panel component
- `parseSceneParams()` and `applyParamToScript()` added to `web/src/lib/scene-interpreter.ts`

## Screenshot
The panel renders between the viewport and BOM panel with collapsible sections, range sliders with amber fill, and monospace numeric inputs.

## Test plan
- [ ] Load a project with `@param` annotations → verify Params button appears in toolbar
- [ ] Click Params button → panel toggles visibility
- [ ] Adjust a slider → verify 3D viewport updates in real-time
- [ ] Type a value in the numeric input → verify scene updates
- [ ] Collapse/expand sections → verify state persists
- [ ] Load a project WITHOUT `@param` annotations → verify no Params button or panel
- [ ] Test in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)