### PR TITLE
Replace hardcoded hex colors with CSS variables

### DIFF
--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -192,7 +192,7 @@ export default function ConfirmDialog({
               ...(isDanger
                 ? {
                     background: "var(--danger)",
-                    color: "#fff",
+                    color: "var(--text-primary)",
                     border: "1px solid var(--danger)",
                   }
                 : {}),

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -46,7 +46,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
-            background: "#111113",
+            background: "var(--bg-secondary)",
             borderRadius: "var(--radius-md)",
           }}
         >
@@ -68,7 +68,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                 height="24"
                 viewBox="0 0 24 24"
                 fill="none"
-                stroke="#ef4444"
+                stroke="var(--danger)"
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
@@ -80,7 +80,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             </div>
             <h3
               style={{
-                color: "#fafafa",
+                color: "var(--text-primary)",
                 fontSize: 16,
                 fontWeight: 600,
                 marginBottom: 8,
@@ -90,7 +90,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             </h3>
             <p
               style={{
-                color: "#52525b",
+                color: "var(--text-muted)",
                 fontSize: 13,
                 lineHeight: 1.5,
                 marginBottom: 20,

--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -205,7 +205,7 @@ export default function SceneEditor({
             flexShrink: 0,
             overflow: "hidden",
             textAlign: "right",
-            color: "#3f3f46",
+            color: "var(--text-muted)",
             userSelect: "none",
             borderRight: "1px solid var(--border)",
             minWidth: 52,
@@ -216,7 +216,7 @@ export default function SceneEditor({
               key={i}
               style={{
                 height: "22.1px",
-                ...(i === cursorLine ? { color: "#71717a" } : {}),
+                ...(i === cursorLine ? { color: "var(--text-secondary)" } : {}),
               }}
             >
               {i + 1}

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -603,7 +603,7 @@ export default function Viewport3D({
         width: "100%",
         height: "100%",
         minHeight: 200,
-        background: "#111113",
+        background: "var(--bg-secondary)",
         borderRadius: "var(--radius-md)",
         overflow: "hidden",
         position: "relative",


### PR DESCRIPTION
## Summary
- Replace hardcoded hex color values (`#111113`, `#ef4444`, `#fafafa`, `#52525b`, `#3f3f46`, `#71717a`, `#fff`) with CSS custom properties (`--bg-secondary`, `--danger`, `--text-primary`, `--text-muted`, `--text-secondary`) in ErrorBoundary, SceneEditor, ConfirmDialog, and Viewport3D
- Ensures all four components respond correctly to light/dark theme changes

## Test plan
- [ ] Toggle between light and dark theme; verify ErrorBoundary fallback renders correctly in both
- [ ] Verify SceneEditor line numbers use appropriate theme colors
- [ ] Verify ConfirmDialog danger button text is readable in both themes
- [ ] Verify Viewport3D background matches theme

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)