### PR TITLE
Fix PUT projects to preserve values when fields omitted

### DIFF
--- a/api/src/routes/projects.ts
+++ b/api/src/routes/projects.ts
@@ -69,7 +69,7 @@ router.put("/:id", async (req, res) => {
     return res.status(400).json({ error: "Project name must be 200 characters or fewer" });
   }
   const result = await query(
-    `UPDATE projects SET name=$1, description=$2, scene_js=$3, updated_at=now()
+    `UPDATE projects SET name=COALESCE($1, name), description=COALESCE($2, description), scene_js=COALESCE($3, scene_js), updated_at=now()
      WHERE id=$4 AND user_id=$5 RETURNING *`,
     [name?.trim(), description, scene_js, req.params.id, req.user!.id]
   );


### PR DESCRIPTION
## Summary
- Use `COALESCE($1, name)` semantics in the PUT `/projects/:id` UPDATE SQL so that omitted fields retain their current database values instead of being silently set to NULL.

Closes #489

## Test plan
- [ ] Send PUT `/projects/:id` with only `scene_js` -- verify `name` and `description` are unchanged
- [ ] Send PUT `/projects/:id` with all fields -- verify all fields update correctly
- [ ] Send PUT `/projects/:id` with empty body -- verify no fields are NULLed

🤖 Generated with [Claude Code](https://claude.com/claude-code)