### PR TITLE
Fix ConfirmDialog i18n: use translated default button labels

### DIFF
--- a/web/src/__tests__/ConfirmDialog.test.tsx
+++ b/web/src/__tests__/ConfirmDialog.test.tsx
@@ -2,6 +2,19 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import ConfirmDialog from "@/components/ConfirmDialog";
 
+// Mock the LocaleProvider's useTranslation hook
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "dialog.confirm": "Confirm",
+        "dialog.cancel": "Cancel",
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
 describe("ConfirmDialog", () => {
   const defaultProps = {
     open: true,
@@ -26,7 +39,7 @@ describe("ConfirmDialog", () => {
     ).toBeDefined();
   });
 
-  it("renders default button labels", () => {
+  it("renders default button labels from i18n", () => {
     render(<ConfirmDialog {...defaultProps} />);
     expect(screen.getByText("Confirm")).toBeDefined();
     expect(screen.getByText("Cancel")).toBeDefined();

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
 
 export interface ConfirmDialogProps {
   open: boolean;
@@ -17,12 +18,15 @@ export default function ConfirmDialog({
   open,
   title,
   message,
-  confirmText = "Confirm",
-  cancelText = "Cancel",
+  confirmText,
+  cancelText,
   variant = "default",
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
+  const { t } = useTranslation();
+  const resolvedConfirmText = confirmText ?? t("dialog.confirm");
+  const resolvedCancelText = cancelText ?? t("dialog.cancel");
   const dialogRef = useRef<HTMLDivElement>(null);
   const confirmBtnRef = useRef<HTMLButtonElement>(null);
   const cancelBtnRef = useRef<HTMLButtonElement>(null);
@@ -179,7 +183,7 @@ export default function ConfirmDialog({
             onClick={onCancel}
             style={{ padding: "10px 20px", fontSize: 13 }}
           >
-            {cancelText}
+            {resolvedCancelText}
           </button>
           <button
             ref={confirmBtnRef}
@@ -198,7 +202,7 @@ export default function ConfirmDialog({
                 : {}),
             }}
           >
-            {confirmText}
+            {resolvedConfirmText}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded English default prop values (`"Confirm"`, `"Cancel"`) in `ConfirmDialog` with translated strings via `useTranslation()` hook
- Uses existing `dialog.confirm` / `dialog.cancel` i18n keys (already present in both `fi` and `en` locales)
- Callers that pass explicit `confirmText`/`cancelText` props are unaffected (nullish coalescing preserves explicit values)
- Updated test suite with `useTranslation` mock to match new behavior

Closes #417

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Next.js production build passes (`npx next build`)
- [x] All 11 ConfirmDialog tests pass
- [ ] Manual: open a ConfirmDialog without explicit labels in Finnish locale -- should show "Vahvista" / "Peruuta"
- [ ] Manual: open a ConfirmDialog without explicit labels in English locale -- should show "Confirm" / "Cancel"
- [ ] Manual: verify callers that pass custom labels (ProjectList delete, Settings delete account, ChatPanel apply) still show their custom text

🤖 Generated with [Claude Code](https://claude.com/claude-code)