### PR TITLE
fix(BomPanel): replace window.confirm with ConfirmDialog for BOM item deletion

### DIFF
--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import { SkeletonPriceComparison } from "@/components/Skeleton";
+import ConfirmDialog from "@/components/ConfirmDialog";
 import { api } from "@/lib/api";
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { interpretScene, extractSceneMaterials } from "@/lib/scene-interpreter";
@@ -871,7 +872,7 @@ function BomItemCard({
   locale,
   index,
   isFocused,
-  onRemove,
+  onRequestRemove,
   onUpdateQty,
   onCompare,
   onNavigate,
@@ -882,7 +883,7 @@ function BomItemCard({
   locale: string;
   index: number;
   isFocused: boolean;
-  onRemove: (materialId: string) => void;
+  onRequestRemove: (materialId: string) => void;
   onUpdateQty: (materialId: string, qty: number) => void;
   onCompare: (id: string, name: string) => void;
   onNavigate: (direction: "up" | "down" | "next") => void;
@@ -998,12 +999,7 @@ function BomItemCard({
         // Only trigger remove if focus is on the card, not the input
         if (document.activeElement === cardRef.current) {
           e.preventDefault();
-          const confirmed = window.confirm(
-            t('editor.confirmRemoveItem', { name: materialName })
-          );
-          if (confirmed) {
-            onRemove(item.material_id);
-          }
+          onRequestRemove(item.material_id);
         }
         break;
       case " ":
@@ -1046,7 +1042,7 @@ function BomItemCard({
           className="bom-remove-btn"
           tabIndex={-1}
           aria-label={t('editor.removeMaterial', { name: materialName })}
-          onClick={(e) => { e.stopPropagation(); onRemove(item.material_id); }}
+          onClick={(e) => { e.stopPropagation(); onRequestRemove(item.material_id); }}
         >
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="18" y1="6" x2="6" y2="18" />
@@ -1116,6 +1112,7 @@ export default function BomPanel({
   const [quickAddQty, setQuickAddQty] = useState(1);
   const [focusedBomIndex, setFocusedBomIndex] = useState(-1);
   const [searchFocused, setSearchFocused] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const { t, locale } = useTranslation();
 
   // Navigate between BOM item rows
@@ -1438,7 +1435,7 @@ export default function BomPanel({
               locale={locale}
               index={idx}
               isFocused={focusedBomIndex === idx}
-              onRemove={onRemove}
+              onRequestRemove={setPendingDelete}
               onUpdateQty={onUpdateQty}
               onCompare={(id, name) => setCompareMaterial({ id, name })}
               onNavigate={(dir) => handleBomNavigate(idx, dir)}
@@ -1704,6 +1701,29 @@ export default function BomPanel({
           onClose={() => setCompareMaterial(null)}
         />
       )}
+
+      {/* BOM item delete confirmation dialog */}
+      {(() => {
+        const pendingItem = pendingDelete ? bom.find((b) => b.material_id === pendingDelete) : null;
+        const pendingName = pendingItem
+          ? getLocalizedBomItemName(pendingItem, materials, locale)
+          : "";
+        return (
+          <ConfirmDialog
+            open={pendingDelete !== null}
+            title={t("dialog.deleteBomItemTitle")}
+            message={t("dialog.deleteBomItemMessage", { name: pendingName })}
+            confirmText={t("project.delete")}
+            cancelText={t("dialog.cancel")}
+            variant="danger"
+            onConfirm={() => {
+              if (pendingDelete) onRemove(pendingDelete);
+              setPendingDelete(null);
+            }}
+            onCancel={() => setPendingDelete(null)}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -411,7 +411,7 @@ describe("exhaustive i18n key parity", () => {
     "project.openAriaLabel", "project.copyAriaLabel", "project.deleteAriaLabel",
     // toast
     "toast.projectCreated", "toast.projectDeleted", "toast.projectDuplicated",
-    "toast.templateCreated", "toast.saved", "toast.bomExported",
+    "toast.templateCreated", "toast.saved", "toast.bomExported", "toast.exportingBom",
     "toast.loadProjectsFailed", "toast.createProjectFailed", "toast.templateFailed",
     "toast.deleteFailed", "toast.duplicateFailed", "toast.loadProjectFailed",
     "toast.saveFailed", "toast.bomExportFailed", "toast.aiError",
@@ -488,6 +488,7 @@ describe("exhaustive i18n key parity", () => {
     // dialog
     "dialog.confirm", "dialog.cancel", "dialog.deleteProjectTitle",
     "dialog.deleteProjectMessage", "dialog.deleteAccountTitle", "dialog.deleteAccountMessage",
+    "dialog.deleteBomItemTitle", "dialog.deleteBomItemMessage",
     // admin
     "admin.adminPanel", "admin.adminDesc", "admin.materials", "admin.suppliers",
     "admin.pricing", "admin.search", "admin.name", "admin.category",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -402,6 +402,8 @@ const translations = {
       permanentDeleteMessage: 'Haluatko varmasti poistaa tämän projektin pysyvästi? Tätä toimintoa ei voi kumota.',
       deleteAccountTitle: 'Poista tili',
       deleteAccountMessage: 'Haluatko varmasti poistaa tilisi? Kaikki projektisi ja tietosi poistetaan pysyvästi. Tätä toimintoa ei voi kumota.',
+      deleteBomItemTitle: 'Poista materiaali',
+      deleteBomItemMessage: 'Poistetaanko {{name}} materiaalilistasta?',
     },
     admin: {
       adminPanel: 'Hallintapaneeli',
@@ -1013,6 +1015,8 @@ const translations = {
       permanentDeleteMessage: 'Are you sure you want to permanently delete this project? This action cannot be undone.',
       deleteAccountTitle: 'Delete account',
       deleteAccountMessage: 'Are you sure you want to delete your account? All your projects and data will be permanently deleted. This cannot be undone.',
+      deleteBomItemTitle: 'Remove material',
+      deleteBomItemMessage: 'Remove {{name}} from the material list?',
     },
     admin: {
       adminPanel: 'Admin panel',


### PR DESCRIPTION
## Summary

- Fixes #620: BOM item deletion now uses the app's styled `ConfirmDialog` component instead of native `window.confirm()`
- Both the remove button click and keyboard Delete/Backspace on a focused card trigger the dialog
- Added i18n keys `dialog.deleteBomItemTitle` and `dialog.deleteBomItemMessage` for both `fi` and `en`
- Added the new keys to the exhaustive parity test in `i18n.test.ts`

## Test plan

- [ ] All 430 existing tests pass (`npx vitest run`)
- [ ] Clicking the × button on a BOM item shows the ConfirmDialog (not native browser dialog)
- [ ] Pressing Delete/Backspace on a focused BOM card shows the ConfirmDialog
- [ ] Confirming the dialog removes the item; cancelling leaves it in place
- [ ] Dialog renders correctly in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)