### PR TITLE
Replace raw x text with SVG close icon in PriceComparisonPopup

### DIFF
--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -552,9 +552,15 @@ function PriceComparisonPopup({
           </div>
           <button
             onClick={onClose}
-            style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", fontSize: 18, padding: "4px 8px", lineHeight: 1 }}
+            className="popup-close-btn"
+            style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: "4px 8px", lineHeight: 1, borderRadius: "var(--radius-sm)", transition: "color 0.15s ease, background 0.15s ease", display: "flex", alignItems: "center", justifyContent: "center" }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text-primary)"; e.currentTarget.style.background = "var(--bg-tertiary)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "none"; }}
           >
-            x
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
           </button>
         </div>
 


### PR DESCRIPTION
Closes #268

## Summary
- Replaced raw 'x' text in PriceComparisonPopup close button with a proper SVG close icon (two crossed lines, 14x14)
- Added hover styles with color transition and background highlight
- Matches existing icon patterns in the design system

## Test plan
- [ ] Open BOM panel, click price comparison on an item
- [ ] Verify the close button shows an SVG X icon, not raw text
- [ ] Hover over the close button — should highlight smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)