### PR TITLE
Add active-state color to chat send button when input has text

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1967,6 +1967,9 @@ select:focus {
   display: flex;
   align-items: center;
 }
+.chat-send-btn[data-ready="true"]:not(:disabled) {
+  color: var(--amber);
+}
 .chat-send-btn:hover:not(:disabled) {
   color: var(--amber);
 }

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -289,6 +289,7 @@ export default function ChatPanel({
           className="chat-send-btn"
           onClick={send}
           disabled={loading || !input.trim()}
+          data-ready={!!input.trim()}
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="22" y1="2" x2="11" y2="13" />


### PR DESCRIPTION
## Summary
- Adds `data-ready` attribute to the chat send button that reflects whether the text input is non-empty
- Adds CSS rule `.chat-send-btn[data-ready="true"]:not(:disabled)` to color the button `var(--amber)` when the user has typed text
- Provides visual "ready to send" feedback, especially important on touch devices where hover states don't exist

Closes #312

## Test plan
- [ ] Type text in the chat input and verify the send button turns amber
- [ ] Clear the input and verify the button returns to muted color
- [ ] Verify the button stays muted/disabled while a message is loading
- [ ] Test on a touch device to confirm the active-state color appears without hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)