### PR TITLE
Auto-scroll code editor to error line (#564)

### DIFF
--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -307,6 +307,19 @@ export default function SceneEditor({
     ? errorLine - 1
     : -1;
 
+  /* ── Auto-scroll to error line when it changes ───────────────── */
+  useEffect(() => {
+    if (errorLineIdx < 0) return;
+    const ta = textareaRef.current;
+    if (!ta) return;
+    // Scroll so the error line is roughly centred in the visible area
+    const lineHeight = 22.1;
+    const paddingTop = 20;
+    const targetScrollTop = paddingTop + errorLineIdx * lineHeight - ta.clientHeight / 2 + lineHeight;
+    ta.scrollTop = Math.max(0, targetScrollTop);
+    syncScroll();
+  }, [errorLineIdx, syncScroll]);
+
   /* ── Sync find-highlight overlay scroll with textarea ─────────── */
   useEffect(() => {
     const ta = textareaRef.current;


### PR DESCRIPTION
## Summary
- When a scene evaluation error occurs with a known line number, the code editor now auto-scrolls to centre the error line in the viewport
- The error line highlight (red background) and gutter styling (red bold line number) were already present but invisible when the error was outside the scroll area
- Adds a `useEffect` watching `errorLineIdx` that scrolls the textarea and syncs the gutter/overlay layers

## Test plan
- [ ] Write a scene script longer than the editor viewport height
- [ ] Introduce a syntax error on a line that is scrolled out of view
- [ ] Verify the editor auto-scrolls to show the error line with its red highlight
- [ ] Fix the error and verify the decoration clears and no spurious scroll happens

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)