### PR TITLE
Fix CommandPalette secondary label duplication for non-Finnish locales

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -136,7 +136,7 @@ export default function CommandPalette({
   onClose: () => void;
   commands: Command[];
 }) {
-  const { t, locale } = useTranslation();
+  const { t } = useTranslation();
   const [query, setQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -298,8 +298,6 @@ export default function CommandPalette({
 
   if (!open) return null;
 
-  const isFi = locale === "fi";
-
   // Map flatCommands index to display items
   let commandIndex = 0;
 
@@ -390,11 +388,10 @@ export default function CommandPalette({
                     <span className="cmd-palette-item-label">
                       {t(cmd.labelKey)}
                     </span>
-                    {cmd.labelSecondaryKey && (
+                    {cmd.labelSecondaryKey &&
+                      t(cmd.labelSecondaryKey) !== t(cmd.labelKey) && (
                       <span className="cmd-palette-item-label-secondary">
-                        {isFi
-                          ? t(cmd.labelSecondaryKey)
-                          : t(cmd.labelKey)}
+                        {t(cmd.labelSecondaryKey)}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- Fixed inverted ternary in `CommandPalette.tsx` that caused the secondary label to render `t(cmd.labelKey)` (same as primary) instead of `t(cmd.labelSecondaryKey)` for non-Finnish locales
- Simplified the logic: always use `t(cmd.labelSecondaryKey)` and only render it when it differs from the primary label, preventing duplication regardless of locale
- Removed unused `isFi` and `locale` variables

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 240 existing tests pass (`npx vitest run`)
- [ ] Manual: switch locale to English, verify secondary labels show Finnish translations (not duplicates of primary)
- [ ] Manual: switch locale to Finnish, verify secondary labels show English translations (not duplicates)
- [ ] Manual: confirm that when both translations resolve to the same string, no secondary label is shown

Fixes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)