### PR TITLE
Add project export as .helscoop JSON file

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -540,6 +540,48 @@ export default function ProjectPage() {
         },
       },
       {
+        id: "export-project",
+        labelKey: "commandPalette.exportProject",
+        labelSecondaryKey: "commandPalette.exportProjectEn",
+        icon: (
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+        ),
+        action: () => {
+          try {
+            track("project_exported", { format: "helscoop" });
+            const exportData = {
+              version: 1,
+              name: projectName,
+              description: projectDesc,
+              scene_js: sceneJs,
+              bom: bom.map((b) => ({
+                material_id: b.material_id,
+                material_name: b.material_name,
+                quantity: b.quantity,
+                unit: b.unit,
+                unit_price: b.unit_price,
+                total: b.total,
+              })),
+              exportedAt: new Date().toISOString(),
+            };
+            const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `${projectName.replace(/\s+/g, '_')}.helscoop`;
+            a.click();
+            URL.revokeObjectURL(url);
+            toast(t("toast.projectExported"), "success");
+          } catch (err) {
+            toast(err instanceof Error ? err.message : t("toast.projectExportFailed"), "error");
+          }
+        },
+      },
+      {
         id: "share-project",
         labelKey: "commandPalette.shareProject",
         labelSecondaryKey: "commandPalette.shareProjectEn",
@@ -947,6 +989,49 @@ export default function ProjectPage() {
                     <polyline points="16 3 16 8 21 8" />
                   </svg>
                   JSON
+                </button>
+                <div style={{ height: 1, background: "var(--border)", margin: "2px 8px" }} />
+                <button
+                  className="btn btn-ghost"
+                  onClick={() => {
+                    setShowExportMenu(false);
+                    try {
+                      track("project_exported", { format: "helscoop" });
+                      const exportData = {
+                        version: 1,
+                        name: projectName,
+                        description: projectDesc,
+                        scene_js: sceneJs,
+                        bom: bom.map((b) => ({
+                          material_id: b.material_id,
+                          material_name: b.material_name,
+                          quantity: b.quantity,
+                          unit: b.unit,
+                          unit_price: b.unit_price,
+                          total: b.total,
+                        })),
+                        exportedAt: new Date().toISOString(),
+                      };
+                      const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
+                      const url = URL.createObjectURL(blob);
+                      const a = document.createElement("a");
+                      a.href = url;
+                      a.download = `${projectName.replace(/\s+/g, '_')}.helscoop`;
+                      a.click();
+                      URL.revokeObjectURL(url);
+                      toast(t('toast.projectExported'), "success");
+                    } catch (err) {
+                      toast(err instanceof Error ? err.message : t('toast.projectExportFailed'), "error");
+                    }
+                  }}
+                  style={{ width: "100%", justifyContent: "flex-start", gap: 8, padding: "8px 12px", fontSize: 12, border: "none" }}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                    <polyline points="7 10 12 15 17 10" />
+                    <line x1="12" y1="15" x2="12" y2="3" />
+                  </svg>
+                  {t('editor.exportProject')}
                 </button>
               </div>
             )}

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -21,6 +21,7 @@ export type AnalyticsEvent =
   | "bom_item_removed"
   | "bom_item_undo_remove"
   | "bom_exported"
+  | "project_exported"
   | "chat_message_sent"
   | "chat_code_applied"
   | "auth_register"
@@ -36,6 +37,7 @@ export interface AnalyticsEventProps {
   bom_item_removed: { material_id: string };
   bom_item_undo_remove: { material_id: string };
   bom_exported: { format: "pdf" | "csv" | "json" };
+  project_exported: { format: "helscoop" };
   chat_message_sent: { suggestion_used: boolean };
   chat_code_applied: Record<string, never>;
   auth_register: Record<string, never>;

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -117,6 +117,8 @@ const translations = {
       templateCreated: 'Projekti luotu mallista',
       saved: 'Tallennettu',
       bomExported: 'BOM viety',
+      projectExported: 'Projekti viety .helscoop-tiedostona',
+      projectExportFailed: 'Projektin vienti epaonnistui',
       loadProjectsFailed: 'Projektien lataus epaonnistui',
       createProjectFailed: 'Projektin luonti epaonnistui',
       templateFailed: 'Mallin luonti epaonnistui',
@@ -236,6 +238,7 @@ const translations = {
       replaceAll: 'Korvaa kaikki',
       noMatches: 'Ei osumia',
       closeFindReplace: 'Sulje haku',
+      exportProject: 'Vie projekti (.helscoop)',
     },
     share: {
       title: 'Jaa projekti',
@@ -464,6 +467,8 @@ const translations = {
       saveEn: 'Save project',
       showDocs: 'Nayta/piilota dokumentit',
       showDocsEn: 'Show/hide docs',
+      exportProject: 'Vie projekti (.helscoop)',
+      exportProjectEn: 'Export project (.helscoop)',
     },
     validation: {
       unmatchedCloser: 'Sulkumerkilla {{char}} ei ole paria (rivi {{line}})',
@@ -609,6 +614,8 @@ const translations = {
       templateCreated: 'Created from template',
       saved: 'Saved',
       bomExported: 'BOM exported',
+      projectExported: 'Project exported as .helscoop file',
+      projectExportFailed: 'Project export failed',
       loadProjectsFailed: 'Failed to load projects',
       createProjectFailed: 'Failed to create project',
       templateFailed: 'Template creation failed',
@@ -728,6 +735,7 @@ const translations = {
       replaceAll: 'Replace all',
       noMatches: 'No matches',
       closeFindReplace: 'Close find',
+      exportProject: 'Export project (.helscoop)',
     },
     share: {
       title: 'Share project',
@@ -956,6 +964,8 @@ const translations = {
       saveEn: 'Save project',
       showDocs: 'Show/hide docs',
       showDocsEn: 'Show/hide docs',
+      exportProject: 'Export project (.helscoop)',
+      exportProjectEn: 'Export project (.helscoop)',
     },
     validation: {
       unmatchedCloser: 'Unmatched closing {{char}} on line {{line}}',


### PR DESCRIPTION
## Summary
- Add a new "Export project (.helscoop)" button in the editor export dropdown menu, separated by a divider from BOM-only exports
- Export downloads a `.helscoop` JSON file containing project name, description, scene script, BOM items, version, and export timestamp
- Add corresponding command palette entry for quick access via Cmd+K
- Add `project_exported` analytics event for tracking
- Add Finnish and English i18n strings for all new UI text

## Format
```json
{
  "version": 1,
  "name": "...",
  "description": "...",
  "scene_js": "...",
  "bom": [...],
  "exportedAt": "2026-04-20T..."
}
```

## Test plan
- [ ] Open a project in the editor
- [ ] Click the export dropdown (download icon with chevron) in the header toolbar
- [ ] Verify the `.helscoop` export option appears below a divider after PDF/CSV/JSON
- [ ] Click it and verify a `.helscoop` file downloads with correct JSON contents
- [ ] Open command palette (Cmd+K) and search for "export project" -- verify the command works
- [ ] Switch locale to English and verify translated strings
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)