### PR TITLE
Fix ScreenshotPopover missing dialog role and accessible name

### DIFF
--- a/web/src/components/ScreenshotPopover.tsx
+++ b/web/src/components/ScreenshotPopover.tsx
@@ -26,6 +26,10 @@ export default function ScreenshotPopover({
     if (imageDataUrl) {
       requestAnimationFrame(() => setVisible(true));
       setCopied(false);
+      // Move focus into the popover when it opens
+      requestAnimationFrame(() => {
+        popoverRef.current?.focus();
+      });
     } else {
       setVisible(false);
     }
@@ -92,6 +96,9 @@ export default function ScreenshotPopover({
   return (
     <div
       ref={popoverRef}
+      role="dialog"
+      aria-label={t("screenshot.dialogTitle")}
+      tabIndex={-1}
       style={{
         position: "absolute",
         top: 48,

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -510,7 +510,7 @@ describe("exhaustive i18n key parity", () => {
     "legal.termsLiability", "legal.termsLiabilityBody", "legal.termsChanges",
     "legal.termsChangesBody",
     // screenshot
-    "screenshot.download", "screenshot.copy", "screenshot.copied",
+    "screenshot.dialogTitle", "screenshot.download", "screenshot.copy", "screenshot.copied",
     // commandPalette
     "commandPalette.title", "commandPalette.placeholder", "commandPalette.noResults",
     "commandPalette.navigate", "commandPalette.execute", "commandPalette.close",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -459,6 +459,7 @@ const translations = {
       termsChangesBody: 'Voimme paivittaa naita ehtoja. Olennaisista muutoksista ilmoitetaan sahkopostitse. Jatkamalla palvelun kayttoa hyvaksyt muutokset.',
     },
     screenshot: {
+      dialogTitle: 'Kuvakaappaus',
       download: 'Lataa',
       copy: 'Kopioi',
       copied: 'Kopioitu!',
@@ -998,6 +999,7 @@ const translations = {
       termsChangesBody: 'We may update these terms. Material changes will be communicated via email. Continued use of the service constitutes acceptance of changes.',
     },
     screenshot: {
+      dialogTitle: 'Screenshot',
       download: 'Download',
       copy: 'Copy',
       copied: 'Copied!',


### PR DESCRIPTION
## Summary
- Add `role="dialog"` to the ScreenshotPopover container so screen readers announce it correctly
- Add `aria-label` using new i18n key `screenshot.dialogTitle` ("Kuvakaappaus" / "Screenshot")
- Add `tabIndex={-1}` and programmatic focus management so focus moves into the popover when opened
- Update exhaustive i18n key parity test to cover the new key

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 47 i18n tests pass (`npx vitest run src/lib/__tests__/i18n.test.ts`)
- [ ] Verify screen reader announces "Screenshot" dialog when popover opens
- [ ] Verify focus moves to the popover container on open
- [ ] Verify Escape key still closes the popover

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)