### PR TITLE
Fix ConnectionBanner retry button focus ring and touch target (#604)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4145,3 +4145,56 @@ select:focus {
 [data-tooltip]:hover::before {
   opacity: 1;
 }
+
+/* === ConnectionBanner === */
+.connection-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: center;
+  font-family: var(--font-body);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background 0.3s ease;
+}
+
+.connection-banner--error {
+  background: var(--amber);
+  color: var(--bg-primary);
+}
+
+.connection-banner--ok {
+  background: var(--forest);
+  color: var(--text-primary);
+}
+
+.connection-banner-retry {
+  margin-left: 8px;
+  min-height: 44px;
+  padding: 8px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-body);
+  background: var(--bg-primary);
+  color: var(--amber);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.connection-banner-retry:hover {
+  background: var(--bg-hover);
+}
+
+.connection-banner-retry:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring), var(--focus-ring-offset);
+}

--- a/web/src/components/ConnectionBanner.tsx
+++ b/web/src/components/ConnectionBanner.tsx
@@ -149,28 +149,9 @@ export default function ConnectionBanner() {
 
   return (
     <div
-      className="anim-up"
+      className={`anim-up connection-banner ${isReconnected ? "connection-banner--ok" : "connection-banner--error"}`}
       role="status"
       aria-live="polite"
-      style={{
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        zIndex: 100,
-        padding: "8px 16px",
-        background: isReconnected ? "var(--forest)" : "var(--amber)",
-        color: isReconnected ? "var(--text-primary)" : "var(--bg-primary)",
-        fontSize: 13,
-        fontWeight: 500,
-        textAlign: "center",
-        fontFamily: "var(--font-body)",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 8,
-        transition: "background 0.3s ease",
-      }}
     >
       {!isReconnected && (
         <svg
@@ -210,18 +191,7 @@ export default function ConnectionBanner() {
       {!isReconnected && (
         <button
           onClick={handleRetryNow}
-          style={{
-            marginLeft: 8,
-            padding: "2px 10px",
-            fontSize: 12,
-            fontWeight: 600,
-            fontFamily: "var(--font-body)",
-            background: "var(--bg-primary)",
-            color: "var(--amber)",
-            border: "none",
-            borderRadius: 4,
-            cursor: "pointer",
-          }}
+          className="connection-banner-retry"
         >
           {t("errors.retryNow")}
         </button>


### PR DESCRIPTION
## Summary
- Move retry button inline styles to CSS classes (`connection-banner`, `connection-banner-retry`)
- Add `:focus-visible` ring using design system tokens (`--focus-ring`, `--focus-ring-offset`)
- Set `min-height: 44px` on retry button for WCAG 2.5.5 touch target compliance (was ~16px)
- Move banner wrapper inline styles to `.connection-banner` / `--ok` / `--error` CSS classes

Closes #604

## Test plan
- [ ] Verify retry button shows amber focus ring when tabbed to with keyboard
- [ ] Verify retry button is at least 44px tall on mobile/touch
- [ ] Verify banner appearance unchanged (amber for error, forest for reconnected)
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` — 398/398 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)