### PR TITLE
Fix form accessibility: required attrs and label associations (#521, #522)

### DIFF
--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -237,12 +237,14 @@ export default function SettingsPage() {
           >
             <div>
               <label
+                htmlFor="settings-name"
                 className="label-mono"
                 style={{ display: "block", marginBottom: 8 }}
               >
                 {t("settings.name")}
               </label>
               <input
+                id="settings-name"
                 className="input"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -251,12 +253,14 @@ export default function SettingsPage() {
             </div>
             <div>
               <label
+                htmlFor="settings-email"
                 className="label-mono"
                 style={{ display: "block", marginBottom: 8 }}
               >
                 {t("settings.email")}
               </label>
               <input
+                id="settings-email"
                 className="input"
                 type="email"
                 value={email}
@@ -304,12 +308,14 @@ export default function SettingsPage() {
           >
             <div>
               <label
+                htmlFor="settings-current-password"
                 className="label-mono"
                 style={{ display: "block", marginBottom: 8 }}
               >
                 {t("settings.currentPassword")}
               </label>
               <input
+                id="settings-current-password"
                 className="input"
                 type="password"
                 value={currentPassword}
@@ -320,12 +326,14 @@ export default function SettingsPage() {
             </div>
             <div>
               <label
+                htmlFor="settings-new-password"
                 className="label-mono"
                 style={{ display: "block", marginBottom: 8 }}
               >
                 {t("settings.newPassword")}
               </label>
               <input
+                id="settings-new-password"
                 className="input"
                 type="password"
                 value={newPassword}
@@ -336,12 +344,14 @@ export default function SettingsPage() {
             </div>
             <div>
               <label
+                htmlFor="settings-confirm-password"
                 className="label-mono"
                 style={{ display: "block", marginBottom: 8 }}
               >
                 {t("settings.confirmPassword")}
               </label>
               <input
+                id="settings-confirm-password"
                 className="input"
                 type="password"
                 value={confirmPassword}

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -169,6 +169,7 @@ export default function LoginForm({
                   placeholder={t('auth.namePlaceholder')}
                   value={name}
                   onChange={(e) => setName(e.target.value)}
+                  required
                   autoComplete="name"
                 />
               </div>


### PR DESCRIPTION
Fixes #521
Fixes #522

## Summary
- Add `required` attribute to LoginForm name input during registration, matching the existing email/password inputs
- Associate all Settings page labels with their inputs via `htmlFor`/`id` pairs (profile name, email, current password, new password, confirm password)

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 253 tests pass (`vitest run`)
- [ ] Verify name field shows browser validation on empty submit during registration
- [ ] Verify clicking labels in Settings focuses the corresponding input

🤖 Generated with [Claude Code](https://claude.com/claude-code)