### PR TITLE
Debounce auto-save with dirty-field diffing (#512)

### DIFF
--- a/web/src/__tests__/useAutoSave.test.ts
+++ b/web/src/__tests__/useAutoSave.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAutoSave } from "@/hooks/useAutoSave";
+import type { SaveableFields, AutoSaveCallbacks } from "@/hooks/useAutoSave";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function makeFields(overrides: Partial<SaveableFields> = {}): SaveableFields {
+  return {
+    name: "Test Project",
+    description: "A description",
+    scene_js: "scene.add(box(1,1,1));",
+    bom: [{ material_id: "mat-1", quantity: 10, unit: "kpl" }],
+    ...overrides,
+  };
+}
+
+function makeCallbacks(overrides: Partial<AutoSaveCallbacks> = {}): AutoSaveCallbacks {
+  return {
+    onSaveProject: vi.fn().mockResolvedValue(undefined),
+    onSaveBom: vi.fn().mockResolvedValue(undefined),
+    onSaveThumbnail: vi.fn().mockResolvedValue(undefined),
+    onStatusChange: vi.fn(),
+    onSaveSuccess: vi.fn(),
+    onSaveError: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+describe("useAutoSave", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── basic debounce ────────────────────────────────────────────────────────
+
+  it("does not save before initialLoadDone is true", async () => {
+    const fields = makeFields();
+    const callbacks = makeCallbacks();
+
+    renderHook(() =>
+      useAutoSave(fields, callbacks, { initialLoadDone: false })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(callbacks.onSaveProject).not.toHaveBeenCalled();
+    expect(callbacks.onSaveBom).not.toHaveBeenCalled();
+  });
+
+  it("does not save when fields have not changed from initial snapshot", async () => {
+    const fields = makeFields();
+    const callbacks = makeCallbacks();
+
+    renderHook(() =>
+      useAutoSave(fields, callbacks, { initialLoadDone: true })
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(callbacks.onSaveProject).not.toHaveBeenCalled();
+    expect(callbacks.onSaveBom).not.toHaveBeenCalled();
+  });
+
+  it("saves only the changed project field after debounce", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    // Simulate user changing only the name
+    const updated = makeFields({ name: "New Name" });
+    rerender({ fields: updated });
+
+    // Not saved yet (within debounce window)
+    expect(callbacks.onSaveProject).not.toHaveBeenCalled();
+
+    // Advance past the default 2s debounce
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveProject).toHaveBeenCalledTimes(1);
+    expect(callbacks.onSaveProject).toHaveBeenCalledWith({ name: "New Name" });
+    // BOM didn't change, so no BOM save
+    expect(callbacks.onSaveBom).not.toHaveBeenCalled();
+  });
+
+  it("does not send scene_js when only name changed", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    rerender({ fields: makeFields({ name: "Different Name" }) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    const callArg = (callbacks.onSaveProject as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArg).toEqual({ name: "Different Name" });
+    expect(callArg).not.toHaveProperty("scene_js");
+    expect(callArg).not.toHaveProperty("description");
+  });
+
+  it("sends only scene_js when only scene_js changed", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    rerender({ fields: makeFields({ scene_js: "scene.add(sphere(2));" }) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveProject).toHaveBeenCalledWith({
+      scene_js: "scene.add(sphere(2));",
+    });
+  });
+
+  // ── BOM diffing ───────────────────────────────────────────────────────────
+
+  it("saves BOM when BOM items change", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    const newBom = [
+      { material_id: "mat-1", quantity: 20, unit: "kpl" },
+    ];
+    rerender({ fields: makeFields({ bom: newBom }) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveBom).toHaveBeenCalledTimes(1);
+    expect(callbacks.onSaveBom).toHaveBeenCalledWith(newBom);
+    // Project fields didn't change
+    expect(callbacks.onSaveProject).not.toHaveBeenCalled();
+  });
+
+  it("does not save BOM when BOM items are identical", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    // Change name but BOM stays the same
+    rerender({
+      fields: makeFields({
+        name: "Renamed",
+        bom: [{ material_id: "mat-1", quantity: 10, unit: "kpl" }],
+      }),
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveBom).not.toHaveBeenCalled();
+    expect(callbacks.onSaveProject).toHaveBeenCalledWith({ name: "Renamed" });
+  });
+
+  // ── thumbnail throttling ─────────────────────────────────────────────────
+
+  it("captures thumbnail only when scene_js changed", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    // Only change name (not scene_js)
+    rerender({ fields: makeFields({ name: "No Scene Change" }) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveThumbnail).not.toHaveBeenCalled();
+
+    // Now change scene_js
+    rerender({ fields: makeFields({ name: "No Scene Change", scene_js: "scene.add(cylinder(1,3));" }) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveThumbnail).toHaveBeenCalledTimes(1);
+  });
+
+  // ── rapid-fire / typing debounce ──────────────────────────────────────────
+
+  it("uses longer debounce when changes arrive rapidly", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) =>
+        useAutoSave(fields, callbacks, {
+          initialLoadDone: true,
+          debounceMs: 2000,
+          typingDebounceMs: 4000,
+          rapidFireThresholdMs: 800,
+        }),
+      { initialProps: { fields: initial } }
+    );
+
+    // Simulate rapid typing: changes 500ms apart
+    rerender({ fields: makeFields({ scene_js: "a" }) });
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    rerender({ fields: makeFields({ scene_js: "ab" }) });
+    await act(async () => { vi.advanceTimersByTime(500); });
+
+    rerender({ fields: makeFields({ scene_js: "abc" }) });
+
+    // After 2100ms total from last change, the 4s typing debounce should NOT have fired
+    await act(async () => { vi.advanceTimersByTime(2100); });
+    expect(callbacks.onSaveProject).not.toHaveBeenCalled();
+
+    // After 4100ms from last change, it should fire
+    await act(async () => { vi.advanceTimersByTime(2000); });
+    expect(callbacks.onSaveProject).toHaveBeenCalledTimes(1);
+  });
+
+  // ── manual save (saveNow) ────────────────────────────────────────────────
+
+  it("saveNow triggers an immediate save", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { result, rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    rerender({ fields: makeFields({ name: "Manual Save" }) });
+
+    // Save immediately without waiting for debounce
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    expect(callbacks.onSaveProject).toHaveBeenCalledWith({ name: "Manual Save" });
+  });
+
+  // ── error handling ────────────────────────────────────────────────────────
+
+  it("calls onSaveError and sets status to unsaved on failure", async () => {
+    const initial = makeFields();
+    const error = new Error("Network error");
+    const callbacks = makeCallbacks({
+      onSaveProject: vi.fn().mockRejectedValue(error),
+    });
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    rerender({ fields: makeFields({ name: "Will Fail" }) });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveError).toHaveBeenCalledWith(error);
+    // Status transitions: unsaved -> saving -> unsaved (on error)
+    const statusCalls = (callbacks.onStatusChange as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c) => c[0]
+    );
+    expect(statusCalls).toContain("saving");
+    expect(statusCalls[statusCalls.length - 1]).toBe("unsaved");
+  });
+
+  // ── onSaveSuccess receives the saved snapshot ─────────────────────────────
+
+  it("onSaveSuccess receives the saved snapshot values", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    const updatedFields = makeFields({ name: "Saved Name", scene_js: "new code;" });
+    rerender({ fields: updatedFields });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveSuccess).toHaveBeenCalledTimes(1);
+    const savedSnapshot = (callbacks.onSaveSuccess as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(savedSnapshot.name).toBe("Saved Name");
+    expect(savedSnapshot.scene_js).toBe("new code;");
+  });
+
+  // ── no duplicate saves after snapshot updated ────────────────────────────
+
+  it("does not re-save after a successful save when fields haven't changed again", async () => {
+    const initial = makeFields();
+    const callbacks = makeCallbacks();
+
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, callbacks, { initialLoadDone: true }),
+      { initialProps: { fields: initial } }
+    );
+
+    const updated = makeFields({ name: "Changed Once" });
+    rerender({ fields: updated });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2100);
+    });
+
+    expect(callbacks.onSaveProject).toHaveBeenCalledTimes(1);
+
+    // Re-render with the same fields (no new changes)
+    rerender({ fields: updated });
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    // Should still only have been called once
+    expect(callbacks.onSaveProject).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -25,6 +25,8 @@ import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { useAnalytics, useEditorSession } from "@/hooks/useAnalytics";
 import { useDraftRecovery } from "@/hooks/useDraftRecovery";
