### PR TITLE
Add password strength feedback to registration form

### DIFF
--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useState, useMemo, type ReactNode } from "react";
 import { api, setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
 import { useAnalytics } from "@/hooks/useAnalytics";
@@ -29,6 +29,21 @@ export default function LoginForm({
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const { t } = useTranslation();
   const { track } = useAnalytics();
+
+  const passwordStrength = useMemo(() => {
+    if (!password) return null;
+    const hasLength = password.length >= 8;
+    const hasNumber = /\d/.test(password);
+    const hasUpper = /[A-Z]/.test(password);
+    const hasSpecial = /[^A-Za-z0-9]/.test(password);
+    if (hasLength && hasNumber && hasUpper && hasSpecial) {
+      return { level: "strong" as const, label: t("auth.passwordStrong"), color: "var(--forest)", width: "100%" };
+    }
+    if (hasLength && hasNumber) {
+      return { level: "medium" as const, label: t("auth.passwordMedium"), color: "var(--amber)", width: "66%" };
+    }
+    return { level: "weak" as const, label: t("auth.passwordWeak"), color: "var(--danger)", width: "33%" };
+  }, [password, t]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -198,8 +213,35 @@ export default function LoginForm({
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
+                minLength={isRegister ? 8 : undefined}
                 autoComplete={isRegister ? "new-password" : "current-password"}
               />
+              {isRegister && password && passwordStrength && (
+                <div style={{ marginTop: 8 }}>
+                  <div style={{
+                    height: 4,
+                    borderRadius: 2,
+                    background: "var(--border)",
+                    overflow: "hidden",
+                  }}>
+                    <div style={{
+                      height: "100%",
+                      width: passwordStrength.width,
+                      background: passwordStrength.color,
+                      borderRadius: 2,
+                      transition: "width 0.25s ease, background 0.25s ease",
+                    }} />
+                  </div>
+                  <div style={{
+                    marginTop: 4,
+                    fontSize: 12,
+                    color: passwordStrength.color,
+                    fontWeight: 500,
+                  }}>
+                    {passwordStrength.label}
+                  </div>
+                </div>
+              )}
               {!isRegister && (
                 <div style={{ marginTop: 8, textAlign: "right" }}>
                   <a

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -385,6 +385,7 @@ describe("exhaustive i18n key parity", () => {
     "auth.resetPasswordNewPlaceholder", "auth.resetPasswordConfirm",
     "auth.resetPasswordConfirmPlaceholder", "auth.resetPasswordSubmit",
     "auth.resetPasswordSuccess", "auth.resetPasswordMismatch", "auth.resetPasswordInvalid",
+    "auth.passwordWeak", "auth.passwordMedium", "auth.passwordStrong",
     // brand
     "brand.tagline", "brand.trustProducts", "brand.trustSuppliers", "brand.trustFree",
     "brand.description", "brand.featureMaterials", "brand.featureMaterialsDesc",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -43,6 +43,9 @@ const translations = {
       resetPasswordSuccess: 'Salasana vaihdettu. Voit nyt kirjautua uudella salasanallasi.',
       resetPasswordMismatch: 'Salasanat eivat tasmaa',
       resetPasswordInvalid: 'Virheellinen tai vanhentunut nollauslinkki',
+      passwordWeak: 'Heikko',
+      passwordMedium: 'Keskiverto',
+      passwordStrong: 'Vahva',
     },
     brand: {
       tagline: 'N\u00c4E TALOSI \u00b7 MUUTA \u00b7 RAKENNA',
@@ -582,6 +585,9 @@ const translations = {
       resetPasswordSuccess: 'Password updated. You can now sign in with your new password.',
       resetPasswordMismatch: 'Passwords do not match',
       resetPasswordInvalid: 'Invalid or expired reset link',
+      passwordWeak: 'Weak',
+      passwordMedium: 'Medium',
+      passwordStrong: 'Strong',
     },
     brand: {
       tagline: 'SEE YOUR HOUSE \u00b7 CHANGE IT \u00b7 BUILD',


### PR DESCRIPTION
## Summary
- Add `minLength={8}` to the registration password input to match the reset-password form
- Add a visual password strength bar (colored fill: red/weak, amber/medium, green/strong) shown only during registration when the user has typed a password
- Strength criteria: length >= 8 (weak), + has digit (medium), + has uppercase + special char (strong)
- Add bilingual i18n strings: `auth.passwordWeak` / `auth.passwordMedium` / `auth.passwordStrong` in Finnish and English
- Update exhaustive i18n key parity test to include the new keys

Closes #556

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] All 47 i18n tests pass (`npx vitest run src/lib/__tests__/i18n.test.ts`)
- [ ] Manual: open registration form, verify strength bar appears as you type
- [ ] Manual: verify bar transitions: red < 8 chars, amber with 8+ chars and a digit, green with 8+ chars, digit, uppercase, and special char
- [ ] Manual: verify `minLength` prevents form submission with < 8 char password
- [ ] Manual: verify strength bar does not appear on login form

🤖 Generated with [Claude Code](https://claude.com/claude-code)