### PR TITLE
Fix ViewportContextMenu hardcoded aria-label (#600)

### DIFF
--- a/web/src/components/ViewportContextMenu.tsx
+++ b/web/src/components/ViewportContextMenu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
 
 export interface ContextMenuItem {
   id: string;
@@ -24,6 +25,7 @@ const RING_RADIUS = 72;
 const BUTTON_SIZE = 44;
 
 export default function ViewportContextMenu({ items, position, onClose }: ViewportContextMenuProps) {
+  const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [focusedIndex, setFocusedIndex] = useState(0);
@@ -101,7 +103,7 @@ export default function ViewportContextMenu({ items, position, onClose }: Viewpo
     <div
       ref={menuRef}
       role="menu"
-      aria-label="Viewport actions"
+      aria-label={t('viewport.contextMenuLabel')}
       style={{
         position: "fixed",
         left: adjustedX,

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -539,6 +539,8 @@ describe("exhaustive i18n key parity", () => {
     "errors.tryAgain", "errors.backToDashboard", "errors.showDetails", "errors.hideDetails",
     "errors.projectNotFoundTitle", "errors.projectNotFoundMessage",
     "errors.connectionLost", "errors.reconnected", "errors.retryNow",
+    // viewport
+    "viewport.contextMenuLabel",
   ];
 
   it("every Finnish key has a corresponding English translation", () => {

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -549,6 +549,9 @@ const translations = {
       errorBoundaryReset: 'Nollaa',
       retryNow: 'Yrita nyt',
     },
+    viewport: {
+      contextMenuLabel: 'Nakyman toiminnot',
+    },
   },
   en: {
     nav: {
@@ -1097,6 +1100,9 @@ const translations = {
       errorBoundaryTitle: '3D Error',
       errorBoundaryReset: 'Reset',
       retryNow: 'Retry now',
+    },
+    viewport: {
+      contextMenuLabel: 'Viewport actions',
     },
   },
 } as const;


### PR DESCRIPTION
## Summary
- Replace hardcoded `aria-label="Viewport actions"` in `ViewportContextMenu.tsx` with `t('viewport.contextMenuLabel')` so it respects the active locale
- Add `viewport.contextMenuLabel` translations for Finnish ("Nakyman toiminnot") and English ("Viewport actions")
- Update the exhaustive i18n key parity test with the new key

Closes #600

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 47 i18n tests pass, including key parity checks
- [ ] Verify aria-label renders in Finnish when locale is `fi`
- [ ] Verify aria-label renders in English when locale is `en`

🤖 Generated with [Claude Code](https://claude.com/claude-code)