### PR TITLE
Add inline validation and character limit to project name input

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2108,6 +2108,37 @@ select:focus {
   box-shadow: 0 0 0 1px var(--amber-border);
 }
 
+.editor-header-name-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.editor-header-name-wrapper .editor-header-name {
+  flex: unset;
+  width: 100%;
+}
+
+.editor-header-name-count {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  pointer-events: none;
+  opacity: 0.7;
+  transition: color 0.15s ease, opacity 0.15s ease;
+}
+
+.editor-header-name-count[data-near-limit="true"] {
+  color: var(--warning, #e5c07b);
+  opacity: 1;
+}
+
 .editor-header-desc {
   font-size: 12px;
   color: var(--text-muted);

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -113,6 +113,7 @@ export default function ProjectPage() {
   const [lastSaved, setLastSaved] = useState<string | null>(null);
   const [loadError, setLoadError] = useState(false);
   const [projectName, setProjectName] = useState("");
+  const previousNameRef = useRef("");
   const [projectDesc, setProjectDesc] = useState("");
   const [showCode, setShowCode] = useState(false);
   const [showBom, setShowBom] = useState(true);
@@ -188,6 +189,7 @@ export default function ProjectPage() {
       .then(([proj, mats]) => {
         setProject(proj);
         setProjectName(proj.name);
+        previousNameRef.current = proj.name;
         setProjectDesc(proj.description || "");
         if (proj.share_token) setShareToken(proj.share_token);
         const initialScene = proj.scene_js || DEFAULT_SCENE;
@@ -693,12 +695,31 @@ export default function ProjectPage() {
           </svg>
         </button>
         <div style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
-        <input
-          className="editor-header-name"
-          value={projectName}
-          onChange={(e) => setProjectName(e.target.value)}
-          title={projectName}
-        />
+        <div className="editor-header-name-wrapper">
+          <input
+            className="editor-header-name"
+            value={projectName}
+            onChange={(e) => setProjectName(e.target.value)}
+            onBlur={() => {
+              const trimmed = projectName.trim();
+              if (trimmed.length === 0) {
+                setProjectName(previousNameRef.current);
+              } else {
+                previousNameRef.current = trimmed;
+              }
+            }}
+            maxLength={100}
+            title={projectName}
+          />
+          {projectName.length > 80 && (
+            <span
+              className="editor-header-name-count"
+              data-near-limit={projectName.length >= 95}
+            >
+              {projectName.length}/100
+            </span>
+          )}
+        </div>
         <div className="editor-save-status" style={{
           color: saveStatus === "unsaved" ? "var(--warning, #e5c07b)" : saveStatus === "saving" ? "var(--accent)" : "var(--text-muted)",
         }}>


### PR DESCRIPTION
## Summary
- Add `maxLength={100}` to the project name input to enforce a hard character limit
- Show a character count indicator (e.g. `85/100`) when the name exceeds 80 characters, with a warning highlight at 95+ characters
- Prevent empty project names: if the user clears the input and blurs away, it reverts to the last valid name
- Add supporting CSS for the `.editor-header-name-wrapper` and `.editor-header-name-count` elements

Closes #286

## Test plan
- [ ] Type a project name longer than 80 characters and verify the character count appears
- [ ] Type near 100 characters and verify the count turns warning-colored at 95+
- [ ] Verify the input stops accepting characters at 100
- [ ] Clear the project name completely, click elsewhere, and verify it reverts to the previous name
- [ ] Verify normal editing (short names) works without any visible counter
- [ ] Run `npx tsc --noEmit` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)