### PR TITLE
Add contextual save status indicator pill with sync animation

### DIFF
--- a/web/src/__tests__/SaveStatusIndicator.test.tsx
+++ b/web/src/__tests__/SaveStatusIndicator.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SaveStatusIndicator from "@/components/SaveStatusIndicator";
+
+// Mock the LocaleProvider to return English translations
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        "saveStatus.saved": "Saved",
+        "saveStatus.saving": "Saving...",
+        "saveStatus.unsaved": "Unsaved changes",
+        "saveStatus.error": "Save failed",
+      };
+      return map[key] ?? key;
+    },
+    locale: "en" as const,
+  }),
+}));
+
+describe("SaveStatusIndicator", () => {
+  it("renders saved state with muted text", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="saved" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill).toBeTruthy();
+    expect(pill?.getAttribute("data-status")).toBe("saved");
+    expect(screen.getByText("Saved")).toBeTruthy();
+  });
+
+  it("renders saved state with last-saved timestamp", () => {
+    render(
+      <SaveStatusIndicator status="saved" lastSaved="14:30:00" />
+    );
+    expect(screen.getByText("Saved 14:30:00")).toBeTruthy();
+  });
+
+  it("renders saving state with spinner", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="saving" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill?.getAttribute("data-status")).toBe("saving");
+    expect(screen.getByText("Saving...")).toBeTruthy();
+    expect(container.querySelector(".save-status-spinner")).toBeTruthy();
+  });
+
+  it("renders unsaved state with dot indicator", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="unsaved" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill?.getAttribute("data-status")).toBe("unsaved");
+    expect(screen.getByText("Unsaved changes")).toBeTruthy();
+    expect(container.querySelector(".save-status-dot")).toBeTruthy();
+  });
+
+  it("renders error state with error icon", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="error" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill?.getAttribute("data-status")).toBe("error");
+    expect(screen.getByText("Save failed")).toBeTruthy();
+  });
+
+  it("has role=status and aria-live for accessibility", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="saved" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill?.getAttribute("role")).toBe("status");
+    expect(pill?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("sets aria-label with timestamp when saved", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="saved" lastSaved="15:00:00" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill?.getAttribute("aria-label")).toBe("Saved 15:00:00");
+  });
+
+  it("sets aria-label for error state", () => {
+    const { container } = render(
+      <SaveStatusIndicator status="error" />
+    );
+    const pill = container.querySelector(".save-status-pill");
+    expect(pill?.getAttribute("aria-label")).toBe("Save failed");
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2400,39 +2400,79 @@ select:focus {
   gap: 4px;
 }
 
-.editor-save-status {
-  display: flex;
+/* ── Save status pill ────────────────────────────────────── */
+
+.save-status-pill {
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   font-size: 11px;
   font-family: var(--font-mono);
   letter-spacing: 0.02em;
   padding: 4px 10px;
-  border-radius: var(--radius-sm);
-  transition: color var(--transition-fast), opacity var(--transition-fast);
+  border-radius: 100px;
   white-space: nowrap;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+  border: 1px solid transparent;
+  flex-shrink: 0;
 }
 
-.editor-save-dot {
+.save-status-pill[data-status="saved"] {
+  color: var(--text-muted);
+  background: transparent;
+  border-color: transparent;
+}
+
+.save-status-pill[data-status="saving"] {
+  color: var(--accent);
+  background: var(--amber-glow);
+  border-color: var(--amber-border);
+}
+
+.save-status-pill[data-status="unsaved"] {
+  color: var(--warning, #e5c07b);
+  background: var(--warning-dim);
+  border-color: var(--warning-border);
+}
+
+.save-status-pill[data-status="error"] {
+  color: var(--danger);
+  background: var(--danger-dim);
+  border-color: rgba(239, 68, 68, 0.25);
+}
+
+.save-status-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+.save-status-spinner {
+  animation: spin 0.8s linear infinite;
+}
+
+.save-status-dot {
+  display: block;
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  flex-shrink: 0;
-  transition: background var(--transition-fast), box-shadow var(--transition-fast);
+  background: currentColor;
+  animation: saveStatusPulse 2s ease-in-out infinite;
 }
 
-.editor-save-dot[data-status="saved"] {
-  background: var(--success);
-  box-shadow: 0 0 4px var(--forest-dim);
+.save-status-label {
+  line-height: 1;
 }
 
-.editor-save-dot[data-status="saving"] {
-  background: var(--accent);
-  animation: pulse 1.5s infinite;
-}
-
-.editor-save-dot[data-status="unsaved"] {
-  background: var(--warning, #e5c07b);
+@keyframes saveStatusPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 /* ── Draft recovery banner ────────────────────────────────── */

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -28,6 +28,8 @@ import { useDraftRecovery } from "@/hooks/useDraftRecovery";
 import { useAutoSave } from "@/hooks/useAutoSave";
 import type { SaveableFields } from "@/hooks/useAutoSave";
 import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
+import SaveStatusIndicator from "@/components/SaveStatusIndicator";
+import type { SaveStatus } from "@/components/SaveStatusIndicator";
 import type { Material, BomItem, Project } from "@/types";
 
 /** Parse a validation warning key like "validation.typoDetected:scene" into
@@ -93,8 +95,6 @@ scene.add(wall2, { material: "lumber", color: [0.85, 0.75, 0.55] });
 scene.add(wall3, { material: "lumber", color: [0.85, 0.75, 0.55] });
 scene.add(wall4, { material: "lumber", color: [0.85, 0.75, 0.55] });
 `;
-
-type SaveStatus = "saved" | "saving" | "unsaved";
 
 const HISTORY_LIMIT = 50;
 
@@ -280,6 +280,7 @@ export default function ProjectPage() {
         toast(t('toast.saved'), "success");
       },
       onSaveError: (err: unknown) => {
+        setSaveStatus("error");
         toast(err instanceof Error ? err.message : t('toast.saveFailed'), "error");
         setSaveFailCount((c) => c + 1);
         setSaveErrorVisible(true);
@@ -299,7 +300,7 @@ export default function ProjectPage() {
   // Block navigation when there are unsaved changes
   useEffect(() => {
     const handler = (e: BeforeUnloadEvent) => {
-      if (saveStatus === "unsaved" || saveStatus === "saving") {
+      if (saveStatus === "unsaved" || saveStatus === "saving" || saveStatus === "error") {
         e.preventDefault();
       }
     };
@@ -804,16 +805,7 @@ export default function ProjectPage() {
             </span>
           )}
         </div>
-        <div className="editor-save-status" style={{
-          color: saveStatus === "unsaved" ? "var(--warning, #e5c07b)" : saveStatus === "saving" ? "var(--accent)" : "var(--text-muted)",
-        }}>
-          <span className="editor-save-dot" data-status={saveStatus} />
-          {saveStatus === "saving"
-            ? t('editor.saving')
-            : saveStatus === "saved"
-              ? `${t('editor.saved')}${lastSaved ? ` ${lastSaved}` : ""}`
-              : t('editor.unsaved')}
-        </div>
+        <SaveStatusIndicator status={saveStatus} lastSaved={lastSaved} />
         <div className="editor-header-actions">
           <button
             className="btn btn-ghost"

--- a/web/src/components/SaveStatusIndicator.tsx
+++ b/web/src/components/SaveStatusIndicator.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useTranslation } from "@/components/LocaleProvider";
+
+export type SaveStatus = "saved" | "saving" | "unsaved" | "error";
+
+interface SaveStatusIndicatorProps {
+  status: SaveStatus;
+  lastSaved?: string | null;
+}
+
+/**
+ * A pill-shaped save status indicator for the editor toolbar.
+ *
+ * States:
+ * - saved:   muted checkmark + timestamp, unobtrusive
+ * - saving:  amber spinner animation, visible but non-distracting
+ * - unsaved: amber dot indicating pending changes
+ * - error:   red exclamation, draws attention to failed saves
+ */
+export default function SaveStatusIndicator({
+  status,
+  lastSaved,
+}: SaveStatusIndicatorProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="save-status-pill"
+      data-status={status}
+      role="status"
+      aria-live="polite"
+      aria-label={
+        status === "error"
+          ? t("saveStatus.error")
+          : status === "saving"
+            ? t("saveStatus.saving")
+            : status === "unsaved"
+              ? t("saveStatus.unsaved")
+              : lastSaved
+                ? `${t("saveStatus.saved")} ${lastSaved}`
+                : t("saveStatus.saved")
+      }
+    >
+      <span className="save-status-icon" data-status={status}>
+        {status === "saved" && (
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        )}
+        {status === "saving" && (
+          <svg
+            className="save-status-spinner"
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+          </svg>
+        )}
+        {status === "unsaved" && (
+          <span className="save-status-dot" />
+        )}
+        {status === "error" && (
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+        )}
+      </span>
+      <span className="save-status-label">
+        {status === "error"
+          ? t("saveStatus.error")
+          : status === "saving"
+            ? t("saveStatus.saving")
+            : status === "unsaved"
+              ? t("saveStatus.unsaved")
+              : lastSaved
+                ? `${t("saveStatus.saved")} ${lastSaved}`
+                : t("saveStatus.saved")}
+      </span>
+    </div>
+  );
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -507,6 +507,12 @@ const translations = {
       invalidDimension: '{{geometry}}-objektilla on nolla- tai negatiivinen mitta',
       warningsTitle: 'Varoitukset',
     },
+    saveStatus: {
+      saved: 'Tallennettu',
+      saving: 'Tallentaa...',
+      unsaved: 'Tallentamattomia muutoksia',
+      error: 'Tallennus epaonnistui',
+    },
     emailVerification: {
       banner: 'Vahvista sahkopostiosoitteesi. Tarkista postilaatikkosi.',
       resent: 'Lahetetty!',
@@ -1035,6 +1041,12 @@ const translations = {
       farFromOrigin: 'Object is {{distance}} units from origin — check position',
       invalidDimension: '{{geometry}} has zero or negative dimensions',
       warningsTitle: 'Warnings',
+    },
+    saveStatus: {
+      saved: 'Saved',
+      saving: 'Saving...',
+      unsaved: 'Unsaved changes',
+      error: 'Save failed',
     },
     emailVerification: {
       banner: 'Please verify your email. Check your inbox.',


### PR DESCRIPTION
## Summary
- Adds a `SaveStatusIndicator` pill component with four visual states: **saved** (muted checkmark), **saving** (amber spinner), **unsaved changes** (pulsing dot), and **error** (red exclamation icon)
- Replaces inline save status markup in the editor header with the new component
- Adds `saveStatus.saved/saving/unsaved/error` i18n strings to both Finnish and English locales
- Includes `role="status"` and `aria-live="polite"` for screen reader accessibility

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 261 tests pass (253 existing + 8 new component tests)
- [ ] Visual check: pill is muted when saved, amber-tinted during save, warning-tinted for unsaved, red for errors
- [ ] Verify smooth CSS transitions between states
- [ ] Check responsive behavior at narrow widths

Closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)