### PR TITLE
Fix error.tsx: use i18n instead of hardcoded English

### DIFF
--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useTranslation } from "@/components/LocaleProvider";
 
 export default function Error({
   error,
@@ -11,6 +12,7 @@ export default function Error({
   reset: () => void;
 }) {
   const [showDetails, setShowDetails] = useState(false);
+  const { t } = useTranslation();
 
   return (
     <div
@@ -46,7 +48,7 @@ export default function Error({
           className="heading-display"
           style={{ fontSize: 24, marginBottom: 8 }}
         >
-          Something went wrong
+          {t("errors.serverErrorTitle")}
         </h1>
 
         <p
@@ -57,7 +59,7 @@ export default function Error({
             lineHeight: 1.6,
           }}
         >
-          An unexpected error occurred. Please try again.
+          {t("errors.serverErrorMessage")}
         </p>
 
         <div
@@ -86,7 +88,7 @@ export default function Error({
               <polyline points="23 4 23 10 17 10" />
               <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
             </svg>
-            Try again
+            {t("errors.tryAgain")}
           </button>
           <Link
             href="/"
@@ -97,7 +99,7 @@ export default function Error({
               fontSize: 14,
             }}
           >
-            Back to dashboard
+            {t("errors.backToDashboard")}
           </Link>
         </div>
 
@@ -115,7 +117,7 @@ export default function Error({
                 fontFamily: "var(--font-body)",
               }}
             >
-              {showDetails ? "Hide details" : "Show details"}
+              {showDetails ? t("errors.hideDetails") : t("errors.showDetails")}
             </button>
             {showDetails && (
               <pre


### PR DESCRIPTION
## Summary
- Replace all 5 hardcoded English strings in `web/src/app/error.tsx` with `t()` calls from the existing i18n system
- Finnish users now see localized text ("Jokin meni pieleen", "Yrita uudelleen", etc.) when the app crashes
- No new translation keys needed -- all strings already existed under `errors.*` in `i18n.ts`

### Strings replaced
| Before (hardcoded) | After (i18n key) |
|---|---|
| "Something went wrong" | `t("errors.serverErrorTitle")` |
| "An unexpected error occurred. Please try again." | `t("errors.serverErrorMessage")` |
| "Try again" | `t("errors.tryAgain")` |
| "Back to dashboard" | `t("errors.backToDashboard")` |
| "Show details" / "Hide details" | `t("errors.showDetails")` / `t("errors.hideDetails")` |

## Test plan
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] `npx vitest run` -- all 251 tests pass
- [ ] Manually trigger an error with locale set to `fi` and verify Finnish strings appear
- [ ] Verify English strings appear when locale is `en`

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)