### PR TITLE
Fix CSS consistency: transitions and badge radius

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -47,6 +47,9 @@
   --success-muted: var(--forest-dim);
   --warning: #eab308;
   --shadow-sm: var(--shadow-subtle);
+
+  --transition-fast: 0.15s ease;
+  --transition-normal: 0.2s ease;
 }
 
 /* Light theme */
@@ -931,7 +934,7 @@ body::before {
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 3px;
-  transition: color 0.15s ease, text-decoration-color 0.15s ease;
+  transition: color var(--transition-fast), text-decoration-color var(--transition-fast);
 }
 .link-muted:hover {
   color: var(--amber);
@@ -947,7 +950,7 @@ body::before {
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 3px;
-  transition: color 0.15s ease, text-decoration-color 0.15s ease, opacity 0.15s ease;
+  transition: color var(--transition-fast), text-decoration-color var(--transition-fast), opacity var(--transition-fast);
 }
 .link-amber:hover {
   text-decoration-color: var(--amber-dim);
@@ -968,7 +971,7 @@ body::before {
   border-radius: var(--radius-sm);
   font-family: inherit;
   text-decoration: none;
-  transition: background 0.12s ease;
+  transition: background var(--transition-fast);
 }
 .menu-item:hover {
   background: var(--bg-tertiary);
@@ -1080,8 +1083,8 @@ body::before {
   font-weight: 500;
   letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease,
-              box-shadow 0.15s ease, opacity 0.15s ease,
+  transition: background var(--transition-fast), color var(--transition-fast), border-color var(--transition-fast),
+              box-shadow var(--transition-fast), opacity var(--transition-fast),
               transform 0.1s cubic-bezier(0.2, 0, 0, 1);
   outline: none;
   white-space: nowrap;
@@ -1951,7 +1954,7 @@ select:focus {
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
-  transition: all 0.15s;
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
 }
 .chat-apply-btn:hover {
   background: var(--amber-light);
@@ -2026,7 +2029,7 @@ select:focus {
   cursor: pointer;
   padding: 4px;
   border-radius: var(--radius-sm);
-  transition: all 0.15s;
+  transition: color var(--transition-fast), opacity var(--transition-fast);
   display: flex;
   align-items: center;
 }
@@ -2420,7 +2423,7 @@ select:focus {
   border-radius: 1px;
   opacity: 0;
   transform: scaleY(0.5);
-  transition: opacity 0.15s ease, transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: opacity var(--transition-fast), transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .card-interactive:hover {

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -628,7 +628,7 @@ function PriceComparisonPopup({
                               fontSize: 10,
                               fontWeight: 600,
                               padding: "2px 6px",
-                              borderRadius: "var(--radius-md)",
+                              borderRadius: "var(--radius-sm)",
                               background: trend.direction === "down" ? "rgba(74, 124, 89, 0.12)" : "rgba(239, 68, 68, 0.08)",
                               color: trend.direction === "down" ? "var(--success)" : "var(--danger)",
                               display: "inline-flex",


### PR DESCRIPTION
## Summary

- **#391**: Added `--transition-fast: 0.15s ease` and `--transition-normal: 0.2s ease` CSS custom properties to `:root` and applied them to `.btn`, `.link-muted`, `.link-amber`, `.menu-item`, and `.card-interactive` for consistent transition durations across interactive elements.
- **#392**: Changed trend badge `border-radius` in `BomPanel.tsx` from `--radius-md` (8px) to `--radius-sm` (6px) to match all other badges.
- **#395**: Replaced bare `transition: all 0.15s` on `.chat-apply-btn` and `.chat-send-btn` with specific property transitions using `ease` easing function.

Closes #391, closes #392, closes #395.

## Test plan

- [ ] Verify buttons, links, menu items, and card-interactives still animate smoothly on hover/focus
- [ ] Verify trend badge in BomPanel price comparison popup has 6px radius matching other badges
- [ ] Verify chat apply and send buttons transition only the relevant properties (no layout thrash from `all`)
- [ ] Check both dark and light themes for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)