### PR TITLE
Add aria-labels to BOM quantity input and increase touch target

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -805,7 +805,7 @@ body {
 
 .bom-item-qty-input {
   width: 56px;
-  padding: 4px 6px;
+  padding: 8px 6px;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -2689,6 +2689,11 @@ select:focus {
 
   .login-brand .heading-display {
     font-size: 32px;
+  }
+
+  .bom-item-qty-input {
+    padding: 10px 8px;
+    min-height: 44px;
   }
 }
 

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -842,6 +842,7 @@ function BomItemCard({
           onChange={(e) => handleQtyChange(e.target.value)}
           onBlur={handleQtyBlur}
           className="bom-item-qty-input"
+          aria-label={t('editor.quantityFor', { name: getLocalizedBomItemName(item, materials, locale) })}
         />
         <span className="bom-item-unit">
           {localizeUnit(item.unit, t)} x {Number(item.unit_price || 0).toFixed(2)}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -208,6 +208,7 @@ const translations = {
       dontAskAgain: 'Ala kysy uudelleen taman istunnon aikana',
       docs: 'Dokumentit',
       share: 'Jaa',
+      quantityFor: 'Maara: {{name}}',
     },
     share: {
       title: 'Jaa projekti',
@@ -672,6 +673,7 @@ const translations = {
       dontAskAgain: "Don't ask again this session",
       docs: 'Docs',
       share: 'Share',
+      quantityFor: 'Quantity for {{name}}',
     },
     share: {
       title: 'Share project',


### PR DESCRIPTION
## Summary
- Add `aria-label` to BOM quantity `<input>` using the localized material name for screen reader accessibility
- Add `editor.quantityFor` i18n key: Finnish `"Maara: {{name}}"`, English `"Quantity for {{name}}"`
- Increase default vertical padding from `4px 6px` to `8px 6px` (taller click target, ~34px)
- Add mobile media query (`max-width: 768px`) with `10px 8px` padding and `min-height: 44px` per WCAG 2.5.8

## Test plan
- [ ] Screen reader announces "Quantity for [material name]" when focusing the input
- [ ] Finnish locale uses "Maara: [nimi]"
- [ ] Input is visually taller than before on desktop
- [ ] Input meets 44px touch target on mobile viewport
- [ ] `cd web && npx tsc --noEmit` passes

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)