### PR TITLE
Fix ErrorBoundary fallback hardcoded English strings

### DIFF
--- a/web/src/__tests__/ErrorBoundary.test.tsx
+++ b/web/src/__tests__/ErrorBoundary.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
+// Mock useTranslation so t() returns the key (consistent with other tests)
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
 // A component that throws on demand
 function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
   if (shouldThrow) {
@@ -31,9 +38,9 @@ describe("ErrorBoundary", () => {
         <ThrowingChild shouldThrow={true} />
       </ErrorBoundary>
     );
-    expect(screen.getByText("3D Error")).toBeDefined();
+    expect(screen.getByText("errors.errorBoundaryTitle")).toBeDefined();
     expect(screen.getByText("Test explosion")).toBeDefined();
-    expect(screen.getByText("Reset")).toBeDefined();
+    expect(screen.getByText("errors.errorBoundaryReset")).toBeDefined();
   });
 
   it("renders custom fallback when provided", () => {
@@ -68,7 +75,7 @@ describe("ErrorBoundary", () => {
     expect(screen.getByText("Test explosion")).toBeDefined();
 
     // Click reset - onReset callback should fire
-    fireEvent.click(screen.getByText("Reset"));
+    fireEvent.click(screen.getByText("errors.errorBoundaryReset"));
     expect(onReset).toHaveBeenCalledTimes(1);
   });
 

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Component, type ReactNode, type ErrorInfo } from "react";
+import { useTranslation } from "./LocaleProvider";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -11,6 +12,85 @@ interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
+}
+
+/** Functional wrapper so the default fallback can use the useTranslation hook. */
+function DefaultErrorFallback({ error, reset }: { error: Error; reset: () => void }) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "var(--bg-secondary)",
+        borderRadius: "var(--radius-md)",
+      }}
+    >
+      <div style={{ textAlign: "center", padding: 32, maxWidth: 400 }}>
+        <div
+          style={{
+            width: 48,
+            height: 48,
+            margin: "0 auto 16px",
+            borderRadius: "50%",
+            background: "var(--danger-dim)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="var(--danger)"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+        </div>
+        <h3
+          style={{
+            color: "var(--text-primary)",
+            fontSize: 16,
+            fontWeight: 600,
+            marginBottom: 8,
+          }}
+        >
+          {t('errors.errorBoundaryTitle')}
+        </h3>
+        <p
+          style={{
+            color: "var(--text-muted)",
+            fontSize: 13,
+            lineHeight: 1.5,
+            marginBottom: 20,
+          }}
+        >
+          {error.message}
+        </p>
+        <button
+          className="btn btn-primary"
+          onClick={reset}
+          style={{
+            padding: "8px 20px",
+            fontSize: 13,
+          }}
+        >
+          {t('errors.errorBoundaryReset')}
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
@@ -38,79 +118,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         return this.props.fallback({ error: this.state.error, reset: this.reset });
       }
 
-      return (
-        <div
-          style={{
-            width: "100%",
-            height: "100%",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: "var(--bg-secondary)",
-            borderRadius: "var(--radius-md)",
-          }}
-        >
-          <div style={{ textAlign: "center", padding: 32, maxWidth: 400 }}>
-            <div
-              style={{
-                width: 48,
-                height: 48,
-                margin: "0 auto 16px",
-                borderRadius: "50%",
-                background: "var(--danger-dim)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-              }}
-            >
-              <svg
-                width="24"
-                height="24"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="var(--danger)"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <circle cx="12" cy="12" r="10" />
-                <line x1="12" y1="8" x2="12" y2="12" />
-                <line x1="12" y1="16" x2="12.01" y2="16" />
-              </svg>
-            </div>
-            <h3
-              style={{
-                color: "var(--text-primary)",
-                fontSize: 16,
-                fontWeight: 600,
-                marginBottom: 8,
-              }}
-            >
-              3D Error
-            </h3>
-            <p
-              style={{
-                color: "var(--text-muted)",
-                fontSize: 13,
-                lineHeight: 1.5,
-                marginBottom: 20,
-              }}
-            >
-              {this.state.error.message}
-            </p>
-            <button
-              className="btn btn-primary"
-              onClick={this.reset}
-              style={{
-                padding: "8px 20px",
-                fontSize: 13,
-              }}
-            >
-              Reset
-            </button>
-          </div>
-        </div>
-      );
+      return <DefaultErrorFallback error={this.state.error} reset={this.reset} />;
     }
 
     return this.props.children;

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -534,6 +534,8 @@ const translations = {
       projectNotFoundMessage: 'Tama projekti on voitu poistaa tai linkki on virheellinen.',
       connectionLost: 'Yhteys katkesi. Yritetaan uudelleen...',
       reconnected: 'Yhteys palautettu',
+      errorBoundaryTitle: '3D-virhe',
+      errorBoundaryReset: 'Nollaa',
     },
   },
   en: {
@@ -1069,6 +1071,8 @@ const translations = {
       projectNotFoundMessage: 'This project may have been deleted or the link is incorrect.',
       connectionLost: 'Connection lost. Retrying...',
       reconnected: 'Reconnected',
+      errorBoundaryTitle: '3D Error',
+      errorBoundaryReset: 'Reset',
     },
   },
 } as const;


### PR DESCRIPTION
## Summary
- Extracted the default fallback UI from the `ErrorBoundary` class component into a `DefaultErrorFallback` function component that uses the `useTranslation` hook
- Replaced hardcoded "3D Error" and "Reset" strings with `t('errors.errorBoundaryTitle')` and `t('errors.errorBoundaryReset')` calls
- Added `errorBoundaryTitle` / `errorBoundaryReset` keys to both Finnish and English locales in `i18n.ts`
- Updated `ErrorBoundary.test.tsx` to mock `useTranslation` (consistent with other test files) and adjusted assertions to match translation keys

Fixes #538

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 302 vitest tests pass (including 6 ErrorBoundary tests)
- [ ] Manual: trigger an error in the 3D viewport with locale set to `fi`, verify fallback shows "3D-virhe" / "Nollaa"
- [ ] Manual: switch to `en`, verify fallback shows "3D Error" / "Reset"

🤖 Generated with [Claude Code](https://claude.com/claude-code)