### PR TITLE
Add subtle noise texture overlay to dark backgrounds for depth

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -327,6 +327,30 @@ body {
   line-height: 1.5;
 }
 
+/* Subtle noise texture overlay for dark backgrounds — adds depth */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.03;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+}
+
+/* Disable noise overlay in light theme */
+[data-theme="light"] body::before {
+  display: none;
+}
+
+/* Disable noise overlay for users who prefer reduced motion/effects */
+@media (prefers-reduced-motion: reduce) {
+  body::before {
+    display: none;
+  }
+}
+
 ::selection {
   background: rgba(229, 160, 75, 0.2);
   color: var(--text-primary);


### PR DESCRIPTION
## Summary
- Adds a subtle SVG noise texture overlay (`body::before`) with 0.03 opacity to dark theme backgrounds, giving the flat `#09090b` surface visual depth and tactile character
- Uses an inline SVG data URI with `feTurbulence` fractal noise -- no external files needed
- Disabled in light theme (`[data-theme="light"]`) and for users with `prefers-reduced-motion: reduce`

## Test plan
- [ ] Verify the noise texture is barely visible on dark backgrounds (zoom in to confirm it's there)
- [ ] Toggle to light theme and confirm the overlay is hidden
- [ ] Test with `prefers-reduced-motion: reduce` in browser dev tools and confirm the overlay is hidden
- [ ] Confirm no interactive elements are blocked (overlay uses `pointer-events: none`)
- [ ] Check that text readability is unaffected

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)