### PR TITLE
Add aria-labels to SceneParamsPanel sliders and inputs

### DIFF
--- a/web/src/components/SceneParamsPanel.tsx
+++ b/web/src/components/SceneParamsPanel.tsx
@@ -152,6 +152,7 @@ function ParamSlider({
           min={param.min}
           max={param.max}
           step={param.step}
+          aria-label={param.label}
           onChange={(e) => handleInput(parseFloat(e.target.value) || param.min)}
         />
       </div>
@@ -163,6 +164,10 @@ function ParamSlider({
         step={param.step}
         value={localValue}
         disabled={param.max === param.min}
+        aria-label={param.label}
+        aria-valuemin={param.min}
+        aria-valuemax={param.max}
+        aria-valuenow={localValue}
         onChange={(e) => handleInput(parseFloat(e.target.value))}
         style={
           {


### PR DESCRIPTION
## Summary
- Add `aria-label={param.label}` to the number input in the ParamSlider component
- Add `aria-label={param.label}`, `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` to the range slider input
- Improves screen reader accessibility for all parametric controls in the SceneParamsPanel

Closes #418

## Test plan
- [ ] Verify sliders and number inputs render correctly in the browser
- [ ] Use a screen reader (e.g., VoiceOver on macOS) to confirm each input announces its parameter label
- [ ] Verify range sliders announce their current value, min, and max
- [ ] Confirm no TypeScript errors: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)