### PR TITLE
Fix #622: move building type labels into i18n system

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,18 +9,15 @@ import FeatureHighlights from "@/components/FeatureHighlights";
 import LandingFooter from "@/components/LandingFooter";
 import ProjectList from "@/components/ProjectList";
 import { useAnalytics } from "@/hooks/useAnalytics";
+import { useTranslation } from "@/components/LocaleProvider";
 import type { BuildingResult } from "@/types";
-
-const BUILDING_TYPE_LABELS: Record<string, Record<string, string>> = {
-  fi: { omakotitalo: "Omakotitalo", rivitalo: "Rivitalo", kerrostalo: "Kerrostalo", paritalo: "Paritalo" },
-  en: { omakotitalo: "Detached house", rivitalo: "Terraced house", kerrostalo: "Apartment block", paritalo: "Semi-detached" },
-};
 
 export default function Home() {
   const router = useRouter();
   const [loggedIn, setLoggedIn] = useState(false);
   const [pendingBuilding, setPendingBuilding] = useState<BuildingResult | null>(null);
   const { track } = useAnalytics();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (getToken()) {
@@ -38,10 +35,10 @@ export default function Home() {
 
   async function createProjectFromBuilding(building: BuildingResult) {
     track("project_created", { source: "address", building_type: building.building_info.type });
-    const buildingTypeLabels = BUILDING_TYPE_LABELS.fi;
+    const buildingTypeLabel = t(`building.${building.building_info.type}`) || building.building_info.type;
     const project = await api.createProject({
       name: building.address,
-      description: `${buildingTypeLabels[building.building_info.type] || building.building_info.type}, ${building.building_info.year_built}, ${building.building_info.area_m2} m²`,
+      description: `${buildingTypeLabel}, ${building.building_info.year_built}, ${building.building_info.area_m2} m²`,
       scene_js: building.scene_js,
     });
     if (building.bom_suggestion.length > 0) {

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -551,6 +551,8 @@ describe("exhaustive i18n key parity", () => {
     "landing.featuresTitle", "landing.feature1Title", "landing.feature1Desc",
     "landing.feature2Title", "landing.feature2Desc",
     "landing.feature3Title", "landing.feature3Desc",
+    // building
+    "building.omakotitalo", "building.rivitalo", "building.kerrostalo", "building.paritalo",
     // viewport
     "viewport.contextMenuLabel",
   ];

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -598,6 +598,12 @@ const translations = {
       feature3Title: 'Automaattinen materiaaliluettelo',
       feature3Desc: 'Reaaliaikaiset hinnat K-Raudasta ja Sarokkaasta, suoraan projektiisi',
     },
+    building: {
+      omakotitalo: 'Omakotitalo',
+      rivitalo: 'Rivitalo',
+      kerrostalo: 'Kerrostalo',
+      paritalo: 'Paritalo',
+    },
     viewport: {
       contextMenuLabel: 'Näkymän toiminnot',
     },
@@ -1208,6 +1214,11 @@ const translations = {
       feature2Desc: 'Describe changes in plain language \u2014 "add a terrace in the back" \u2014 AI executes',
       feature3Title: 'Automatic bill of materials',
       feature3Desc: 'Real-time prices from K-Rauta and Stark, directly in your project',
+    building: {
+      omakotitalo: 'Detached house',
+      rivitalo: 'Terraced house',
+      kerrostalo: 'Apartment block',
+      paritalo: 'Semi-detached',
     },
     viewport: {
       contextMenuLabel: 'Viewport actions',

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1214,6 +1214,7 @@ const translations = {
       feature2Desc: 'Describe changes in plain language \u2014 "add a terrace in the back" \u2014 AI executes',
       feature3Title: 'Automatic bill of materials',
       feature3Desc: 'Real-time prices from K-Rauta and Stark, directly in your project',
+    },
     building: {
       omakotitalo: 'Detached house',
       rivitalo: 'Terraced house',


### PR DESCRIPTION
## Summary

- Adds a `building` namespace to `web/src/lib/i18n.ts` with 4 keys (`omakotitalo`, `rivitalo`, `kerrostalo`, `paritalo`) in both Finnish and English
- Removes the hardcoded `BUILDING_TYPE_LABELS` constant from `web/src/app/page.tsx` and replaces it with `t('building.' + type)` via `useTranslation()`, so project descriptions respect the active locale
- Removes the hardcoded `.fi` index — the locale is now resolved through the `useTranslation` hook
- Adds the 4 new keys to the exhaustive parity test in `web/src/lib/__tests__/i18n.test.ts`

Fixes #622

## Test plan

- [x] `cd web && npx vitest run` — all 414 tests pass
- [ ] Create a project from an address while locale is English — description should use "Detached house" / "Terraced house" / etc.
- [ ] Switch locale to Finnish — description should use "Omakotitalo" / "Rivitalo" / etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)