### PR TITLE
Fix focus traps for WelcomeModal and PriceComparisonPopup

### DIFF
--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -520,6 +520,13 @@ function PriceComparisonPopup({
   const [showChart, setShowChart] = useState(false);
   const { t } = useTranslation();
   const popupRef = useRef<HTMLDivElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  // Capture the element that triggered the popup so we can return focus on close
+  useEffect(() => {
+    triggerRef.current = document.activeElement;
+  }, []);
 
   useEffect(() => {
     setLoading(true);
@@ -537,14 +544,49 @@ function PriceComparisonPopup({
       });
   }, [materialId]);
 
+  // Return focus to the trigger element when the popup closes
+  const handleClose = useCallback(() => {
+    if (triggerRef.current && triggerRef.current instanceof HTMLElement) {
+      triggerRef.current.focus();
+    }
+    onClose();
+  }, [onClose]);
+
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
-        onClose();
+        handleClose();
       }
     };
     const keyHandler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+
+      // Focus trap: cycle through focusable elements within the popup
+      if (e.key === "Tab" && popupRef.current) {
+        const focusable = popupRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
     };
     document.addEventListener("mousedown", handler);
     document.addEventListener("keydown", keyHandler);
@@ -552,7 +594,12 @@ function PriceComparisonPopup({
       document.removeEventListener("mousedown", handler);
       document.removeEventListener("keydown", keyHandler);
     };
-  }, [onClose]);
+  }, [handleClose]);
+
+  // Focus the close button when the popup opens
+  useEffect(() => {
+    requestAnimationFrame(() => closeBtnRef.current?.focus());
+  }, []);
 
   // Build supplier color map
   const supplierColors = useMemo(() => {
@@ -618,8 +665,10 @@ function PriceComparisonPopup({
             <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2 }}>{materialName}</div>
           </div>
           <button
-            onClick={onClose}
+            ref={closeBtnRef}
+            onClick={handleClose}
             className="popup-close-btn"
+            aria-label={t('dialog.close') || 'Close'}
             style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", padding: "4px 8px", lineHeight: 1, borderRadius: "var(--radius-sm)", transition: "color 0.15s ease, background 0.15s ease", display: "flex", alignItems: "center", justifyContent: "center" }}
             onMouseEnter={(e) => { e.currentTarget.style.color = "var(--text-primary)"; e.currentTarget.style.background = "var(--bg-tertiary)"; }}
             onMouseLeave={(e) => { e.currentTarget.style.color = "var(--text-muted)"; e.currentTarget.style.background = "none"; }}

--- a/web/src/components/OnboardingTour.tsx
+++ b/web/src/components/OnboardingTour.tsx
@@ -119,6 +119,49 @@ export function WelcomeModal({
   onSkip: () => void;
 }) {
   const { t } = useTranslation();
+  const skipBtnRef = useRef<HTMLButtonElement>(null);
+  const startBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Focus trap: cycle between skip and start buttons, Escape to close
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onSkip();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const focusable = [skipBtnRef.current, startBtnRef.current].filter(
+          Boolean
+        ) as HTMLElement[];
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    },
+    [onSkip]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    // Focus the start button by default (primary action)
+    requestAnimationFrame(() => startBtnRef.current?.focus());
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
     <div
@@ -137,6 +180,9 @@ export function WelcomeModal({
       }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="welcome-modal-title"
         style={{
           background: "var(--surface-overlay, var(--bg-elevated))",
           border: "1px solid var(--surface-border-overlay)",
@@ -177,6 +223,7 @@ export function WelcomeModal({
         </div>
 
         <h2
+          id="welcome-modal-title"
           className="heading-display"
           style={{
             fontSize: 24,
@@ -199,6 +246,7 @@ export function WelcomeModal({
 
         <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
           <button
+            ref={skipBtnRef}
             className="btn btn-ghost"
             onClick={onSkip}
             style={{ padding: "10px 20px" }}
@@ -206,6 +254,7 @@ export function WelcomeModal({
             {t("onboarding.welcomeSkip")}
           </button>
           <button
+            ref={startBtnRef}
             className="btn btn-primary"
             onClick={onStart}
             style={{ padding: "10px 24px" }}


### PR DESCRIPTION
## Summary
- **WelcomeModal**: Add focus trap (Tab/Shift+Tab cycles between Skip and Start buttons), Escape key closes modal, auto-focus on Start button, and proper ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-labelledby`)
- **PriceComparisonPopup**: Add focus trap (Tab/Shift+Tab cycles through all focusable elements within the popup), return focus to the trigger element on close, auto-focus on close button when opened, and `aria-label` on the close button

Both implementations follow the same pattern already established in `ConfirmDialog.tsx`.

Fixes #539
Fixes #540

## Test plan
- [ ] Open the WelcomeModal (clear onboarding state) and verify Tab key cycles only between Skip and Start buttons
- [ ] Press Escape in WelcomeModal and verify it closes
- [ ] Open PriceComparisonPopup from a BOM item, verify Tab cycles within the popup
- [ ] Close PriceComparisonPopup and verify focus returns to the compare button that opened it
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `npx vitest run` passes (295 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)