### PR TITLE
Add smooth height transition to collapsible panel sections

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -440,6 +440,20 @@ body {
   color: var(--text-muted);
 }
 
+.scene-params-section-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.2s ease;
+}
+
+.scene-params-section-body[data-open="true"] {
+  grid-template-rows: 1fr;
+}
+
+.scene-params-section-body-inner {
+  overflow: hidden;
+}
+
 .scene-params-items {
   padding: 0 14px 8px;
   display: flex;

--- a/web/src/components/SceneParamsPanel.tsx
+++ b/web/src/components/SceneParamsPanel.tsx
@@ -96,17 +96,22 @@ export default function SceneParamsPanel({
                 {sectionParams.length}
               </span>
             </button>
-            {!collapsed[section] && (
-              <div className="scene-params-items">
-                {sectionParams.map((p) => (
-                  <ParamSlider
-                    key={p.name}
-                    param={p}
-                    onChange={handleChange}
-                  />
-                ))}
+            <div
+              className="scene-params-section-body"
+              data-open={!collapsed[section]}
+            >
+              <div className="scene-params-section-body-inner">
+                <div className="scene-params-items">
+                  {sectionParams.map((p) => (
+                    <ParamSlider
+                      key={p.name}
+                      param={p}
+                      onChange={handleChange}
+                    />
+                  ))}
+                </div>
               </div>
-            )}
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Replace conditional rendering (`{open && <div>...}`) in `SceneParamsPanel` with a CSS `grid-template-rows: 0fr/1fr` transition pattern
- Section bodies now animate smoothly over 0.2s when expanding/collapsing instead of popping in/out instantly
- Chevron rotation animation (already present) now pairs with the content transition for a polished feel

## Changes
- **`web/src/components/SceneParamsPanel.tsx`** -- wrap section content in `.scene-params-section-body` (grid container) and `.scene-params-section-body-inner` (overflow wrapper), driven by `data-open` attribute
- **`web/src/app/globals.css`** -- add three new CSS rules for the grid transition

## Test plan
- [ ] Open the scene params panel with multiple sections
- [ ] Click section toggles and verify content slides open/closed smoothly
- [ ] Verify chevron rotation still animates in sync
- [ ] Check both dark and light themes
- [ ] Confirm no layout shift or overflow issues with long parameter lists

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)