### PR TITLE
Add component tests for OnboardingTour, ErrorBoundary, ConfirmDialog

### DIFF
--- a/web/src/__tests__/ConfirmDialog.test.tsx
+++ b/web/src/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ConfirmDialog from "@/components/ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  const defaultProps = {
+    open: true,
+    title: "Delete item",
+    message: "Are you sure you want to delete this?",
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ConfirmDialog {...defaultProps} open={false} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders title and message when open", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText("Delete item")).toBeDefined();
+    expect(
+      screen.getByText("Are you sure you want to delete this?")
+    ).toBeDefined();
+  });
+
+  it("renders default button labels", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    expect(screen.getByText("Confirm")).toBeDefined();
+    expect(screen.getByText("Cancel")).toBeDefined();
+  });
+
+  it("renders custom button labels", () => {
+    render(
+      <ConfirmDialog
+        {...defaultProps}
+        confirmText="Yes, delete"
+        cancelText="No, keep"
+      />
+    );
+    expect(screen.getByText("Yes, delete")).toBeDefined();
+    expect(screen.getByText("No, keep")).toBeDefined();
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText("Confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel button is clicked", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when clicking the backdrop", () => {
+    const onCancel = vi.fn();
+    const { container } = render(
+      <ConfirmDialog {...defaultProps} onCancel={onCancel} />
+    );
+    // The outermost fixed div acts as the backdrop click target
+    const backdrop = container.firstElementChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when Escape key is pressed", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("has role=dialog with accessible labels", () => {
+    render(<ConfirmDialog {...defaultProps} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeDefined();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe(
+      "confirm-dialog-title"
+    );
+    expect(dialog.getAttribute("aria-describedby")).toBe(
+      "confirm-dialog-message"
+    );
+  });
+
+  it("applies danger variant styling to confirm button", () => {
+    render(<ConfirmDialog {...defaultProps} variant="danger" />);
+    const confirmBtn = screen.getByText("Confirm");
+    expect(confirmBtn.className).toContain("btn-danger");
+  });
+
+  it("applies default variant styling to confirm button", () => {
+    render(<ConfirmDialog {...defaultProps} variant="default" />);
+    const confirmBtn = screen.getByText("Confirm");
+    expect(confirmBtn.className).toContain("btn-primary");
+  });
+});

