### PR TITLE
Add focus trap to share dialog modal

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -22,6 +22,7 @@ import { generateQuotePdf } from "@/lib/pdf";
 import { useTheme } from "@/components/ThemeProvider";
 import Link from "next/link";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { useAnalytics, useEditorSession } from "@/hooks/useAnalytics";
 import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
 import type { Material, BomItem, Project } from "@/types";
@@ -137,6 +138,7 @@ export default function ProjectPage() {
   const [viewportKey, setViewportKey] = useState(0);
   const [sceneWarnings, setSceneWarnings] = useState<string[]>([]);
   const viewportRef = useRef<HTMLDivElement>(null);
+  const shareDialogRef = useRef<HTMLDivElement>(null);
 
   const historyRef = useRef<string[]>([]);
   const historyIndexRef = useRef<number>(-1);
@@ -418,6 +420,9 @@ export default function ProjectPage() {
   ], [save, handleApplyCode, sceneJs, closeAllPanels, undo, redo]);
 
   useKeyboardShortcuts(shortcuts);
+
+  const closeShareDialog = useCallback(() => setShowShareDialog(false), []);
+  useFocusTrap(shareDialogRef, showShareDialog && !!shareToken, closeShareDialog);
 
   /* ── Command palette commands ───────────────────────────── */
   const paletteCommands = useMemo<Command[]>(() => {
@@ -1212,6 +1217,7 @@ export default function ProjectPage() {
             backdropFilter: "blur(4px)",
           }} />
           <div
+            ref={shareDialogRef}
             role="dialog"
             aria-modal="true"
             style={{

--- a/web/src/hooks/useFocusTrap.ts
+++ b/web/src/hooks/useFocusTrap.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+/**
+ * Trap keyboard focus within a container element while a dialog is open.
+ *
+ * - On mount, saves the previously-focused element and focuses the first
+ *   focusable child inside the container.
+ * - Tab / Shift+Tab cycle within the container's focusable elements.
+ * - Escape calls `onClose` and restores focus to the previously-focused element.
+ * - On unmount, restores focus to the previously-focused element.
+ */
+export function useFocusTrap(
+  containerRef: React.RefObject<HTMLElement | null>,
+  open: boolean,
+  onClose: () => void,
+) {
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Save the element that had focus before the dialog opened
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+
+    // Focus the first focusable element inside the container
+    const focusableElements = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    } else {
+      // If no focusable children, focus the container itself
+      container.focus();
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const focusable = container!.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        // Shift+Tab: if focus is on first element, wrap to last
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab: if focus is on last element, wrap to first
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+
+      // Restore focus to the previously-focused element
+      if (previousFocusRef.current && typeof previousFocusRef.current.focus === "function") {
+        previousFocusRef.current.focus();
+      }
+      previousFocusRef.current = null;
+    };
+  }, [open, containerRef, onClose]);
+}


### PR DESCRIPTION
Closes #264

## Summary
- Created a reusable `useFocusTrap` hook (`web/src/hooks/useFocusTrap.ts`) that traps keyboard focus within a container element
- Applied the focus trap to the share dialog in the project editor page
- On open: saves previously-focused element, focuses first focusable child inside the dialog
- Tab/Shift+Tab cycle through the dialog's focusable elements without escaping
- Escape closes the dialog and restores focus to the previously-focused element
- On unmount, focus is automatically restored

## Test plan
- [ ] Open a project, click Share to open the share dialog
- [ ] Press Tab repeatedly -- focus should cycle through the URL input, Copy button, Unshare button, and Close button without leaving the dialog
- [ ] Press Shift+Tab -- focus should cycle in reverse
- [ ] Press Escape -- dialog should close and focus should return to the Share button in the header
- [ ] Verify `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)