### PR TITLE
Fix KeyboardShortcutsHelp close button a11y (#599)

### DIFF
--- a/web/src/components/KeyboardShortcutsHelp.tsx
+++ b/web/src/components/KeyboardShortcutsHelp.tsx
@@ -182,7 +182,7 @@ export default function KeyboardShortcutsHelp({
           </h2>
           <button
             ref={closeButtonRef}
-            aria-label="Close"
+            aria-label={t("shortcuts.close")}
             onClick={onClose}
             style={{
               background: "none",
@@ -191,6 +191,11 @@ export default function KeyboardShortcutsHelp({
               cursor: "pointer",
               fontSize: 18,
               padding: "4px 8px",
+              minWidth: 44,
+              minHeight: 44,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
               lineHeight: 1,
             }}
           >

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -457,7 +457,7 @@ describe("exhaustive i18n key parity", () => {
     "share.viewerTitle", "share.notFound", "share.notFoundDesc", "share.readOnly",
     "share.signUpCta", "share.materials", "share.total",
     // shortcuts
-    "shortcuts.title", "shortcuts.save", "shortcuts.toggleBom", "shortcuts.applyCode",
+    "shortcuts.title", "shortcuts.close", "shortcuts.save", "shortcuts.toggleBom", "shortcuts.applyCode",
     "shortcuts.closePanel", "shortcuts.showShortcuts", "shortcuts.undo", "shortcuts.redo",
     "shortcuts.commandPalette", "shortcuts.escToClose",
     // settings

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -286,6 +286,7 @@ const translations = {
     },
     shortcuts: {
       title: 'Pikanappaimet',
+      close: 'Sulje',
       save: 'Tallenna',
       toggleBom: 'Nayta/piilota materiaalilista',
       applyCode: 'Suorita koodi',
@@ -834,6 +835,7 @@ const translations = {
     },
     shortcuts: {
       title: 'Keyboard shortcuts',
+      close: 'Close',
       save: 'Save',
       toggleBom: 'Toggle material list',
       applyCode: 'Apply code',


### PR DESCRIPTION
## Summary
- Replace hardcoded `aria-label="Close"` with translated `t('shortcuts.close')` for i18n support
- Add `minWidth: 44, minHeight: 44` with flexbox centering to meet WCAG 2.5.5 touch target guidelines
- Add `shortcuts.close` translation key in both Finnish ('Sulje') and English ('Close')
- Update i18n key parity test list

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)