### PR TITLE
Extract inline error banner styles into reusable CSS class

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1108,6 +1108,17 @@ body {
   border-color: rgba(239, 68, 68, 0.2);
 }
 
+.inline-error-banner {
+  padding: 8px 12px;
+  margin-bottom: 8px;
+  background: var(--danger-dim);
+  border: 1px solid rgba(239, 68, 68, 0.15);
+  border-radius: var(--radius-sm);
+  color: var(--danger);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .input {
   width: 100%;
   padding: 10px 14px;

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -163,7 +163,7 @@ export default function AddressSearch({
                 </div>
               </div>
               {createError && (
-                <div style={{ padding: "8px 12px", marginBottom: 8, background: "rgba(220,50,50,0.1)", border: "1px solid rgba(220,50,50,0.3)", borderRadius: "var(--radius-sm)", color: "var(--danger)", fontSize: 12 }}>
+                <div className="inline-error-banner">
                   {t('search.createError')}
                 </div>
               )}
@@ -328,7 +328,7 @@ export default function AddressSearch({
               )}
 
               {createError && (
-                <div style={{ padding: "10px 14px", marginBottom: 10, background: "rgba(220,50,50,0.1)", border: "1px solid rgba(220,50,50,0.3)", borderRadius: "var(--radius-sm)", color: "var(--danger)", fontSize: 13 }}>
+                <div className="inline-error-banner">
                   {t('search.createError')}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Add `.inline-error-banner` reusable CSS class using design system variables (`--danger-dim`, `--danger`, `--radius-sm`) instead of hardcoded `rgba(220,50,50,...)` values
- Replace both inline-styled error banners in `AddressSearch.tsx` with the new class
- Fix inconsistent padding (`8px 12px` vs `10px 14px`) and font size (`12px` vs `13px`) between the two banners
- Correct color mismatch: inline `rgba(220,50,50)` did not match `--danger: #ef4444` (rgb 239,68,68)

## Test plan
- [ ] Error banner appears with correct styling when address creation fails
- [ ] Both error locations show identical, consistent styling
- [ ] Light theme: banner uses correct danger-dim background
- [ ] Class is available for reuse in other components
- [ ] `cd web && npx tsc --noEmit` passes

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)