### PR TITLE
Fix LanguageSwitcher and ThemeToggle touch targets (#602)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1146,7 +1146,11 @@ body::before {
   background: transparent;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  padding: 4px 8px;
+  padding: 10px 12px;
+  min-height: 44px;
+  min-width: 44px;
+  box-sizing: border-box;
+  justify-content: center;
   cursor: pointer;
   font-size: 11px;
   font-family: var(--font-mono);

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -3,12 +3,12 @@
 import { useTranslation } from "@/components/LocaleProvider";
 
 export function LanguageSwitcher() {
-  const { locale, setLocale } = useTranslation();
+  const { locale, setLocale, t } = useTranslation();
 
   return (
     <button
       className="lang-switch"
-      aria-label="Switch language"
+      aria-label={t("aria.switchLanguage")}
       onClick={() => setLocale(locale === "fi" ? "en" : "fi")}
     >
       <span style={{ opacity: locale === "fi" ? 1 : 0.4, transition: "opacity 0.15s ease" }}>FI</span>

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 import { useTheme } from "@/components/ThemeProvider";
+import { useTranslation } from "@/components/LocaleProvider";
 
 export function ThemeToggle() {
   const { theme, toggle } = useTheme();
+  const { t } = useTranslation();
 
-  const label =
-    theme === "dark" ? "Dark" : theme === "light" ? "Light" : "Auto";
+  const labelKey =
+    theme === "dark"
+      ? "aria.themeDark"
+      : theme === "light"
+        ? "aria.themeLight"
+        : "aria.themeAuto";
+  const label = t(labelKey);
 
   return (
     <button
       className="lang-switch"
       onClick={toggle}
-      title={`Theme: ${label}`}
-      aria-label={`Theme: ${label}`}
+      title={label}
+      aria-label={label}
       style={{ gap: 5 }}
     >
       {theme === "dark" && (

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -533,6 +533,8 @@ describe("exhaustive i18n key parity", () => {
     "validation.unmatchedCloser", "validation.unmatchedOpener", "validation.typoDetected",
     "validation.undefinedIdentifier", "validation.emptyScene", "validation.tooManyObjects",
     "validation.farFromOrigin", "validation.invalidDimension", "validation.warningsTitle",
+    // aria
+    "aria.switchLanguage", "aria.themeDark", "aria.themeLight", "aria.themeAuto",
     // errors
     "errors.notFoundTitle", "errors.notFoundMessage", "errors.backToProjects",
     "errors.searchAddress", "errors.serverErrorTitle", "errors.serverErrorMessage",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -530,6 +530,12 @@ const translations = {
       resend: 'Laheta uudelleen',
       dismiss: 'Sulje',
     },
+    aria: {
+      switchLanguage: 'Vaihda kieli',
+      themeDark: 'Teema: Tumma',
+      themeLight: 'Teema: Vaalea',
+      themeAuto: 'Teema: Automaattinen',
+    },
     errors: {
       notFoundTitle: 'Sivua ei loytynyt',
       notFoundMessage: 'Etsimasi sivu ei ole olemassa tai se on siirretty.',
@@ -1078,6 +1084,12 @@ const translations = {
       resent: 'Sent!',
       resend: 'Resend',
       dismiss: 'Dismiss',
+    },
+    aria: {
+      switchLanguage: 'Switch language',
+      themeDark: 'Theme: Dark',
+      themeLight: 'Theme: Light',
+      themeAuto: 'Theme: Auto',
     },
     errors: {
       notFoundTitle: 'Page not found',


### PR DESCRIPTION
## Summary
- Increase `.lang-switch` CSS touch targets to 44px minimum (padding: 10px 12px, min-height/min-width: 44px) to meet WCAG 2.5.8
- Replace hardcoded English `aria-label="Switch language"` in LanguageSwitcher with i18n `t("aria.switchLanguage")`
- Replace hardcoded English `aria-label` / `title` in ThemeToggle with i18n `t("aria.themeDark/themeLight/themeAuto")`
- Add `aria` namespace with 4 new keys in both Finnish and English translations
- Update i18n key parity test to cover new keys

Closes #602

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — all 398 tests pass (including i18n parity)
- [ ] Verify LanguageSwitcher and ThemeToggle buttons are at least 44px tall in browser
- [ ] Verify aria-labels switch correctly between Finnish and English

🤖 Generated with [Claude Code](https://claude.com/claude-code)