### PR TITLE
Apply 44px touch target to BOM qty input on all viewports

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -812,7 +812,8 @@ body {
 
 .bom-item-qty-input {
   width: 56px;
-  padding: 8px 6px;
+  min-height: 44px;
+  padding: 10px 6px;
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -2716,7 +2717,6 @@ select:focus {
 
   .bom-item-qty-input {
     padding: 10px 8px;
-    min-height: 44px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Move `min-height: 44px` from the mobile-only media query to the base `.bom-item-qty-input` rule so the WCAG 2.5.8 touch target size requirement is satisfied on desktop and tablet, not just mobile
- Increase base vertical padding from `8px` to `10px` to complement the min-height

PR #369 added aria-labels and a mobile-only 44px touch target. This PR completes the fix by ensuring the touch target applies universally.

Closes #314

## Test plan
- [ ] Inspect `.bom-item-qty-input` in browser devtools on desktop -- confirm `min-height: 44px` is applied
- [ ] On mobile viewport (<768px), confirm padding is `10px 8px` (unchanged from #369)
- [ ] Verify BOM quantity inputs are still visually aligned within the card layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)