### PR TITLE
Fix a11y: i18n loading text, duplicate aria-label, share dialog name

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -760,6 +760,7 @@ export default function ProjectPage() {
           <button
             className="btn btn-ghost"
             data-tooltip={t('project.copy')}
+            aria-label={t('editor.duplicateProject')}
             disabled={duplicating}
             onClick={async () => {
               setDuplicating(true);
@@ -1253,6 +1254,7 @@ export default function ProjectPage() {
             ref={shareDialogRef}
             role="dialog"
             aria-modal="true"
+            aria-labelledby="share-dialog-title"
             style={{
               position: "relative",
               width: "100%",
@@ -1266,6 +1268,7 @@ export default function ProjectPage() {
             }}
           >
             <h2
+              id="share-dialog-title"
               className="heading-display"
               style={{ fontSize: 18, margin: "0 0 8px", color: "var(--text-primary)" }}
             >

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -7,13 +7,18 @@ import { useTranslation } from "@/components/LocaleProvider";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import type { BuildingResult } from "@/types";
 
+function Viewport3DLoading() {
+  const { t } = useTranslation();
+  return (
+    <div style={{ width: "100%", height: "100%", background: "var(--bg-secondary)", borderRadius: "var(--radius-md)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-muted)", fontSize: 13 }}>
+      {t('editor.loading3D')}
+    </div>
+  );
+}
+
 const Viewport3D = dynamic(() => import("@/components/Viewport3D"), {
   ssr: false,
-  loading: () => (
-    <div style={{ width: "100%", height: "100%", background: "var(--bg-secondary)", borderRadius: "var(--radius-md)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-muted)", fontSize: 13 }}>
-      Ladataan 3D...
-    </div>
-  ),
+  loading: () => <Viewport3DLoading />,
 });
 
 const BUILDING_TYPE_LABELS: Record<string, Record<string, string>> = {

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -210,6 +210,7 @@ const translations = {
       dontAskAgain: 'Ala kysy uudelleen taman istunnon aikana',
       docs: 'Dokumentit',
       share: 'Jaa',
+      duplicateProject: 'Kopioi projekti',
       quantityFor: 'Maara: {{name}}',
     },
     share: {
@@ -677,6 +678,7 @@ const translations = {
       dontAskAgain: "Don't ask again this session",
       docs: 'Docs',
       share: 'Share',
+      duplicateProject: 'Duplicate project',
       quantityFor: 'Quantity for {{name}}',
     },
     share: {


### PR DESCRIPTION
## Summary
- **#385**: Replace hardcoded Finnish string "Ladataan 3D..." in `AddressSearch.tsx` Viewport3D loading fallback with an i18n-aware component using `t('editor.loading3D')`, matching the pattern already used in the project editor page.
- **#387**: Add `aria-label={t('editor.duplicateProject')}` to the duplicate project button so screen readers announce its purpose. Added fi/en i18n keys.
- **#389**: Add `aria-labelledby="share-dialog-title"` to the share dialog and `id="share-dialog-title"` to its heading, giving the dialog an accessible name.

Closes #385, closes #387, closes #389

## Test plan
- [ ] Switch locale to English, open AddressSearch with slow network -- loading fallback should show "Loading 3D view..." instead of Finnish
- [ ] Switch locale to Finnish -- loading fallback should show "Ladataan 3D-nakyma..."
- [ ] Inspect duplicate project button with screen reader / axe DevTools -- should announce "Duplicate project" (en) or "Kopioi projekti" (fi)
- [ ] Open share dialog, inspect with accessibility tools -- dialog should have accessible name from heading
- [ ] Run `npx tsc --noEmit` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)