### PR TITLE
Fix aria-labels, shadow tokens, and theme color (#421, #423, #431)

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1263,7 +1263,7 @@ export default function ProjectPage() {
               border: "1px solid var(--border-strong)",
               borderRadius: "var(--radius-lg)",
               padding: "28px 28px 24px",
-              boxShadow: "0 16px 48px rgba(0, 0, 0, 0.4)",
+              boxShadow: "var(--shadow-lg)",
               animation: "dialogSlideUp 0.25s cubic-bezier(0.16, 1, 0.3, 1) both",
             }}
           >

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -42,6 +42,8 @@ function DataSourcesSection({ label, sources }: { label: string; sources: string
     <div style={{ marginBottom: 12 }}>
       <button
         onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        aria-label={label}
         style={{
           background: "none",
           border: "none",
@@ -123,6 +125,7 @@ export default function AddressSearch({
           <input
             className="input"
             placeholder={t('search.placeholder')}
+            aria-label={t('search.placeholder')}
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);
@@ -135,6 +138,7 @@ export default function AddressSearch({
             className={`btn ${query.trim().length >= 3 ? "btn-primary" : "btn-ghost"}`}
             onClick={search}
             disabled={loading || query.trim().length < 3}
+            aria-label={t('search.searchButton')}
             style={{ padding: "12px 20px", fontSize: 13 }}
           >
             {loading ? t('search.searching') : t('search.searchButton')}
@@ -225,6 +229,7 @@ export default function AddressSearch({
           <input
             className="input"
             placeholder={t('search.placeholder')}
+            aria-label={t('search.placeholder')}
             value={query}
             onChange={(e) => {
               setQuery(e.target.value);
@@ -237,6 +242,7 @@ export default function AddressSearch({
             className={`btn ${query.trim().length >= 3 ? "btn-primary" : "btn-ghost"}`}
             onClick={search}
             disabled={loading || query.trim().length < 3}
+            aria-label={t('search.searchButton')}
             style={{ padding: "14px 28px", fontSize: 14 }}
           >
             {loading ? t('search.searching') : t('search.searchButton')}

--- a/web/src/components/ConnectionBanner.tsx
+++ b/web/src/components/ConnectionBanner.tsx
@@ -94,7 +94,7 @@ export default function ConnectionBanner() {
         zIndex: 9999,
         padding: "8px 16px",
         background: isReconnected ? "var(--forest)" : "var(--amber)",
-        color: isReconnected ? "#fff" : "var(--bg-primary)",
+        color: isReconnected ? "var(--text-primary)" : "var(--bg-primary)",
         fontSize: 13,
         fontWeight: 500,
         textAlign: "center",

--- a/web/src/components/KeyboardShortcutsHelp.tsx
+++ b/web/src/components/KeyboardShortcutsHelp.tsx
@@ -112,7 +112,7 @@ export default function KeyboardShortcutsHelp({
           border: "1px solid var(--border-strong)",
           borderRadius: "var(--radius-lg)",
           padding: "28px 28px 24px",
-          boxShadow: "0 16px 48px rgba(0, 0, 0, 0.4)",
+          boxShadow: "var(--shadow-lg)",
           animation: "dialogSlideUp 0.25s cubic-bezier(0.16, 1, 0.3, 1) both",
         }}
       >

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -63,7 +63,7 @@ export default function UserMenu({ userName }: { userName: string }) {
               minWidth: 180,
               padding: "6px",
               zIndex: 100,
-              boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
+              boxShadow: "var(--shadow-lg)",
             }}
           >
             <div


### PR DESCRIPTION
## Summary
- **#421**: Add `aria-label` attributes to all `<input>` and `<button>` elements in `AddressSearch.tsx` (both compact and full variants), plus `aria-expanded` on the data sources toggle
- **#423**: Replace 3 hardcoded `boxShadow` values with `var(--shadow-lg)` token in `KeyboardShortcutsHelp.tsx`, `UserMenu.tsx`, and `project/[id]/page.tsx` share dialog
- **#431**: Replace hardcoded `#fff` with `var(--text-primary)` in `ConnectionBanner.tsx` reconnected state for theme-aware rendering

## Test plan
- [ ] Verify AddressSearch inputs are announced correctly by screen readers (compact and full modes)
- [ ] Verify DataSourcesSection toggle button announces expanded/collapsed state
- [ ] Confirm shadow appearance is consistent across dialogs (KeyboardShortcutsHelp, UserMenu dropdown, share dialog)
- [ ] Test ConnectionBanner reconnected state text is visible in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)