### PR TITLE
Fix settings page: CSS variable for danger-zone border and stagger delay on Account card

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -39,6 +39,7 @@
 
   --danger: #ef4444;
   --danger-dim: rgba(239, 68, 68, 0.1);
+  --danger-border: rgba(239, 68, 68, 0.2);
 
   --border: rgba(255, 255, 255, 0.06);
   --border-strong: rgba(255, 255, 255, 0.1);
@@ -138,6 +139,7 @@
 
   --danger: #dc2626;
   --danger-dim: rgba(220, 38, 38, 0.06);
+  --danger-border: rgba(220, 38, 38, 0.12);
 
   --warning: #ca8a04;
   --warning-dim: rgba(202, 138, 4, 0.08);

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -473,7 +473,7 @@ export default function SettingsPage() {
 
         {/* Account section */}
         <div
-          className="card anim-up delay-3 settings-card"
+          className="card anim-up delay-4 settings-card"
         >
           <h2
             className="heading-display"
@@ -536,7 +536,7 @@ export default function SettingsPage() {
               padding: "16px 20px",
               borderRadius: "var(--radius-sm)",
               background: "var(--danger-dim)",
-              border: "1px solid rgba(199, 95, 95, 0.12)",
+              border: "1px solid var(--danger-border)",
               marginBottom: 16,
             }}
           >


### PR DESCRIPTION
## Summary

- Replace hardcoded `rgba(199, 95, 95, 0.12)` border on the danger zone in the Account card with a new `--danger-border` CSS variable, defined in `globals.css` for both dark (`rgba(239, 68, 68, 0.2)`) and light (`rgba(220, 38, 38, 0.12)`) themes — consistent with the existing `--warning-border` pattern
- Change the Account card from `delay-3` to `delay-4` so it staggers after the Legal card instead of animating simultaneously (`.delay-4` already exists in globals.css at `animation-delay: 0.12s`)

Fixes #495

## Test plan

- [ ] Run `cd web && npx vitest run` — all pre-existing tests pass (1 Toast.test.tsx failure is pre-existing and unrelated)
- [ ] Visually verify settings page cards animate in sequence: Profile → Security → Onboarding → Legal → Account
- [ ] Toggle dark/light theme and confirm the danger zone border is visible and theme-appropriate in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)