### PR TITLE
Add visible focus ring to BOM material search input

### DIFF
--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -1007,6 +1007,7 @@ export default function BomPanel({
   const [quickAddId, setQuickAddId] = useState<string | null>(null);
   const [quickAddQty, setQuickAddQty] = useState(1);
   const [focusedBomIndex, setFocusedBomIndex] = useState(-1);
+  const [searchFocused, setSearchFocused] = useState(false);
   const { t, locale } = useTranslation();
 
   // Navigate between BOM item rows
@@ -1292,16 +1293,19 @@ export default function BomPanel({
               type="text"
               value={materialSearch}
               onChange={(e) => setMaterialSearch(e.target.value)}
+              onFocus={() => setSearchFocused(true)}
+              onBlur={() => setSearchFocused(false)}
               placeholder={t('pricing.searchMaterials')}
               style={{
                 width: "100%",
                 padding: "7px 8px 7px 28px",
                 background: "var(--bg-tertiary)",
-                border: "1px solid var(--border)",
+                border: searchFocused ? "1px solid var(--amber)" : "1px solid var(--border)",
                 borderRadius: "var(--radius-sm)",
                 fontSize: 12,
                 color: "var(--text-primary)",
-                outline: "none",
+                outline: searchFocused ? "1px solid var(--amber)" : "none",
+                outlineOffset: "-1px",
               }}
             />
           </div>


### PR DESCRIPTION
## Summary
- Add visible amber focus ring to the material search input in `BomPanel.tsx` to satisfy WCAG 2.4.7 (Focus Visible)
- Replace bare `outline: "none"` with `onFocus`/`onBlur` handlers that toggle an amber border + outline when focused
- Uses `var(--amber)` to match the existing design system

## Test plan
- [ ] Tab to the material search input in the BOM panel and verify an amber focus ring appears
- [ ] Click into the search input and verify the amber border is visible
- [ ] Tab or click away and verify the focus ring disappears
- [ ] Verify no visual regression on the search input in its default (unfocused) state

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)