### PR TITLE
Fix ConfirmDialog danger button contrast ratio

### DIFF
--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -196,7 +196,7 @@ export default function ConfirmDialog({
               ...(isDanger
                 ? {
                     background: "var(--danger)",
-                    color: "var(--text-primary)",
+                    color: "#09090b",
                     border: "1px solid var(--danger)",
                   }
                 : {}),


### PR DESCRIPTION
Closes #465

Changes danger button text from `var(--text-primary)` (#fafafa) to `#09090b` for WCAG AA contrast on the red `var(--danger)` background. The previous contrast ratio was ~2.9:1; the fix brings it well above the 4.5:1 AA threshold.