### PR TITLE
Fix toast dismiss button: 44px touch target and i18n aria-label (#598)

### DIFF
--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -253,37 +253,47 @@ function ToastMessage({ toast, onDismiss }: { toast: ToastItem; onDismiss: (id: 
           {toast.action.label}
         </button>
       )}
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          dismiss();
-        }}
-        style={{
-          background: "none",
-          border: "none",
-          color: style.color,
-          opacity: 0.5,
-          cursor: "pointer",
-          padding: 2,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flexShrink: 0,
-          transition: "opacity 0.15s ease",
-        }}
-        onMouseEnter={(e) => {
-          (e.currentTarget as HTMLElement).style.opacity = "1";
-        }}
-        onMouseLeave={(e) => {
-          (e.currentTarget as HTMLElement).style.opacity = "0.5";
-        }}
-        aria-label="Dismiss"
-      >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M18 6L6 18M6 6l12 12" />
-        </svg>
-      </button>
+      <DismissButton style={style} onDismiss={dismiss} />
     </div>
+  );
+}
+
+function DismissButton({ style, onDismiss }: { style: { color: string }; onDismiss: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onDismiss();
+      }}
+      style={{
+        background: "none",
+        border: "none",
+        color: style.color,
+        opacity: 0.5,
+        cursor: "pointer",
+        padding: 2,
+        minWidth: 44,
+        minHeight: 44,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        transition: "opacity 0.15s ease",
+        margin: "-12px -14px -12px 0",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLElement).style.opacity = "1";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.opacity = "0.5";
+      }}
+      aria-label={t('toast.dismiss')}
+    >
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 6L6 18M6 6l12 12" />
+      </svg>
+    </button>
   );
 }
 

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -417,7 +417,7 @@ describe("exhaustive i18n key parity", () => {
     "toast.shareFailed", "toast.unshareFailed", "toast.linkCopied",
     "toast.projectUnshared", "toast.loadMaterialsFailed", "toast.loadSuppliersFailed",
     "toast.loadPricingFailed", "toast.materialRemoved", "toast.undo",
-    "toast.overflowMore",
+    "toast.overflowMore", "toast.dismiss",
     "toast.copyFailed",
     // editor
     "editor.scene", "editor.materialList", "editor.save", "editor.saved",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -160,6 +160,7 @@ const translations = {
       undo: 'Kumoa',
       overflowMore: '+{{count}} lisaa',
       copyFailed: 'Kopiointi epäonnistui',
+      dismiss: 'Sulje',
     },
     editor: {
       scene: 'Kohtaus',
@@ -707,6 +708,7 @@ const translations = {
       undo: 'Undo',
       overflowMore: '+{{count}} more',
       copyFailed: 'Copy failed',
+      dismiss: 'Dismiss',
     },
     editor: {
       scene: 'Scene',


### PR DESCRIPTION
## Summary
- Increase toast dismiss button touch target from ~18px to 44px minimum (WCAG 2.5.8) using `min-width`/`min-height` with negative margins to preserve layout
- Replace hardcoded `aria-label="Dismiss"` with `t('toast.dismiss')` for Finnish/English i18n support
- Add `toast.dismiss` key to both locales (fi: "Sulje", en: "Dismiss") and update key parity test

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 302 vitest tests pass (including 47 i18n parity tests)
- [ ] Visual check: dismiss button clickable area is 44x44px, icon remains 14x14px centered
- [ ] Verify Finnish locale shows "Sulje" in screen reader for dismiss button

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)