### PR TITLE
Fix SceneParamsPanel labels not linked to inputs

### DIFF
--- a/web/src/components/SceneParamsPanel.tsx
+++ b/web/src/components/SceneParamsPanel.tsx
@@ -150,15 +150,15 @@ function ParamSlider({
   return (
     <div className="scene-param-item">
       <div className="scene-param-label-row">
-        <label className="scene-param-label">{param.label}</label>
+        <label className="scene-param-label" htmlFor={`param-${param.name}`}>{param.label}</label>
         <input
+          id={`param-${param.name}`}
           type="number"
           className="scene-param-value"
           value={localValue}
           min={param.min}
           max={param.max}
           step={param.step}
-          aria-label={param.label}
           onChange={(e) => handleInput(parseFloat(e.target.value) || param.min)}
         />
       </div>
@@ -171,6 +171,7 @@ function ParamSlider({
           {displayValue}
         </span>
         <input
+          id={`param-${param.name}-slider`}
           type="range"
           className="scene-param-slider"
           min={param.min}
@@ -178,7 +179,7 @@ function ParamSlider({
           step={param.step}
           value={localValue}
           disabled={param.max === param.min}
-          aria-label={param.label}
+          aria-label={`${param.label} slider`}
           aria-valuemin={param.min}
           aria-valuemax={param.max}
           aria-valuenow={localValue}


### PR DESCRIPTION
## Summary
- Add `htmlFor` attributes to `<label>` elements and matching `id` attributes to `<input>` elements in `SceneParamsPanel`
- Add unique `id` to range slider inputs (`param-{name}-slider`)
- Remove redundant `aria-label` from number inputs (now covered by the programmatic label association)
- Differentiate range slider `aria-label` with " slider" suffix to distinguish from the number input

## Test plan
- [ ] Verify clicking a parameter label focuses the corresponding number input
- [ ] Verify screen reader announces the label when focusing inputs
- [ ] Verify no duplicate IDs when multiple parameters are rendered
- [ ] Run `npx tsc --noEmit` -- passes clean

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)