### PR TITLE
Fix EmailVerificationBanner: use i18n instead of hardcoded bilingual strings

### DIFF
--- a/web/src/components/EmailVerificationBanner.tsx
+++ b/web/src/components/EmailVerificationBanner.tsx
@@ -2,12 +2,14 @@
 
 import { useState } from "react";
 import { api } from "@/lib/api";
+import { useTranslation } from "@/components/LocaleProvider";
 
 interface Props {
   emailVerified: boolean;
 }
 
 export default function EmailVerificationBanner({ emailVerified }: Props) {
+  const { t } = useTranslation();
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
   const [dismissed, setDismissed] = useState(false);
@@ -40,14 +42,12 @@ export default function EmailVerificationBanner({ emailVerified }: Props) {
       marginBottom: 16,
     }}>
       <span>
-        Vahvista sahkopostiosoitteesi. Tarkista postilaatikkosi.
-        {" / "}
-        Please verify your email. Check your inbox.
+        {t('emailVerification.banner')}
       </span>
       <div style={{ display: "flex", gap: 8, alignItems: "center", flexShrink: 0 }}>
         {resent ? (
           <span style={{ color: "var(--success, #4ade80)", fontSize: 12 }}>
-            Lahetetty! / Sent!
+            {t('emailVerification.resent')}
           </span>
         ) : (
           <button
@@ -56,7 +56,7 @@ export default function EmailVerificationBanner({ emailVerified }: Props) {
             className="btn btn-ghost"
             style={{ fontSize: 12, padding: "4px 12px" }}
           >
-            {resending ? <span className="btn-spinner" /> : "Lähetä uudelleen / Resend"}
+            {resending ? <span className="btn-spinner" /> : t('emailVerification.resend')}
           </button>
         )}
         <button
@@ -75,7 +75,7 @@ export default function EmailVerificationBanner({ emailVerified }: Props) {
             padding: 0,
             lineHeight: 1,
           }}
-          aria-label="Sulje / Dismiss"
+          aria-label={t('emailVerification.dismiss')}
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="18" y1="6" x2="6" y2="18" />

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -493,6 +493,12 @@ const translations = {
       invalidDimension: '{{geometry}}-objektilla on nolla- tai negatiivinen mitta',
       warningsTitle: 'Varoitukset',
     },
+    emailVerification: {
+      banner: 'Vahvista sahkopostiosoitteesi. Tarkista postilaatikkosi.',
+      resent: 'Lahetetty!',
+      resend: 'Laheta uudelleen',
+      dismiss: 'Sulje',
+    },
     errors: {
       notFoundTitle: 'Sivua ei loytynyt',
       notFoundMessage: 'Etsimasi sivu ei ole olemassa tai se on siirretty.',
@@ -1001,6 +1007,12 @@ const translations = {
       farFromOrigin: 'Object is {{distance}} units from origin — check position',
       invalidDimension: '{{geometry}} has zero or negative dimensions',
       warningsTitle: 'Warnings',
+    },
+    emailVerification: {
+      banner: 'Please verify your email. Check your inbox.',
+      resent: 'Sent!',
+      resend: 'Resend',
+      dismiss: 'Dismiss',
     },
     errors: {
       notFoundTitle: 'Page not found',


### PR DESCRIPTION
## Summary
- Replace all 4 hardcoded "Finnish / English" concatenated strings in `EmailVerificationBanner.tsx` with `t()` calls using `useTranslation()` hook
- Add new `emailVerification` translation section (banner, resent, resend, dismiss) to both `fi` and `en` locales in `i18n.ts`
- Banner now displays the correct language based on user's locale setting

Closes #520

## Test plan
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] `npx vitest run` passes (251/251 tests, including 47 i18n tests)
- [ ] Manually verify banner renders in Finnish when locale is `fi`
- [ ] Manually verify banner renders in English when locale is `en`
- [ ] Verify resend button, confirmation text, and dismiss aria-label all respect locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)