### PR TITLE
Add empty project list onboarding state

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2512,6 +2512,66 @@ select:focus {
   font-size: 13px;
 }
 
+/* ── Empty onboarding card ─────────────────────── */
+.dash-empty-onboarding {
+  padding: 56px 32px 48px;
+  text-align: center;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--amber-border);
+  background: linear-gradient(
+    180deg,
+    var(--amber-glow) 0%,
+    var(--bg-secondary) 60%
+  );
+  box-shadow: 0 0 40px rgba(229, 160, 75, 0.06), var(--shadow-subtle);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.empty-onboarding-heading {
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  letter-spacing: -0.01em;
+}
+
+.empty-onboarding-subtitle {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0 0 28px;
+  max-width: 380px;
+}
+
+.empty-onboarding-search {
+  width: 100%;
+  max-width: 480px;
+  margin-bottom: 24px;
+}
+
+.empty-onboarding-divider {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  max-width: 320px;
+  margin-bottom: 20px;
+  color: var(--text-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.empty-onboarding-divider::before,
+.empty-onboarding-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-strong);
+}
+
 .dash-search-bar {
   display: flex;
   gap: 8px;

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { api, setToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectCard } from "@/components/Skeleton";
@@ -34,6 +34,7 @@ export default function ProjectList({
   const { toast } = useToast();
   const { t, locale } = useTranslation();
   const { track } = useAnalytics();
+  const templateRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let mounted = true;
@@ -248,6 +249,7 @@ export default function ProjectList({
           </div>
 
           {/* Template picker */}
+          <div ref={templateRef} />
           <TemplateGrid
             templates={templates}
             loading={loading}
@@ -273,25 +275,39 @@ export default function ProjectList({
             ))}
           </div>
         ) : projects.length === 0 ? (
-          <div className="anim-up delay-1 dash-empty">
+          <div className="anim-up delay-1 dash-empty-onboarding">
             <div className="empty-state-illustration">
-              <svg width="28" height="28" viewBox="0 0 32 32" fill="none" stroke="var(--amber)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                <rect x="4" y="12" width="24" height="16" rx="1" />
-                <polyline points="4,12 16,4 28,12" />
-                <line x1="13" y1="20" x2="19" y2="20" />
-                <line x1="16" y1="17" x2="16" y2="23" />
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+                <polyline points="9 22 9 12 15 12 15 22" />
               </svg>
             </div>
-            <div className="empty-state-title">{t('project.emptyTitle')}</div>
-            <div className="empty-state-hint">{t('project.emptyHint')}</div>
+            <h2 className="empty-onboarding-heading">{t('project.emptyOnboardingHeading')}</h2>
+            <p className="empty-onboarding-subtitle">{t('project.emptyOnboardingSubtitle')}</p>
+
+            {onCreateFromBuilding && (
+              <div className="empty-onboarding-search">
+                <AddressSearch onCreateProject={onCreateFromBuilding} compact />
+              </div>
+            )}
+
+            <div className="empty-onboarding-divider">
+              <span>{t('project.emptyOnboardingOr')}</span>
+            </div>
+
             <button
               className="empty-state-cta"
               onClick={() => {
-                const input = document.querySelector<HTMLInputElement>('.input[placeholder]');
-                if (input) input.focus();
+                templateRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
               }}
             >
-              {t('project.emptyCta')}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="3" y="3" width="7" height="7" />
+                <rect x="14" y="3" width="7" height="7" />
+                <rect x="14" y="14" width="7" height="7" />
+                <rect x="3" y="14" width="7" height="7" />
+              </svg>
+              {t('project.emptyOnboardingTemplate')}
             </button>
           </div>
         ) : (

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -104,6 +104,10 @@ const translations = {
       emptyTitle: 'Ei projekteja viela',
       emptyHint: 'Luo ensimmainen projektisi kirjoittamalla nimi yllaolevaan kenttaan tai valitsemalla valmis malli.',
       emptyCta: 'Luo ensimmainen projekti',
+      emptyOnboardingHeading: 'Aloita ensimmäinen projektisi',
+      emptyOnboardingSubtitle: 'Syötä osoitteesi ja näe talosi 3D-mallina',
+      emptyOnboardingOr: 'tai',
+      emptyOnboardingTemplate: 'Luo mallista',
       noSearchResultsCta: 'Tyhjenna haku',
     },
     toast: {
@@ -579,6 +583,10 @@ const translations = {
       emptyTitle: 'No projects yet',
       emptyHint: 'Create your first project by typing a name above or picking a template.',
       emptyCta: 'Create your first project',
+      emptyOnboardingHeading: 'Start your first project',
+      emptyOnboardingSubtitle: 'Enter your address to see your house in 3D',
+      emptyOnboardingOr: 'or',
+      emptyOnboardingTemplate: 'Create from template',
       noSearchResultsCta: 'Clear search',
     },
     toast: {


### PR DESCRIPTION
Closes #468

## Summary
- When users have no projects, shows a welcoming onboarding card instead of a bare empty state
- Card includes a Feather-style house icon, bilingual heading/subtitle (fi/en), inline AddressSearch component (compact variant), and a "Create from template" button that scrolls to the template picker
- Styled with amber glow gradient background matching the dark theme design system, using the existing `.anim-up` fade-in animation

## Changes
- `web/src/components/ProjectList.tsx` -- replaced minimal empty state with onboarding card containing AddressSearch CTA and template scroll button
- `web/src/lib/i18n.ts` -- added fi/en translation keys for onboarding heading, subtitle, divider, and template button
- `web/src/app/globals.css` -- added `.dash-empty-onboarding` card styles with amber gradient, heading/subtitle/search/divider classes

## Test plan
- [ ] Sign in with a fresh account (or delete all projects) and verify the onboarding card renders
- [ ] Verify the AddressSearch component appears and functions within the card
- [ ] Click "Create from template" / "Luo mallista" and verify it smoothly scrolls to the template section
- [ ] Toggle locale between fi/en and verify all strings update
- [ ] Verify light theme renders correctly (inherits design system variables)
- [ ] Create a project and verify the onboarding card disappears, replaced by the project grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)