### PR TITLE
Add disabled state to chat input during AI loading

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1975,6 +1975,17 @@ select:focus {
   cursor: default;
 }
 
+.chat-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  color: var(--text-muted);
+}
+
+.chat-input-bar-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
 .chat-suggestion-chip {
   padding: 5px 12px;
   border-radius: 20px;

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -260,7 +260,7 @@ export default function ChatPanel({
       )}
 
       {/* Input bar - always visible */}
-      <div className={`chat-input-bar${inputFocused ? " chat-input-bar-focused" : ""}`}>
+      <div className={`chat-input-bar${inputFocused ? " chat-input-bar-focused" : ""}${loading ? " chat-input-bar-disabled" : ""}`}>
         <svg className="chat-input-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
           <polyline points="9 22 9 12 15 12 15 22" />


### PR DESCRIPTION
## Summary
- Add `cursor: not-allowed` and `opacity: 0.5` to `.chat-input:disabled` so users see clear feedback when clicking the textarea during AI processing
- Add `.chat-input-bar-disabled` class with `opacity: 0.6` and `pointer-events: none` to dim the entire input bar while loading
- Apply the disabled class conditionally in ChatPanel when `loading === true`

## Test plan
- [ ] Send a chat message and verify the input bar dims and shows not-allowed cursor during AI response
- [ ] Verify the input bar returns to normal after response completes
- [ ] Verify the disabled state does not interfere with the focused glow animation

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)