### PR TITLE
Show toggle state in command palette commands (#563)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3952,6 +3952,38 @@ select:focus {
   color: var(--text-muted);
 }
 
+.cmd-palette-item-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cmd-palette-toggle-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  color: var(--text-muted);
+  transition: color var(--transition-micro);
+}
+
+.cmd-palette-toggle-on {
+  color: var(--amber);
+}
+
+.cmd-palette-toggle-off-label {
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.5;
+}
+
+.cmd-palette-item[data-selected="true"] .cmd-palette-toggle-on {
+  color: var(--amber);
+}
+
 /* Light theme overrides */
 [data-theme="light"] .cmd-palette {
   background: rgba(255, 255, 255, 0.88);

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -104,7 +104,7 @@ export default function ProjectPage() {
   const projectId = params.id as string;
   const { toast } = useToast();
   const { t, locale } = useTranslation();
-  const { toggle: toggleTheme } = useTheme();
+  const { toggle: toggleTheme, resolved: resolvedTheme } = useTheme();
   const { track } = useAnalytics();
   const { markCodeEditor, markChat } = useEditorSession();
 
@@ -486,6 +486,7 @@ export default function ProjectPage() {
         labelSecondaryKey: "commandPalette.toggleWireframeEn",
         icon: icon("M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"),
         action: () => setWireframe((v) => !v),
+        isActive: wireframe,
       },
       {
         id: "reset-camera",
@@ -511,6 +512,7 @@ export default function ProjectPage() {
           </svg>
         ),
         action: () => { if (!showCode) markCodeEditor(); setShowCode((v) => !v); },
+        isActive: showCode,
       },
       {
         id: "toggle-bom",
@@ -528,6 +530,7 @@ export default function ProjectPage() {
           </svg>
         ),
         action: () => setShowBom((v) => !v),
+        isActive: showBom,
       },
       {
         id: "export-pdf",
@@ -638,6 +641,7 @@ export default function ProjectPage() {
           </svg>
         ),
         action: toggleTheme,
+        isActive: resolvedTheme === "dark",
       },
       {
         id: "show-shortcuts",
@@ -682,9 +686,10 @@ export default function ProjectPage() {
           </svg>
         ),
         action: () => setShowDocs((v) => !v),
+        isActive: showDocs,
       },
     ];
-  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, markCodeEditor]);
+  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, markCodeEditor, wireframe, showBom, showDocs, resolvedTheme]);
 
   const handleViewportReset = useCallback(() => {
     setSceneJs(DEFAULT_SCENE);

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -21,6 +21,8 @@ export interface Command {
   action: () => void;
   /** Category for grouped display */
   category?: CommandCategory;
+  /** Whether this toggle command is currently active/on (undefined = not a toggle) */
+  isActive?: boolean;
 }
 
 const RECENT_COMMANDS_KEY = "helscoop_recent_commands";
@@ -396,11 +398,29 @@ export default function CommandPalette({
                     )}
                   </div>
                 </div>
-                {cmd.shortcut && (
-                  <kbd className="cmd-palette-kbd">
-                    {formatShortcutDisplay(cmd.shortcut)}
-                  </kbd>
-                )}
+                <div className="cmd-palette-item-right">
+                  {cmd.isActive !== undefined && (
+                    <span
+                      className={`cmd-palette-toggle-state${cmd.isActive ? " cmd-palette-toggle-on" : ""}`}
+                      aria-label={cmd.isActive ? t("commandPalette.stateOn") : t("commandPalette.stateOff")}
+                    >
+                      {cmd.isActive ? (
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      ) : (
+                        <span className="cmd-palette-toggle-off-label">
+                          {t("commandPalette.stateOff")}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  {cmd.shortcut && (
+                    <kbd className="cmd-palette-kbd">
+                      {formatShortcutDisplay(cmd.shortcut)}
+                    </kbd>
+                  )}
+                </div>
               </button>
             );
           })}

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -523,6 +523,7 @@ describe("exhaustive i18n key parity", () => {
     "commandPalette.showShortcuts", "commandPalette.showShortcutsEn",
     "commandPalette.save", "commandPalette.saveEn",
     "commandPalette.showDocs", "commandPalette.showDocsEn",
+    "commandPalette.stateOn", "commandPalette.stateOff",
     // validation
     "validation.unmatchedCloser", "validation.unmatchedOpener", "validation.typoDetected",
     "validation.undefinedIdentifier", "validation.emptyScene", "validation.tooManyObjects",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -481,6 +481,8 @@ const translations = {
       categoryScene: 'Nakyma',
       categoryProject: 'Projekti',
       categoryPreferences: 'Asetukset',
+      stateOn: 'Paalla',
+      stateOff: 'Pois',
     },
     validation: {
       unmatchedCloser: 'Sulkumerkilla {{char}} ei ole paria (rivi {{line}})',
@@ -990,6 +992,8 @@ const translations = {
       categoryScene: 'Scene',
       categoryProject: 'Project',
       categoryPreferences: 'Preferences',
+      stateOn: 'On',
+      stateOff: 'Off',
     },
     validation: {
       unmatchedCloser: 'Unmatched closing {{char}} on line {{line}}',


### PR DESCRIPTION
## Summary
- Add `isActive` optional field to the `Command` interface for toggle commands
- Display an amber checkmark icon when a toggle is active, and a subtle "OFF" label when inactive
- Wire up state for all five toggle commands: wireframe, code editor, BOM panel, dark theme, and docs
- Add i18n keys `commandPalette.stateOn` / `commandPalette.stateOff` in both Finnish and English
- Update i18n key parity test list

## Test plan
- [x] `npx tsc --noEmit` passes (no new errors)
- [x] `npx vitest run` passes (251/251, including i18n parity)
- [ ] Open command palette (Cmd+K), verify toggle commands show "OFF" by default
- [ ] Toggle wireframe on, reopen palette, verify checkmark appears
- [ ] Toggle BOM off, reopen palette, verify "OFF" label appears
- [ ] Switch theme, reopen palette, verify theme toggle reflects new state

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)