### PR TITLE
Add focus-visible styles to viewport camera buttons and scene param controls

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2803,7 +2803,10 @@ select:focus {
 .lang-switch:focus-visible,
 .menu-item:focus-visible,
 .link-muted:focus-visible,
-.link-amber:focus-visible {
+.link-amber:focus-visible,
+.viewport-cam-btn:focus-visible,
+.viewport-toolbar-btn:focus-visible,
+.scene-params-section-toggle:focus-visible {
   outline: 2px solid var(--amber);
   outline-offset: 2px;
   box-shadow: 0 0 0 4px var(--amber-glow);
@@ -2811,6 +2814,19 @@ select:focus {
 
 .input:focus-visible {
   outline: none;
+}
+
+.scene-param-value:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 1px;
+  box-shadow: 0 0 0 4px var(--amber-glow);
+}
+
+.scene-param-slider:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 3px;
+  border-radius: 2px;
+  box-shadow: 0 0 0 4px var(--amber-glow);
 }
 
 .btn-ghost:focus-visible {


### PR DESCRIPTION
## Summary
- Added `:focus-visible` amber outline rings to `.viewport-cam-btn`, `.viewport-toolbar-btn`, and `.scene-params-section-toggle` by extending the existing focus-visible selector list
- Added dedicated `:focus-visible` rules for `.scene-param-value` (number inputs) and `.scene-param-slider` (range inputs) that override their `outline: none` base styles
- All focus rings use `var(--amber)` outline with `var(--amber-glow)` box-shadow, consistent with the existing accessibility styles and visible on dark backgrounds

## Test plan
- [ ] Tab through the viewport camera preset buttons (Front, Side, Top, etc.) and verify the amber focus ring appears
- [ ] Tab through the viewport toolbar buttons and verify focus ring
- [ ] Tab into the scene parameters panel, verify section toggle buttons show focus ring
- [ ] Tab to scene param number inputs and verify amber outline appears
- [ ] Tab to scene param slider controls and verify amber outline appears
- [ ] Verify focus rings are visible in both dark and light themes
- [ ] Verify mouse clicks do not trigger focus rings (`:focus-visible` only)

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)