### PR TITLE
Fix a11y: UserMenu keyboard dismiss + ARIA, ConnectionBanner aria-live

### DIFF
--- a/web/src/components/ConnectionBanner.tsx
+++ b/web/src/components/ConnectionBanner.tsx
@@ -86,6 +86,8 @@ export default function ConnectionBanner() {
   return (
     <div
       className="anim-up"
+      role="status"
+      aria-live="polite"
       style={{
         position: "fixed",
         top: 0,

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
 import Link from "next/link";
 
-function UserAvatar({ name, onClick }: { name: string; onClick?: () => void }) {
+function UserAvatar({ name, onClick, expanded }: { name: string; onClick?: () => void; expanded: boolean }) {
   const initials = name
     .split(/\s+/)
     .map((w) => w[0])
@@ -18,6 +18,8 @@ function UserAvatar({ name, onClick }: { name: string; onClick?: () => void }) {
     <button
       onClick={onClick}
       aria-label={`User menu for ${name}`}
+      aria-haspopup="true"
+      aria-expanded={expanded}
       style={{
         width: 44,
         height: 44,
@@ -47,10 +49,29 @@ function UserAvatar({ name, onClick }: { name: string; onClick?: () => void }) {
 export default function UserMenu({ userName }: { userName: string }) {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeMenu();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, closeMenu]);
 
   return (
-    <div style={{ position: "relative" }}>
-      <UserAvatar name={userName} onClick={() => setOpen(!open)} />
+    <div style={{ position: "relative" }} ref={triggerRef}>
+      <UserAvatar name={userName} onClick={() => setOpen(!open)} expanded={open} />
       {open && (
         <>
           {/* Backdrop to close menu */}
@@ -60,6 +81,8 @@ export default function UserMenu({ userName }: { userName: string }) {
           />
           <div
             className="card anim-fade"
+            role="menu"
+            aria-label={`${userName} menu`}
             style={{
               position: "absolute",
               right: 0,
@@ -85,12 +108,14 @@ export default function UserMenu({ userName }: { userName: string }) {
             <Link
               href="/settings"
               className="menu-item"
+              role="menuitem"
               onClick={() => setOpen(false)}
             >
               {t("nav.settings")}
             </Link>
             <button
               className="menu-item"
+              role="menuitem"
               onClick={() => {
                 setToken(null);
                 window.location.reload();


### PR DESCRIPTION
## Summary
- **UserMenu** (#524): Add `aria-haspopup`, `aria-expanded`, `role="menu"`, `role="menuitem"`, and Escape key handler to close the dropdown
- **ConnectionBanner** (#525): Add `aria-live="polite"` and `role="status"` so screen readers announce connection state changes

Closes #524
Closes #525

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npx vitest run` — all 253 tests pass
- [ ] Manual: open UserMenu dropdown, press Escape — dropdown closes
- [ ] Manual: verify screen reader announces ConnectionBanner state changes
- [ ] Manual: inspect trigger button for `aria-haspopup="true"` and `aria-expanded` toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)