### PR TITLE
Add aria-live region to toast container (#537)

### DIFF
--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -71,6 +71,9 @@ export function ToastContainer({ toasts, onDismiss }: { toasts: ToastItem[]; onD
 
   return (
     <div
+      role="status"
+      aria-live="polite"
+      aria-relevant="additions"
       style={{
         position: "fixed",
         bottom: 24,
@@ -162,6 +165,8 @@ function ToastMessage({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: 
 
   return (
     <div
+      role={toast.type === "error" ? "alert" : "status"}
+      aria-live={toast.type === "error" ? "assertive" : "polite"}
       style={{
         display: "flex",
         alignItems: "center",
@@ -305,6 +310,9 @@ function ProgressToast({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id:
 
   return (
     <div
+      role="status"
+      aria-live="polite"
+      aria-label={`${toast.message} ${Math.round(progress)}%`}
       style={{
         display: "flex",
         flexDirection: "column",
@@ -353,6 +361,11 @@ function ProgressToast({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id:
         </span>
       </div>
       <div
+        role="progressbar"
+        aria-valuenow={Math.round(progress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${toast.message} progress`}
         style={{
           height: 3,
           borderRadius: "2px",


### PR DESCRIPTION
## Summary
- Add `aria-live="polite"` and `role="status"` to `ToastContainer` wrapper so screen readers announce new toasts
- Add per-toast ARIA roles: `role="alert"` with `aria-live="assertive"` for error toasts, `role="status"` with `aria-live="polite"` for all others
- Add `role="progressbar"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax` to progress toast bars

Fixes #537

## Test plan
- [ ] Verify screen readers (VoiceOver, NVDA) announce new toasts when they appear
- [ ] Verify error toasts are announced immediately (assertive)
- [ ] Verify progress toasts read current percentage
- [ ] Verify existing toast functionality (dismiss, auto-dismiss, grouping, actions) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)