### PR TITLE
Fix ProjectCard action buttons: aria-labels and 44px touch targets (#606)

### DIFF
--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -78,7 +78,7 @@ export default function ProjectCard({
           </div>
         </div>
         <div className="project-card-actions" onClick={(e) => e.stopPropagation()} style={{ marginTop: 10 }}>
-          <button className="btn btn-ghost" style={{ padding: "5px 10px", fontSize: 11, gap: 4 }} onClick={() => (router.push(`/project/${project.id}`))}>
+          <button className="btn btn-ghost" style={{ minWidth: 44, minHeight: 44, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "6px 12px", fontSize: 11, gap: 4 }} aria-label={t('project.openAriaLabel', { name: project.name })} onClick={() => (router.push(`/project/${project.id}`))}>
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
               <polyline points="15 3 21 3 21 9" />
@@ -86,14 +86,14 @@ export default function ProjectCard({
             </svg>
             {t('project.open')}
           </button>
-          <button className="btn btn-ghost" style={{ padding: "5px 10px", fontSize: 11, gap: 4 }} onClick={() => onDuplicate(project.id)}>
+          <button className="btn btn-ghost" style={{ minWidth: 44, minHeight: 44, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "6px 12px", fontSize: 11, gap: 4 }} aria-label={t('project.copyAriaLabel', { name: project.name })} onClick={() => onDuplicate(project.id)}>
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
               <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
             </svg>
             {t('project.copy')}
           </button>
-          <button className="btn btn-danger" style={{ padding: "5px 10px", fontSize: 11, gap: 4 }} onClick={() => onDelete(project.id)}>
+          <button className="btn btn-danger" style={{ minWidth: 44, minHeight: 44, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "6px 12px", fontSize: 11, gap: 4 }} aria-label={t('project.deleteAriaLabel', { name: project.name })} onClick={() => onDelete(project.id)}>
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <polyline points="3 6 5 6 21 6" />
               <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -408,6 +408,7 @@ describe("exhaustive i18n key parity", () => {
     "project.sortByCreated", "project.sortByCost", "project.noSearchResults",
     "project.noSearchResultsDesc", "project.emptyTitle", "project.emptyHint",
     "project.emptyCta", "project.noSearchResultsCta",
+    "project.openAriaLabel", "project.copyAriaLabel", "project.deleteAriaLabel",
     // toast
     "toast.projectCreated", "toast.projectDeleted", "toast.projectDuplicated",
     "toast.templateCreated", "toast.saved", "toast.bomExported",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -123,6 +123,9 @@ const translations = {
       permanentDelete: 'Poista pysyvasti',
       showTrash: 'Nayta roskakori',
       hideTrash: 'Piilota roskakori',
+      openAriaLabel: 'Avaa projekti {{name}}',
+      copyAriaLabel: 'Kopioi projekti {{name}}',
+      deleteAriaLabel: 'Poista projekti {{name}}',
     },
     toast: {
       projectCreated: 'Projekti luotu',
@@ -675,6 +678,9 @@ const translations = {
       permanentDelete: 'Delete permanently',
       showTrash: 'Show trash',
       hideTrash: 'Hide trash',
+      openAriaLabel: 'Open project {{name}}',
+      copyAriaLabel: 'Copy project {{name}}',
+      deleteAriaLabel: 'Delete project {{name}}',
     },
     toast: {
       projectCreated: 'Project created',


### PR DESCRIPTION
## Summary
- Add descriptive `aria-label` attributes to ProjectCard Open/Copy/Delete buttons with project name context via i18n (e.g. "Open project Garage 6x4m" / "Avaa projekti Garage 6x4m")
- Increase button touch targets from ~22x26px to minimum 44x44px (`minWidth: 44, minHeight: 44`) with `inline-flex` centering, meeting WCAG 2.5.8 Target Size
- Add new i18n keys (`project.openAriaLabel`, `project.copyAriaLabel`, `project.deleteAriaLabel`) in both Finnish and English, and update exhaustive key parity test

Closes #606

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (398 tests, including i18n key parity)
- [ ] Visually verify buttons are at least 44x44px on mobile viewport
- [ ] Verify aria-labels read correctly in screen reader (e.g. VoiceOver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)