### PR TITLE
Replace hardcoded rgba in Toast warning with CSS tokens

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -54,6 +54,8 @@
   --success: var(--forest);
   --success-muted: var(--forest-dim);
   --warning: #eab308;
+  --warning-dim: rgba(234, 179, 8, 0.1);
+  --warning-border: rgba(234, 179, 8, 0.2);
   --shadow-sm: var(--shadow-subtle);
 
   --transition-micro: 0.08s ease;
@@ -116,6 +118,8 @@
   --danger-dim: rgba(220, 38, 38, 0.06);
 
   --warning: #ca8a04;
+  --warning-dim: rgba(202, 138, 4, 0.08);
+  --warning-border: rgba(202, 138, 4, 0.2);
 
   --border: rgba(0, 0, 0, 0.06);
   --border-strong: rgba(0, 0, 0, 0.12);

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -48,9 +48,9 @@ const TYPE_STYLES: Record<ToastType, { bg: string; color: string; border: string
     icon: "M12 2v10M12 16v2",
   },
   warning: {
-    bg: "rgba(234, 179, 8, 0.1)",
+    bg: "var(--warning-dim)",
     color: "var(--warning)",
-    border: "rgba(234, 179, 8, 0.2)",
+    border: "var(--warning-border)",
     icon: "M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0zM12 9v4M12 17h.01",
   },
   progress: {


### PR DESCRIPTION
## Summary
- Added `--warning-dim` and `--warning-border` CSS custom properties to `globals.css` for both dark and light themes
- Replaced hardcoded `rgba(234, 179, 8, ...)` values in the Toast `warning` `TYPE_STYLES` entry with the new CSS variables, matching the pattern used by all other toast types

Closes #479

## Test plan
- [ ] Verify warning toasts render with correct background and border colors in dark theme
- [ ] Verify warning toasts render correctly in light theme
- [ ] Confirm no visual regression on success, error, info, and progress toast types

🤖 Generated with [Claude Code](https://claude.com/claude-code)