+import { useAutoSave } from "@/hooks/useAutoSave";
+import type { SaveableFields } from "@/hooks/useAutoSave";
 import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
 import type { Material, BomItem, Project } from "@/types";
 
@@ -151,9 +153,8 @@ export default function ProjectPage() {
   const historyRef = useRef<string[]>([]);
   const historyIndexRef = useRef<number>(-1);
 
-  const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const bomChangedRef = useRef(false);
   const initialLoadDoneRef = useRef(false);
+  const [initialLoadDone, setInitialLoadDone] = useState(false);
   const captureThumbRef = useRef<(() => string | null) | null>(null);
   const resizingRef = useRef(false);
 
@@ -204,12 +205,27 @@ export default function ProjectPage() {
         historyRef.current = [initialScene];
         historyIndexRef.current = 0;
         setMaterials(mats);
-        if (proj.bom) setBom(proj.bom.map((b: BomItem & { line_cost?: number }) => ({
-          ...b,
-          total: b.total ?? b.line_cost ?? ((b.unit_price || 0) * b.quantity),
-        })));
+        const initialBom = proj.bom
+          ? proj.bom.map((b: BomItem & { line_cost?: number }) => ({
+              ...b,
+              total: b.total ?? b.line_cost ?? ((b.unit_price || 0) * b.quantity),
+            }))
+          : [];
+        setBom(initialBom);
+        // Set the auto-save baseline to match what the server has
+        setSavedSnapshot({
+          name: proj.name,
+          description: proj.description || "",
+          scene_js: initialScene,
+          bom: initialBom.map((b: BomItem) => ({
+            material_id: b.material_id,
+            quantity: b.quantity,
+            unit: b.unit,
+          })),
+        });
         setTimeout(() => {
           initialLoadDoneRef.current = true;
+          setInitialLoadDone(true);
         }, 0);
       })
       .catch((err) => {
@@ -223,70 +239,64 @@ export default function ProjectPage() {
       });
   }, [projectId, router, toast, t]);
 
