### PR TITLE
Add truncation with tooltip to project name in editor header

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -590,7 +590,7 @@ body {
   font-size: 10px;
   font-weight: 500;
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -2058,9 +2058,13 @@ select:focus {
   color: var(--text-primary);
   flex: 1;
   min-width: 0;
+  max-width: calc(100vw - 600px);
   padding: 4px 8px;
   border-radius: var(--radius-sm);
   transition: background 0.15s ease;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .editor-header-name:hover {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -696,6 +696,7 @@ export default function ProjectPage() {
           className="editor-header-name"
           value={projectName}
           onChange={(e) => setProjectName(e.target.value)}
+          title={projectName}
         />
         <div className="editor-save-status" style={{
           color: saveStatus === "unsaved" ? "var(--warning, #e5c07b)" : saveStatus === "saving" ? "var(--accent)" : "var(--text-muted)",


### PR DESCRIPTION
Closes #315

## Summary
- Adds CSS text truncation (`text-overflow: ellipsis`, `overflow: hidden`, `white-space: nowrap`) to the `.editor-header-name` input so long project names don't break the header layout on narrow viewports
- Adds a responsive `max-width: calc(100vw - 600px)` so the name field shrinks gracefully as the viewport narrows, while using all available space on wider screens
- Adds a `title` attribute to the project name input so the full name is visible as a native tooltip on hover

## Test plan
- [ ] Open a project with a long name on a narrow viewport and verify the name truncates with ellipsis
- [ ] Hover over the truncated name and verify the full name appears as a tooltip
- [ ] Click/focus the input and verify inline editing still works correctly
- [ ] Resize the browser window and verify the truncation responds smoothly
- [ ] Verify the header layout does not break on mobile-width viewports

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>