### PR TITLE
Fix clipboard operations failing silently without fallback

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1109,11 +1109,15 @@ export default function ProjectPage() {
             </button>
             <button
               className="btn btn-ghost save-failure-btn"
-              onClick={() => {
-                navigator.clipboard.writeText(sceneJs);
-                setClipboardCopied(true);
-                toast(t('editor.saveFailedCopied'), "success");
-                setTimeout(() => setClipboardCopied(false), 2000);
+              onClick={async () => {
+                try {
+                  await navigator.clipboard.writeText(sceneJs);
+                  setClipboardCopied(true);
+                  toast(t('editor.saveFailedCopied'), "success");
+                  setTimeout(() => setClipboardCopied(false), 2000);
+                } catch {
+                  toast(t('toast.copyFailed'), "error");
+                }
               }}
             >
               {clipboardCopied ? t('editor.saveFailedCopied') : t('editor.saveFailedCopy')}
@@ -1508,12 +1512,16 @@ export default function ProjectPage() {
               />
               <button
                 className="btn btn-primary"
-                onClick={() => {
+                onClick={async () => {
                   const url = `${window.location.origin}/shared/${shareToken}`;
-                  navigator.clipboard.writeText(url);
-                  setShareCopied(true);
-                  toast(t('toast.linkCopied'), "success");
-                  setTimeout(() => setShareCopied(false), 2000);
+                  try {
+                    await navigator.clipboard.writeText(url);
+                    setShareCopied(true);
+                    toast(t('toast.linkCopied'), "success");
+                    setTimeout(() => setShareCopied(false), 2000);
+                  } catch {
+                    toast(t('toast.copyFailed'), "error");
+                  }
                 }}
                 style={{ padding: "10px 16px", fontSize: 13, fontWeight: 600, flexShrink: 0 }}
               >

--- a/web/src/components/ScreenshotPopover.tsx
+++ b/web/src/components/ScreenshotPopover.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
+import { useToast } from "@/components/ToastProvider";
 
 interface ScreenshotPopoverProps {
   /** Base64 data URL of the captured screenshot */
@@ -21,6 +22,7 @@ export default function ScreenshotPopover({
   const [copied, setCopied] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
+  const { toast } = useToast();
 
   useEffect(() => {
     if (imageDataUrl) {
@@ -82,10 +84,10 @@ export default function ScreenshotPopover({
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       } catch {
-        // Silently fail
+        toast(t('toast.copyFailed'), "error");
       }
     }
-  }, [imageDataUrl]);
+  }, [imageDataUrl, toast, t]);
 
   if (!imageDataUrl) return null;
 

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -417,6 +417,7 @@ describe("exhaustive i18n key parity", () => {
     "toast.projectUnshared", "toast.loadMaterialsFailed", "toast.loadSuppliersFailed",
     "toast.loadPricingFailed", "toast.materialRemoved", "toast.undo",
     "toast.overflowMore",
+    "toast.copyFailed",
     // editor
     "editor.scene", "editor.materialList", "editor.save", "editor.saved",
     "editor.saving", "editor.unsaved", "editor.export", "editor.exportPdf",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -156,6 +156,7 @@ const translations = {
       materialRemoved: 'Materiaali poistettu',
       undo: 'Kumoa',
       overflowMore: '+{{count}} lisaa',
+      copyFailed: 'Kopiointi epäonnistui',
     },
     editor: {
       scene: 'Kohtaus',
@@ -695,6 +696,7 @@ const translations = {
       materialRemoved: 'Material removed',
       undo: 'Undo',
       overflowMore: '+{{count}} more',
+      copyFailed: 'Copy failed',
     },
     editor: {
       scene: 'Scene',


### PR DESCRIPTION
## Summary
- Wrap all `navigator.clipboard.writeText()` calls in try/catch blocks with user-visible error toasts on failure
- Fix share link copy button in project editor showing false success when clipboard API throws
- Fix save-failure "Copy to clipboard" button silently failing without feedback
- Fix ScreenshotPopover inner clipboard fallback silently swallowing errors
- Add `toast.copyFailed` i18n key: "Kopiointi epäonnistui" (fi) / "Copy failed" (en)
- Update exhaustive i18n parity test with new key

## Test plan
- [ ] Open project editor, trigger share dialog, click "Copy link" with clipboard permission denied -- should show error toast
- [ ] Trigger a save failure, click "Copy to clipboard" with clipboard blocked -- should show error toast  
- [ ] Take a screenshot in viewport, click "Copy" with clipboard blocked -- should show error toast
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify i18n tests pass (`npx vitest run src/lib/__tests__/i18n.test.ts`)

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)