### PR TITLE
Fix toast overflow badge hardcoded English text

### DIFF
--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
 
 export type ToastType = "success" | "error" | "info" | "warning" | "progress";
 
@@ -65,6 +66,7 @@ const TYPE_STYLES: Record<ToastType, { bg: string; color: string; border: string
 const MAX_VISIBLE = 5;
 
 export function ToastContainer({ toasts, onDismiss }: { toasts: ToastItem[]; onDismiss: (id: number) => void }) {
+  const { t } = useTranslation();
   const grouped = groupToasts(toasts);
   const visible = grouped.slice(0, MAX_VISIBLE);
   const overflowCount = grouped.length - MAX_VISIBLE;
@@ -101,14 +103,14 @@ export function ToastContainer({ toasts, onDismiss }: { toasts: ToastItem[]; onD
             backdropFilter: "blur(12px)",
           }}
         >
-          +{overflowCount} more
+          {t('toast.overflowMore', { count: overflowCount })}
         </div>
       )}
-      {visible.map((t) =>
-        t.type === "progress" ? (
-          <ProgressToast key={t.id} toast={t} onDismiss={onDismiss} />
+      {visible.map((item) =>
+        item.type === "progress" ? (
+          <ProgressToast key={item.id} toast={item} onDismiss={onDismiss} />
         ) : (
-          <ToastMessage key={t.id} toast={t} onDismiss={onDismiss} />
+          <ToastMessage key={item.id} toast={item} onDismiss={onDismiss} />
         )
       )}
     </div>

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -416,6 +416,7 @@ describe("exhaustive i18n key parity", () => {
     "toast.shareFailed", "toast.unshareFailed", "toast.linkCopied",
     "toast.projectUnshared", "toast.loadMaterialsFailed", "toast.loadSuppliersFailed",
     "toast.loadPricingFailed", "toast.materialRemoved", "toast.undo",
+    "toast.overflowMore",
     // editor
     "editor.scene", "editor.materialList", "editor.save", "editor.saved",
     "editor.saving", "editor.unsaved", "editor.export", "editor.exportPdf",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -155,6 +155,7 @@ const translations = {
       loadPricingFailed: 'Hintatietojen lataus epaonnistui',
       materialRemoved: 'Materiaali poistettu',
       undo: 'Kumoa',
+      overflowMore: '+{{count}} lisaa',
     },
     editor: {
       scene: 'Kohtaus',
@@ -693,6 +694,7 @@ const translations = {
       loadPricingFailed: 'Failed to load pricing',
       materialRemoved: 'Material removed',
       undo: 'Undo',
+      overflowMore: '+{{count}} more',
     },
     editor: {
       scene: 'Scene',


### PR DESCRIPTION
## Summary
- Replace hardcoded `+{overflowCount} more` English text in the toast overflow badge with i18n `t('toast.overflowMore', { count })` call
- Add `toast.overflowMore` translation key: Finnish (`+{{count}} lisaa`) and English (`+{{count}} more`)
- Fix variable shadowing where `.map((t) =>` shadowed the `t` translation function by renaming to `item`
- Add new key to the exhaustive i18n test parity list

## Test plan
- [x] `npx tsc --noEmit` passes cleanly
- [x] All 47 i18n tests pass (`vitest run src/lib/__tests__/i18n.test.ts`)
- [ ] Manual: trigger 6+ toasts to see overflow badge renders correctly in both fi and en locales

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)