### PR TITLE
Replace hardcoded colors with CSS variables

### DIFF
--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -192,7 +192,7 @@ export default function ConfirmDialog({
               ...(isDanger
                 ? {
                     background: "var(--danger)",
-                    color: "#fff",
+                    color: "var(--text-primary)",
                     border: "1px solid var(--danger)",
                   }
                 : {}),

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -678,7 +678,7 @@ export default function Viewport3D({
         width: "100%",
         height: "100%",
         minHeight: 200,
-        background: "#111113",
+        background: "var(--bg-secondary)",
         borderRadius: "var(--radius-md)",
         overflow: "hidden",
         position: "relative",


### PR DESCRIPTION
## Summary
- Replace `color: "#fff"` with `color: "var(--text-primary)"` in ConfirmDialog danger button styling
- Replace `background: "#111113"` with `background: "var(--bg-secondary)"` in Viewport3D container
- Audited both files for other hardcoded colors; remaining hex values are Three.js WebGL internals (canvas gradients, lights, materials) which cannot use CSS variables

## Test plan
- [ ] Verify danger-variant ConfirmDialog button text is visible in both dark and light themes
- [ ] Verify Viewport3D container background matches the design system in both themes
- [ ] Run `npx tsc --noEmit` -- passes clean

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)