--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+// A component that throws on demand
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test explosion");
+  }
+  return <div>Child content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    // Suppress React error boundary console noise in test output
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("renders children when there is no error", () => {
+    render(
+      <ErrorBoundary>
+        <div>Hello</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Hello")).toBeDefined();
+  });
+
+  it("renders default fallback UI when a child throws", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("3D Error")).toBeDefined();
+    expect(screen.getByText("Test explosion")).toBeDefined();
+    expect(screen.getByText("Reset")).toBeDefined();
+  });
+
+  it("renders custom fallback when provided", () => {
+    const fallback = ({ error, reset }: { error: Error; reset: () => void }) => (
+      <div>
+        <span>Custom error: {error.message}</span>
+        <button onClick={reset}>Retry</button>
+      </div>
+    );
+
+    render(
+      <ErrorBoundary fallback={fallback}>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Custom error: Test explosion")).toBeDefined();
+    expect(screen.getByText("Retry")).toBeDefined();
+  });
+
+  it("resets error state when Reset button is clicked (default fallback)", () => {
+    const onReset = vi.fn();
+
+    function Wrapper() {
+      return (
+        <ErrorBoundary onReset={onReset}>
+          <ThrowingChild shouldThrow={true} />
+        </ErrorBoundary>
+      );
+    }
+
+    render(<Wrapper />);
+    expect(screen.getByText("Test explosion")).toBeDefined();
+
+    // Click reset - onReset callback should fire
+    fireEvent.click(screen.getByText("Reset"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets error state when custom fallback reset is triggered", () => {
+    const onReset = vi.fn();
+    const fallback = ({ error, reset }: { error: Error; reset: () => void }) => (
+      <div>
+        <span>Broken: {error.message}</span>
+        <button onClick={reset}>Try Again</button>
+      </div>
+    );
+
+    render(
+      <ErrorBoundary fallback={fallback} onReset={onReset}>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Broken: Test explosion")).toBeDefined();
+    fireEvent.click(screen.getByText("Try Again"));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the error via console.error", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    // React itself and our componentDidCatch both call console.error
+    const ourCall = consoleSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" &&
+        call[0].includes("[ErrorBoundary] Caught error:")
+    );
+    expect(ourCall).toBeDefined();
+  });
+});

--- a/web/src/__tests__/OnboardingTour.test.tsx
+++ b/web/src/__tests__/OnboardingTour.test.tsx
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import OnboardingTour, {
+  WelcomeModal,
+  TourOverlay,
+  isOnboardingCompleted,
+  resetOnboarding,
+} from "@/components/OnboardingTour";
+
+// Mock the LocaleProvider's useTranslation hook
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      if (params) {
+        let result = key;
+        for (const [k, v] of Object.entries(params)) {
+          result += ` ${k}=${v}`;
+        }
+        return result;
+      }
+      return key;
+    },
+  }),
+}));
+
+// Mock the api module
+vi.mock("@/lib/api", () => ({
+  getToken: vi.fn(() => "fake-token"),
+}));
+
+// Retrieve the mock so we can control it per test
+import { getToken } from "@/lib/api";
+const mockedGetToken = vi.mocked(getToken);
+
+describe("WelcomeModal", () => {
+  it("renders welcome title and body", () => {
+    const onStart = vi.fn();
+    const onSkip = vi.fn();
+    render(<WelcomeModal onStart={onStart} onSkip={onSkip} />);
+    expect(screen.getByText("onboarding.welcomeTitle")).toBeDefined();
+    expect(screen.getByText("onboarding.welcomeBody")).toBeDefined();
+  });
+
+  it("renders start and skip buttons", () => {
+    const onStart = vi.fn();
+    const onSkip = vi.fn();
+    render(<WelcomeModal onStart={onStart} onSkip={onSkip} />);
+    expect(screen.getByText("onboarding.welcomeStart")).toBeDefined();
+    expect(screen.getByText("onboarding.welcomeSkip")).toBeDefined();
+  });
+
+  it("calls onStart when start button is clicked", () => {
+    const onStart = vi.fn();
+    const onSkip = vi.fn();
+    render(<WelcomeModal onStart={onStart} onSkip={onSkip} />);
+    fireEvent.click(screen.getByText("onboarding.welcomeStart"));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSkip when skip button is clicked", () => {
+    const onStart = vi.fn();
+    const onSkip = vi.fn();
+    render(<WelcomeModal onStart={onStart} onSkip={onSkip} />);
+    fireEvent.click(screen.getByText("onboarding.welcomeSkip"));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSkip when clicking the backdrop overlay", () => {
+    const onStart = vi.fn();
+    const onSkip = vi.fn();
+    const { container } = render(
+      <WelcomeModal onStart={onStart} onSkip={onSkip} />
+    );
+    // The outermost fixed div is the backdrop
+    const backdrop = container.firstElementChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("TourOverlay", () => {
+  beforeEach(() => {
+    // Set up DOM elements that match TOUR_STEPS selectors
+    const targets = [
+      { attr: "address-input", id: "t1" },
+      { attr: "viewport", id: "t2" },
+      { attr: "chat-toggle", id: "t3" },
+      { attr: "bom-panel", id: "t4" },
+      { attr: "export-btn", id: "t5" },
+    ];
+    for (const t of targets) {
+      const el = document.createElement("div");
+      el.setAttribute("data-tour", t.attr);
+      el.setAttribute("id", t.id);
+      // Give it a bounding rect
+      el.getBoundingClientRect = () => ({
+        top: 100,
+        left: 100,
+        width: 200,
+        height: 50,
+        right: 300,
+        bottom: 150,
+        x: 100,
+        y: 100,
+        toJSON: () => {},
+      });
+      document.body.appendChild(el);
+    }
+  });
+
+  afterEach(() => {
+    // Clean up tour target elements
+    document
+      .querySelectorAll("[data-tour]")
+      .forEach((el) => el.remove());
+  });
+
+  it("renders the first step", () => {
+    const onComplete = vi.fn();
+    render(<TourOverlay onComplete={onComplete} />);
+    // Should show step counter for step 1
+    expect(
+      screen.getByText("onboarding.stepOf current=1 total=5")
+    ).toBeDefined();
+    // Should show the content key for step 1
+    expect(screen.getByText("onboarding.stepAddress")).toBeDefined();
+  });
+
+  it("advances to the next step when Next is clicked", () => {
+    const onComplete = vi.fn();
+    render(<TourOverlay onComplete={onComplete} />);
+
+    // Click Next to go to step 2
+    fireEvent.click(screen.getByText("onboarding.next"));
+    expect(
+      screen.getByText("onboarding.stepOf current=2 total=5")
+    ).toBeDefined();
+    expect(screen.getByText("onboarding.stepViewport")).toBeDefined();
+  });
+
+  it("advances through all steps and completes", () => {
+    const onComplete = vi.fn();
+    render(<TourOverlay onComplete={onComplete} />);
+
+    // Steps 1-4: click Next
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByText("onboarding.next"));
+    }
+
+    // Step 5 (last): button should say "done"
+    expect(
+      screen.getByText("onboarding.stepOf current=5 total=5")
+    ).toBeDefined();
+    expect(screen.getByText("onboarding.done")).toBeDefined();
+
+    // Click Done to complete
+    fireEvent.click(screen.getByText("onboarding.done"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onComplete when Skip is clicked", () => {
+    const onComplete = vi.fn();
+    render(<TourOverlay onComplete={onComplete} />);
+    fireEvent.click(screen.getByText("onboarding.skip"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onComplete immediately when no tour elements exist", () => {
+    // Remove all tour target elements
+    document
+      .querySelectorAll("[data-tour]")
+      .forEach((el) => el.remove());
+
+    const onComplete = vi.fn();
+    render(<TourOverlay onComplete={onComplete} />);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("OnboardingTour", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedGetToken.mockReturnValue("fake-token");
+  });
+
+  it("renders nothing when onboarding is already completed", async () => {
+    localStorage.setItem("helscoop_onboarding_completed", "true");
+
+    const { container } = render(<OnboardingTour />);
+    // Wait for useEffect
+    await act(async () => {});
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when user has no token", async () => {
+    mockedGetToken.mockReturnValue(null);
+
+    const { container } = render(<OnboardingTour />);
+    await act(async () => {});
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows the welcome modal for first-time users", async () => {
+    mockedGetToken.mockReturnValue("fake-token");
+
+    render(<OnboardingTour />);
+    await act(async () => {});
+    expect(screen.getByText("onboarding.welcomeTitle")).toBeDefined();
+  });
+
+  it("transitions to tour when start is clicked", async () => {
+    mockedGetToken.mockReturnValue("fake-token");
+
+    // Add at least one tour target so TourOverlay doesn't immediately complete
+    const el = document.createElement("div");
+    el.setAttribute("data-tour", "address-input");
+    el.getBoundingClientRect = () => ({
+      top: 100,
+      left: 100,
+      width: 200,
+      height: 50,
+      right: 300,
+      bottom: 150,
+      x: 100,
+      y: 100,
+      toJSON: () => {},
+    });
+    document.body.appendChild(el);
+
+    render(<OnboardingTour />);
+    await act(async () => {});
+
+    // Click start tour
+    fireEvent.click(screen.getByText("onboarding.welcomeStart"));
+
+    // Should now show tour step content
+    expect(screen.getByText("onboarding.stepAddress")).toBeDefined();
+
+    el.remove();
+  });
+
+  it("marks onboarding complete when skip is clicked", async () => {
+    mockedGetToken.mockReturnValue("fake-token");
+
+    render(<OnboardingTour />);
+    await act(async () => {});
+
+    fireEvent.click(screen.getByText("onboarding.welcomeSkip"));
+    expect(localStorage.getItem("helscoop_onboarding_completed")).toBe("true");
+  });
+});
+
+describe("isOnboardingCompleted / resetOnboarding", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns false when not completed", () => {
+    expect(isOnboardingCompleted()).toBe(false);
+  });
+
+  it("returns true when completed", () => {
+    localStorage.setItem("helscoop_onboarding_completed", "true");
+    expect(isOnboardingCompleted()).toBe(true);
+  });
+
+  it("resets onboarding state", () => {
+    localStorage.setItem("helscoop_onboarding_completed", "true");
+    resetOnboarding();
+    expect(isOnboardingCompleted()).toBe(false);
+  });
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary
- Adds 35 vitest + @testing-library/react component tests across three new test files
- **ConfirmDialog** (11 tests): open/close rendering, confirm/cancel callbacks, backdrop click, Escape key, ARIA attributes, danger variant styling
- **ErrorBoundary** (6 tests): child rendering, default and custom fallback UI, reset callback, console.error logging
- **OnboardingTour** (18 tests): WelcomeModal rendering and callbacks, TourOverlay step advancement and completion, skip behavior, empty-steps edge case, localStorage persistence, token-gated display
- Configures `esbuild.jsx: "automatic"` in `vitest.config.ts` so TSX component tests work without explicit React imports

Closes #382

## Test plan
- [x] All 35 new tests pass (`npx vitest run`)
- [x] Existing tests unaffected (pre-existing scene-interpreter failures remain unchanged)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)