-  const save = useCallback(async () => {
-    setSaveStatus("saving");
-    try {
-      const savePromises: Promise<unknown>[] = [
-        api.updateProject(projectId, {
-          name: projectName,
-          description: projectDesc,
-          scene_js: sceneJs,
-        }),
-      ];
-      if (bomChangedRef.current) {
-        savePromises.push(
-          api.saveBOM(
-            projectId,
-            bom.map((b) => ({
-              material_id: b.material_id,
-              quantity: b.quantity,
-              unit: b.unit,
-            }))
-          )
-        );
-        bomChangedRef.current = false;
-      }
-      // Capture and save thumbnail in the background (non-blocking)
-      const thumbDataUrl = captureThumbRef.current?.();
-      if (thumbDataUrl) {
-        savePromises.push(api.saveThumbnail(projectId, thumbDataUrl));
-      }
-      await Promise.all(savePromises);
-      setSavedScript(sceneJs);
-      setLastSaved(new Date().toLocaleTimeString());
-      setSaveStatus("saved");
-      setSaveFailCount(0);
-      setSaveErrorVisible(false);
-      toast(t('toast.saved'), "success");
-    } catch (err) {
-      toast(err instanceof Error ? err.message : t('toast.saveFailed'), "error");
-      setSaveStatus("unsaved");
-      setSaveFailCount((c) => c + 1);
-      setSaveErrorVisible(true);
-    }
-  }, [projectId, projectName, projectDesc, sceneJs, bom, toast, t]);
+  // Memoize the BOM in a save-friendly format to avoid unnecessary re-renders
+  const bomForSave = useMemo(
+    () => bom.map((b) => ({ material_id: b.material_id, quantity: b.quantity, unit: b.unit })),
+    [bom]
+  );
 
