### PR TITLE
Add focus-visible styles to button classes

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1816,6 +1816,11 @@ select:focus {
   padding: 4px;
 }
 
+.nav-hamburger:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
 .nav-mobile-menu {
   display: none;
   flex-direction: column;
@@ -1936,6 +1941,11 @@ select:focus {
   color: var(--text-primary);
 }
 
+.chat-collapse-btn:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+}
+
 .chat-expand-btn {
   display: flex;
   align-items: center;
@@ -1956,6 +1966,11 @@ select:focus {
 .chat-expand-btn:hover {
   color: var(--text-primary);
   background: var(--bg-hover);
+}
+
+.chat-expand-btn:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
 }
 
 .chat-msg {
@@ -2191,6 +2206,11 @@ select:focus {
 }
 .chat-suggestion-chip:active {
   transform: translateY(0);
+}
+
+.chat-suggestion-chip:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
 }
 
 .chat-skip-confirm {
@@ -3317,6 +3337,11 @@ select:focus {
 .api-ref-copy-btn:hover {
   color: var(--amber);
   background: var(--bg-hover);
+}
+
+.api-ref-copy-btn:focus-visible {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
 }
 
 .api-ref-materials {


### PR DESCRIPTION
## Summary
- Adds `:focus-visible` outline styles (`2px solid var(--amber)`, `outline-offset: 2px`) to 5 button classes that were missing them: `.api-ref-copy-btn`, `.chat-suggestion-chip`, `.chat-collapse-btn`, `.chat-expand-btn`, and `.nav-hamburger`
- `.viewport-toolbar-btn` already had a `:focus-visible` rule in a grouped selector (line ~3013), so no duplicate was added
- Each rule is placed right after the corresponding `:hover` block (or after the main class definition for `.nav-hamburger` which has no `:hover`)

Closes #457

## Test plan
- [ ] Tab through the UI and verify amber outline appears on each button when focused via keyboard
- [ ] Verify no outline appears on mouse click (focus-visible, not focus)
- [ ] Confirm `npx tsc --noEmit` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)