### PR TITLE
Fix slider crash when param min equals max

### DIFF
--- a/web/src/components/SceneParamsPanel.tsx
+++ b/web/src/components/SceneParamsPanel.tsx
@@ -130,7 +130,9 @@ function ParamSlider({
   };
 
   const pct =
-    ((localValue - param.min) / (param.max - param.min)) * 100;
+    param.max === param.min
+      ? 100
+      : ((localValue - param.min) / (param.max - param.min)) * 100;
 
   return (
     <div className="scene-param-item">
@@ -153,6 +155,7 @@ function ParamSlider({
         max={param.max}
         step={param.step}
         value={localValue}
+        disabled={param.max === param.min}
         onChange={(e) => handleInput(parseFloat(e.target.value))}
         style={
           {


### PR DESCRIPTION
## Summary
- Guard against division by zero in `ParamSlider` when `param.max === param.min`, which produced `NaN` for the CSS `--pct` variable and crashed the slider
- Default `pct` to `100` when the range is zero
- Disable the range `<input>` when `min === max` since there is no meaningful range to slide

Closes #347

## Test plan
- [ ] Open a scene with a parameter where `min === max` and verify the slider renders without crashing
- [ ] Confirm the slider is visually disabled (greyed out / non-interactive)
- [ ] Verify normal sliders (min !== max) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)