-  const scheduleAutoSave = useCallback(() => {
-    if (!initialLoadDoneRef.current) return;
-    setSaveStatus("unsaved");
-    if (autoSaveTimerRef.current) {
-      clearTimeout(autoSaveTimerRef.current);
-    }
-    autoSaveTimerRef.current = setTimeout(() => {
-      save();
-    }, 2000);
-  }, [save]);
+  const saveableFields = useMemo<SaveableFields>(
+    () => ({
+      name: projectName,
+      description: projectDesc,
+      scene_js: sceneJs,
+      bom: bomForSave,
+    }),
+    [projectName, projectDesc, sceneJs, bomForSave]
+  );
 
-  useEffect(() => {
-    if (!initialLoadDoneRef.current) return;
-    scheduleAutoSave();
-    return () => {
-      if (autoSaveTimerRef.current) {
-        clearTimeout(autoSaveTimerRef.current);
-      }
-    };
-  }, [sceneJs, projectName, projectDesc, bom, scheduleAutoSave]);
+  const autoSaveCallbacks = useMemo(
+    () => ({
+      onSaveProject: async (dirty: Partial<Pick<SaveableFields, "name" | "description" | "scene_js">>) => {
+        await api.updateProject(projectId, dirty);
+      },
+      onSaveBom: async (items: SaveableFields["bom"]) => {
+        await api.saveBOM(projectId, items);
+      },
+      onSaveThumbnail: async () => {
+        const thumbDataUrl = captureThumbRef.current?.();
+        if (thumbDataUrl) {
+          await api.saveThumbnail(projectId, thumbDataUrl);
+        }
+      },
+      onStatusChange: (status: "saved" | "saving" | "unsaved") => {
+        setSaveStatus(status);
+      },
+      onSaveSuccess: (saved: SaveableFields) => {
+        setSavedScript(saved.scene_js);
+        setLastSaved(new Date().toLocaleTimeString());
+        setSaveFailCount(0);
+        setSaveErrorVisible(false);
+        toast(t('toast.saved'), "success");
+      },
+      onSaveError: (err: unknown) => {
+        toast(err instanceof Error ? err.message : t('toast.saveFailed'), "error");
+        setSaveFailCount((c) => c + 1);
+        setSaveErrorVisible(true);
+      },
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [projectId, toast, t]
+  );
 
+  const { saveNow: save, setSavedSnapshot } = useAutoSave(saveableFields, autoSaveCallbacks, {
+    initialLoadDone,
+    debounceMs: 2000,
+    typingDebounceMs: 4000,
+    rapidFireThresholdMs: 800,
+  });
+
+  // Block navigation when there are unsaved changes
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
       if (saveStatus === "unsaved" || saveStatus === "saving") {
@@ -689,7 +699,7 @@ export default function ProjectPage() {
       const mat = materials.find((m) => m.id === materialId);
       if (!mat) return;
       const pricing = mat.pricing?.find((p) => p.is_primary) || mat.pricing?.[0];
-      bomChangedRef.current = true;
+
       track("bom_item_added", { material_id: materialId, category: mat.category_name || "" });
       setBom((prev) => [
         ...prev,
@@ -714,7 +724,6 @@ export default function ProjectPage() {
       removedItem = prev.find((b) => b.material_id === materialId);
       return prev.filter((b) => b.material_id !== materialId);
     });
-    bomChangedRef.current = true;
     track("bom_item_removed", { material_id: materialId });
 
     // Show undo toast — if the user clicks "Undo" within 5s, re-add the item
@@ -725,7 +734,6 @@ export default function ProjectPage() {
         action: {
           label: t("toast.undo"),
           onClick: () => {
-            bomChangedRef.current = true;
             track("bom_item_undo_remove", { material_id: materialId });
             setBom((prev) => [...prev, item]);
           },
@@ -735,7 +743,6 @@ export default function ProjectPage() {
   }, [track, toast, t]);
 
   const updateBomQty = useCallback((materialId: string, qty: number) => {
-    bomChangedRef.current = true;
     setBom((prev) =>
       prev.map((b) =>
         b.material_id === materialId

--- a/web/src/hooks/useAutoSave.ts
+++ b/web/src/hooks/useAutoSave.ts
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Fields that can be auto-saved. Each key maps to a saveable project field.
+ */
+export interface SaveableFields {
+  name: string;
+  description: string;
+  scene_js: string;
+  bom: { material_id: string; quantity: number; unit: string }[];
+}
+
+export interface AutoSaveCallbacks {
+  /** Called with only the changed project fields (name, description, scene_js). */
+  onSaveProject: (dirty: Partial<Pick<SaveableFields, "name" | "description" | "scene_js">>) => Promise<void>;
+  /** Called when BOM has changed. */
+  onSaveBom: (bom: SaveableFields["bom"]) => Promise<void>;
+  /** Called when scene_js changed and save succeeded, to capture a new thumbnail. */
+  onSaveThumbnail: () => Promise<void>;
+  /** Called on save status transitions. */
+  onStatusChange: (status: "saved" | "saving" | "unsaved") => void;
+  /** Called on save success with the snapshot that was actually saved. */
+  onSaveSuccess: (saved: SaveableFields) => void;
+  /** Called on save failure. */
+  onSaveError: (err: unknown) => void;
+}
+
+export interface AutoSaveOptions {
+  /** Debounce delay in ms for discrete changes (param slider, BOM). Default: 2000. */
+  debounceMs?: number;
+  /** Debounce delay in ms during rapid-fire changes (typing). Default: 4000. */
+  typingDebounceMs?: number;
+  /** Threshold in ms: if two changes arrive within this window, use typingDebounceMs. Default: 800. */
+  rapidFireThresholdMs?: number;
+  /** Whether the initial data load is complete. Auto-save is suppressed until true. */
+  initialLoadDone: boolean;
+}
+
+const DEFAULT_DEBOUNCE_MS = 2000;
+const DEFAULT_TYPING_DEBOUNCE_MS = 4000;
+const DEFAULT_RAPID_FIRE_THRESHOLD_MS = 800;
+
+/**
+ * Deeply compare two BOM arrays by material_id, quantity, unit.
+ */
+function bomEquals(
+  a: SaveableFields["bom"],
+  b: SaveableFields["bom"]
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (
+      a[i].material_id !== b[i].material_id ||
+      a[i].quantity !== b[i].quantity ||
+      a[i].unit !== b[i].unit
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * A hook that tracks dirty fields and debounces auto-save requests.
+ *
+ * Instead of saving the entire payload every 2 seconds, this hook:
+ * - Diffs current values against the last-saved snapshot
+ * - Only sends changed fields in the PUT
+ * - Uses a longer debounce during rapid typing
+ * - Captures thumbnails only when scene_js actually changed
+ * - Flushes pending saves on unmount / beforeunload
+ */
+export function useAutoSave(
+  fields: SaveableFields,
+  callbacks: AutoSaveCallbacks,
+  options: AutoSaveOptions
+) {
+  const {
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    typingDebounceMs = DEFAULT_TYPING_DEBOUNCE_MS,
+    rapidFireThresholdMs = DEFAULT_RAPID_FIRE_THRESHOLD_MS,
+    initialLoadDone,
+  } = options;
+
+  // Snapshot of last-saved values
+  const savedRef = useRef<SaveableFields>({ ...fields });
+  // Current values ref (kept in sync) for use in flush callbacks
+  const currentRef = useRef<SaveableFields>(fields);
+  // Timer for debounced save
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Timestamp of last change event, for rapid-fire detection
+  const lastChangeRef = useRef<number>(0);
+  // Whether a save is currently in flight (to avoid overlapping saves)
+  const savingRef = useRef(false);
+  // Whether there are pending dirty changes that haven't been saved yet
+  const dirtyRef = useRef(false);
+  // Stable ref to callbacks to avoid re-creating closures
+  const cbRef = useRef(callbacks);
+  cbRef.current = callbacks;
+
+  // Keep currentRef in sync
+  currentRef.current = fields;
+
+  /**
+   * Compute which fields have changed since the last saved snapshot.
+   * Returns null if nothing changed.
+   */
+  const computeDirtyFields = useCallback(
+    (current: SaveableFields, saved: SaveableFields) => {
+      const projectDirty: Partial<Pick<SaveableFields, "name" | "description" | "scene_js">> = {};
+      let hasProjectChanges = false;
+      let sceneChanged = false;
+
+      if (current.name !== saved.name) {
+        projectDirty.name = current.name;
+        hasProjectChanges = true;
+      }
+      if (current.description !== saved.description) {
+        projectDirty.description = current.description;
+        hasProjectChanges = true;
+      }
+      if (current.scene_js !== saved.scene_js) {
+        projectDirty.scene_js = current.scene_js;
+        hasProjectChanges = true;
+        sceneChanged = true;
+      }
+
+      const bomChanged = !bomEquals(current.bom, saved.bom);
+
+      return {
+        projectDirty: hasProjectChanges ? projectDirty : null,
+        bomChanged,
+        sceneChanged,
+        hasAnyChanges: hasProjectChanges || bomChanged,
+      };
+    },
+    []
+  );
+
+  /**
+   * Execute a save with only the dirty fields.
+   */
+  const doSave = useCallback(async () => {
+    if (savingRef.current) return;
+
+    const current = { ...currentRef.current };
+    const saved = savedRef.current;
+    const { projectDirty, bomChanged, sceneChanged, hasAnyChanges } =
+      computeDirtyFields(current, saved);
+
+    if (!hasAnyChanges) {
+      cbRef.current.onStatusChange("saved");
+      dirtyRef.current = false;
+      return;
+    }
+
+    savingRef.current = true;
+    cbRef.current.onStatusChange("saving");
+
+    try {
+      const promises: Promise<void>[] = [];
+
+      if (projectDirty) {
+        promises.push(cbRef.current.onSaveProject(projectDirty));
+      }
+      if (bomChanged) {
+        promises.push(cbRef.current.onSaveBom(current.bom));
+      }
+
+      await Promise.all(promises);
+
+      // Thumbnail only when scene_js changed and save succeeded
+      if (sceneChanged) {
+        // Fire-and-forget; don't block the save status
+        cbRef.current.onSaveThumbnail().catch(() => {});
+      }
+
+      // Update saved snapshot
+      savedRef.current = { ...current };
+      dirtyRef.current = false;
+      cbRef.current.onStatusChange("saved");
+      cbRef.current.onSaveSuccess(current);
+    } catch (err) {
+      cbRef.current.onStatusChange("unsaved");
+      cbRef.current.onSaveError(err);
+    } finally {
+      savingRef.current = false;
+    }
+  }, [computeDirtyFields]);
+
+  /**
+   * Schedule a debounced save. Uses a longer debounce window when changes
+   * arrive in rapid succession (typing).
+   */
+  const scheduleAutoSave = useCallback(() => {
+    if (!initialLoadDone) return;
+
+    const now = Date.now();
+    const timeSinceLastChange = now - lastChangeRef.current;
+    lastChangeRef.current = now;
+
+    dirtyRef.current = true;
+    cbRef.current.onStatusChange("unsaved");
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    // Use longer debounce if changes arrive rapidly (e.g. typing)
+    const delay =
+      timeSinceLastChange < rapidFireThresholdMs
+        ? typingDebounceMs
+        : debounceMs;
+
+    timerRef.current = setTimeout(() => {
+      doSave();
+    }, delay);
+  }, [initialLoadDone, debounceMs, typingDebounceMs, rapidFireThresholdMs, doSave]);
+
+  /**
+   * Force an immediate save (for Cmd+S, manual save button, etc.)
+   */
+  const saveNow = useCallback(async () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    await doSave();
+  }, [doSave]);
+
+  /**
+   * Synchronous flush for beforeunload. Uses sendBeacon-style approach
+   * but since we can't easily do that with auth headers, we just fire
+   * the async save and hope it lands.
+   */
+  const flush = useCallback(() => {
+    if (!dirtyRef.current) return;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    // Best-effort flush — call doSave but can't await in beforeunload
+    doSave();
+  }, [doSave]);
+
+  /**
+   * Update the saved snapshot externally (e.g., after initial load).
+   */
+  const setSavedSnapshot = useCallback((snapshot: SaveableFields) => {
+    savedRef.current = { ...snapshot };
+  }, []);
+
+  // React to field changes — schedule auto-save
+  useEffect(() => {
+    if (!initialLoadDone) return;
+    // Compare against saved snapshot to decide if we need to schedule
+    const { hasAnyChanges } = computeDirtyFields(fields, savedRef.current);
+    if (hasAnyChanges) {
+      scheduleAutoSave();
+    }
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [
+    fields.name,
+    fields.description,
+    fields.scene_js,
+    fields.bom,
+    initialLoadDone,
+    scheduleAutoSave,
+    computeDirtyFields,
+    // Note: we intentionally depend on the individual field values, not `fields` object identity
+  ]);
+
+  // beforeunload handler — flush on page leave
+  useEffect(() => {
+    const handler = () => {
+      flush();
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => {
+      window.removeEventListener("beforeunload", handler);
+      // Also flush on unmount (component teardown / navigation)
+      flush();
+    };
+  }, [flush]);
+
+  return {
+    /** Force an immediate save (e.g., Cmd+S). */
+    saveNow,
+    /** Update the saved snapshot (call after initial data load). */
+    setSavedSnapshot,
+    /** Whether there are pending unsaved changes. */
+    isDirty: dirtyRef.current,
+  };
+}


### PR DESCRIPTION
## Summary

- **Extract `useAutoSave` hook** that tracks dirty fields and only sends changed data in PUT requests (e.g., if only `projectName` changed, `scene_js` is omitted entirely)
- **Adaptive debounce**: Uses a 4-second debounce during rapid typing (changes <800ms apart) vs the standard 2-second debounce for discrete changes like slider adjustments
- **Throttle thumbnail capture**: Only captures and uploads a new thumbnail when `scene_js` has actually changed AND the save succeeds (previously every save attempted a thumbnail upload)
- **Deep BOM comparison**: Replaces the `bomChangedRef` boolean flag with actual diff comparison, so BOM is only saved when material_id/quantity/unit values differ from the last-saved snapshot
- **Save on unmount/beforeunload**: Flushes pending dirty changes when the component unmounts or the user navigates away

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 253 tests pass (240 existing + 13 new `useAutoSave` tests)
- [ ] Manual test: open a project, edit scene_js, verify Network tab shows only `scene_js` in PUT payload
- [ ] Manual test: rename project without editing scene, verify PUT does not include `scene_js`
- [ ] Manual test: rapid typing in editor, verify save fires ~4s after last keystroke (not every 2s)
- [ ] Manual test: adjust a param slider, verify save fires ~2s after release
- [ ] Manual test: close browser tab with unsaved changes, verify beforeunload prompt appears

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)