### PR TITLE
feat(quote-engine): labour, VAT, margin, rounding, and package-pricing logic (#649)

### DIFF
--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -7,6 +7,8 @@ import ConfirmDialog from "@/components/ConfirmDialog";
 import { api } from "@/lib/api";
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { interpretScene, extractSceneMaterials } from "@/lib/scene-interpreter";
+import { calculateQuote, defaultQuoteConfig } from "@/lib/quote-engine";
+import type { QuoteConfig } from "@/lib/quote-engine";
 import type { BomItem, Material, MaterialPriceData, Category, PriceHistoryRow, VatClass } from "@/types";
 
 /* ── Localization helpers ──────────────────────────────────── */
@@ -74,6 +76,37 @@ function designToPurchasable(
   const unitsNeeded = designQty / conversionFactor;
   const packs = packSize && packSize > 1 ? unitsNeeded / packSize : unitsNeeded;
   return Math.ceil(packs);
+}
+
+/**
+ * Compute the purchasable buy quantity from a design quantity.
+ *
+ * Returns null when the material has no conversion metadata (e.g. preview
+ * materials that are not purchasable). When designUnit === purchasableUnit the
+ * function still returns a value so the caller can decide whether to display it.
+ *
+ * Examples:
+ *   osb_9mm, designQty=10 m² → { buyQty: 4, purchasableUnit: "sheet", packSize: 2.88 }
+ *   pine_48x98_c24, designQty=15 m → { buyQty: 15, purchasableUnit: "m", packSize: null }
+ */
+function computeBuyQty(
+  materialId: string,
+  designQty: number,
+  materials: Material[],
+): { buyQty: number; purchasableUnit: string; packSize: number | null } | null {
+  const mat = materials.find((m) => m.id === materialId);
+  if (!mat || mat.conversion_factor == null || mat.conversion_factor <= 0) return null;
+  const rawBuyQty = designQty * mat.conversion_factor;
+  // Round up to the nearest whole unit for pack-based items; otherwise keep 2dp
+  const buyQty =
+    mat.pack_size != null && mat.pack_size > 0
+      ? Math.ceil(rawBuyQty)
+      : Math.round(rawBuyQty * 100) / 100;
+  return {
+    buyQty,
+    purchasableUnit: mat.purchasable_unit ?? mat.design_unit ?? "kpl",
+    packSize: mat.pack_size ?? null,
+  };
 }
 
 /* ── Category color palette ─────────────────────────────────── */
@@ -903,6 +936,157 @@ function PriceComparisonPopup({
   );
 }
 
+/* ── Quote summary sub-component ──────────────────────────── */
+function QuoteSummary({
+  bom,
+  materials,
+}: {
+  bom: BomItem[];
+  materials: Material[];
+}) {
+  const { t } = useTranslation();
+  const [quoteMode, setQuoteMode] = useState<"homeowner" | "contractor">("homeowner");
+
+  const quote = useMemo(() => {
+    if (bom.length === 0) return null;
+    const config: QuoteConfig = defaultQuoteConfig(quoteMode);
+    return calculateQuote(bom, materials, config);
+  }, [bom, materials, quoteMode]);
+
+  if (!quote) return null;
+
+  const vatPct = Math.round(quote.config.vatRate * 100 * 10) / 10;
+
+  const rowStyle: React.CSSProperties = {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    fontSize: 12,
+    padding: "3px 0",
+  };
+
+  const labelStyle: React.CSSProperties = {
+    color: "var(--text-muted)",
+    fontFamily: "var(--font-body)",
+  };
+
+  const valueStyle: React.CSSProperties = {
+    fontFamily: "var(--font-mono)",
+    fontSize: 12,
+    color: "var(--text-primary)",
+    fontVariantNumeric: "tabular-nums",
+  };
+
+  const dividerStyle: React.CSSProperties = {
+    borderTop: "1px solid var(--border)",
+    margin: "6px 0",
+  };
+
+  const formatEur = (n: number) =>
+    n.toLocaleString("fi-FI", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " \u20ac";
+
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        padding: "14px 16px",
+        background: "var(--bg-tertiary)",
+        borderRadius: "var(--radius-md)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      {/* Header with mode toggle */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12 }}>
+        <div className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)" }}>
+          {t("quote.sectionLabel")}
+        </div>
+        <div style={{ display: "flex", gap: 2, background: "var(--bg-secondary)", borderRadius: "var(--radius-sm)", padding: 2 }}>
+          {(["homeowner", "contractor"] as const).map((mode) => (
+            <button
+              key={mode}
+              onClick={() => setQuoteMode(mode)}
+              style={{
+                padding: "2px 8px",
+                fontSize: 10,
+                fontWeight: quoteMode === mode ? 600 : 400,
+                background: quoteMode === mode ? "var(--bg-elevated)" : "transparent",
+                border: quoteMode === mode ? "1px solid var(--border)" : "1px solid transparent",
+                borderRadius: "var(--radius-sm)",
+                color: quoteMode === mode ? "var(--text-primary)" : "var(--text-muted)",
+                cursor: "pointer",
+                fontFamily: "var(--font-body)",
+                transition: "all 0.12s ease",
+              }}
+            >
+              {t(`quote.${mode}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Line items */}
+      <div>
+        <div style={rowStyle}>
+          <span style={labelStyle}>{t("quote.materials")}</span>
+          <span style={valueStyle}>{formatEur(quote.materialSubtotal)}</span>
+        </div>
+        <div style={rowStyle}>
+          <span style={labelStyle}>
+            {t("quote.labour")}&nbsp;
+            <span style={{ fontSize: 10, opacity: 0.7 }}>
+              ({t("quote.labourRate", { rate: quote.config.labourRatePerHour })})
+            </span>
+          </span>
+          <span style={valueStyle}>{formatEur(quote.labourSubtotal)}</span>
+        </div>
+        <div style={rowStyle}>
+          <span style={labelStyle}>
+            {t("quote.wastage")}&nbsp;
+            <span style={{ fontSize: 10, opacity: 0.7 }}>
+              ({t("quote.wastageRate", { pct: Math.round(quote.config.wastagePercent * 100) })})
+            </span>
+          </span>
+          <span style={{ ...valueStyle, color: "var(--text-muted)" }}>{formatEur(quote.wastageTotal)}</span>
+        </div>
+
+        <div style={dividerStyle} />
+
+        <div style={rowStyle}>
+          <span style={labelStyle}>{t("quote.subtotalExVat")}</span>
+          <span style={valueStyle}>{formatEur(quote.subtotalExVat)}</span>
+        </div>
+        <div style={rowStyle}>
+          <span style={labelStyle}>{t("quote.vat", { rate: vatPct })}</span>
+          <span style={valueStyle}>{formatEur(quote.vatTotal)}</span>
+        </div>
+
+        {quote.contractorMargin != null && (
+          <div style={rowStyle}>
+            <span style={labelStyle}>
+              {t("quote.contractorMargin")}&nbsp;
+              <span style={{ fontSize: 10, opacity: 0.7 }}>
+                ({Math.round((quote.config.contractorMarginPercent ?? 0) * 100)}%)
+              </span>
+            </span>
+            <span style={valueStyle}>{formatEur(quote.contractorMargin)}</span>
+          </div>
+        )}
+
+        <div style={dividerStyle} />
+
+        <div style={{ ...rowStyle, marginTop: 4 }}>
+          <span style={{ ...labelStyle, fontWeight: 600, color: "var(--text-primary)", fontSize: 13 }}>
+            {t("quote.grandTotal")}
+          </span>
+          <span style={{ ...valueStyle, fontWeight: 700, fontSize: 15, color: "var(--amber)" }}>
+            {formatEur(quote.grandTotal)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /* ── BOM item card with debounced quantity input ──────────── */
 function BomItemCard({
   item,
@@ -1051,6 +1235,18 @@ function BomItemCard({
 
   const materialName = getLocalizedBomItemName(item, materials, locale);
 
+  // Compute purchasable buy quantity for display alongside the design quantity
+  const designQty = parseFloat(localQty) || 0;
+  const buyInfo = computeBuyQty(item.material_id, designQty, materials);
+  const mat = materials.find((m) => m.id === item.material_id);
+  // Only show the buy-qty line when designUnit differs from purchasableUnit
+  // (e.g. "10 m² → 4 sheets × 2.88 m²") but not for 1:1 continuous units
+  const showBuyQty =
+    buyInfo != null &&
+    mat != null &&
+    mat.design_unit != null &&
+    mat.purchasable_unit != null &&
+    mat.design_unit !== mat.purchasable_unit;
 
   return (
     <div
@@ -1141,6 +1337,30 @@ function BomItemCard({
           </div>
         );
       })()}
+      {/* Buy quantity line: e.g. "45 m² → 16 sheets × 2.88 m²" */}
+      {showBuyQty && buyInfo && (
+        <div
+          style={{
+            fontSize: 10,
+            color: "var(--text-muted)",
+            fontFamily: "var(--font-mono)",
+            marginTop: 2,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
+          <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+          <span>
+            {buyInfo.buyQty} {buyInfo.purchasableUnit}
+            {buyInfo.packSize != null && (
+              <> &times; {buyInfo.packSize} {mat?.design_unit ?? item.unit}</>
+            )}
+          </span>
+        </div>
+      )}
       {item.supplier && (
         <div className="bom-item-supplier">
           {item.supplier}
@@ -1414,6 +1634,9 @@ export default function BomPanel({
         )}
         {bom.length > 0 && total > 0 && (
           <CostBreakdownChart bom={bom} materials={materials} total={total} />
+        )}
+        {bom.length > 0 && (
+          <QuoteSummary bom={bom} materials={materials} />
         )}
       </div>
 

--- a/web/src/lib/__tests__/quote-engine.test.ts
+++ b/web/src/lib/__tests__/quote-engine.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect } from "vitest";
+import { calculateQuote, defaultQuoteConfig } from "@/lib/quote-engine";
+import type { QuoteConfig } from "@/lib/quote-engine";
+import type { BomItem, Material } from "@/types";
+
+/* ── Fixtures ──────────────────────────────────────────────── */
+
+const lumberMaterial: Material = {
+  id: "pine_48x98_c24",
+  name: "48x98 Runkopuu C24",
+  name_fi: "48x98 Runkopuu C24",
+  name_en: "48x98 Framing Timber C24",
+  category_name: "Lumber",
+  category_name_fi: "Sahatavara",
+  image_url: null,
+  pricing: [{ unit_price: 2.60, unit: "jm", supplier_name: "Sarokas", is_primary: true }],
+};
+
+const insulationMaterial: Material = {
+  id: "rockwool_50mm",
+  name: "Mineraalivilla 50mm",
+  name_fi: "Mineraalivilla 50mm",
+  name_en: "Mineral Wool 50mm",
+  category_name: "Insulation",
+  category_name_fi: "Eristys",
+  image_url: null,
+  pricing: [{ unit_price: 8.0, unit: "m2", supplier_name: "K-Rauta", is_primary: true }],
+};
+
+const roofingMaterial: Material = {
+  id: "metal_roof_sheet",
+  name: "Peltilaatta",
+  name_fi: "Peltilaatta",
+  name_en: "Metal Roof Sheet",
+  category_name: "Roofing",
+  category_name_fi: "Katto",
+  image_url: null,
+  pricing: [{ unit_price: 15.0, unit: "m2", supplier_name: "Ruukki", is_primary: true }],
+};
+
+const concreteMaterial: Material = {
+  id: "concrete_ready_mix",
+  name: "Valmisbetoni C25",
+  name_fi: "Valmisbetoni C25",
+  name_en: "Ready Mix Concrete C25",
+  category_name: "Foundation",
+  category_name_fi: "Perustus",
+  image_url: null,
+  pricing: [{ unit_price: 120.0, unit: "m3", supplier_name: "Rudus", is_primary: true }],
+};
+
+const unknownMaterial: Material = {
+  id: "generic_item",
+  name: "Generic Item",
+  name_fi: null,
+  name_en: null,
+  category_name: "Other",
+  category_name_fi: null,
+  image_url: null,
+  pricing: [{ unit_price: 10.0, unit: "kpl", supplier_name: "Test", is_primary: true }],
+};
+
+const allMaterials: Material[] = [
+  lumberMaterial,
+  insulationMaterial,
+  roofingMaterial,
+  concreteMaterial,
+  unknownMaterial,
+];
+
+const homeownerConfig: QuoteConfig = {
+  mode: "homeowner",
+  vatRate: 0.255,
+  labourRatePerHour: 45,
+  wastagePercent: 0.10,
+};
+
+const contractorConfig: QuoteConfig = {
+  mode: "contractor",
+  vatRate: 0.255,
+  labourRatePerHour: 45,
+  wastagePercent: 0.10,
+  contractorMarginPercent: 0.15,
+};
+
+/* ── 1. Empty BOM ──────────────────────────────────────────── */
+
+describe("calculateQuote — empty BOM", () => {
+  it("returns zero totals for an empty BOM", () => {
+    const quote = calculateQuote([], allMaterials, homeownerConfig);
+    expect(quote.lines).toHaveLength(0);
+    expect(quote.grandTotal).toBe(0);
+    expect(quote.vatTotal).toBe(0);
+    expect(quote.materialSubtotal).toBe(0);
+    expect(quote.labourSubtotal).toBe(0);
+  });
+
+  it("still has a generatedAt timestamp", () => {
+    const before = new Date().toISOString();
+    const quote = calculateQuote([], allMaterials, homeownerConfig);
+    const after = new Date().toISOString();
+    expect(quote.generatedAt >= before).toBe(true);
+    expect(quote.generatedAt <= after).toBe(true);
+  });
+});
+
+/* ── 2. Basic calculation ──────────────────────────────────── */
+
+describe("calculateQuote — basic calculation", () => {
+  it("calculates a single lumber line correctly", () => {
+    const bom: BomItem[] = [{ material_id: "pine_48x98_c24", quantity: 10, unit: "jm" }];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+
+    expect(quote.lines).toHaveLength(1);
+    const line = quote.lines[0];
+
+    // designQty = 10, wastageQty = 10 * 0.10 = 1
+    expect(line.designQty).toBe(10);
+    expect(line.wastageQty).toBe(1);
+
+    // totalQty = 11, unitPrice = 2.60
+    const totalQty = 11;
+    const materialCost = Math.round(totalQty * 2.60 * 100) / 100; // 28.60
+    expect(line.materialCost).toBe(materialCost);
+
+    // Lumber labourHoursPerUnit = 0.5
+    const labourHours = Math.round(totalQty * 0.5 * 100) / 100; // 5.5
+    expect(line.labourHours).toBe(labourHours);
+
+    const labourCost = Math.round(labourHours * 45 * 100) / 100; // 247.50
+    expect(line.labourCost).toBe(labourCost);
+  });
+
+  it("includes the config in the returned quote", () => {
+    const quote = calculateQuote([], allMaterials, homeownerConfig);
+    expect(quote.config).toStrictEqual(homeownerConfig);
+  });
+
+  it("populates materialName from the materials catalog", () => {
+    const bom: BomItem[] = [{ material_id: "pine_48x98_c24", quantity: 1, unit: "jm" }];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    expect(quote.lines[0].materialName).toBe("48x98 Framing Timber C24");
+  });
+});
+
+/* ── 3. Wastage calculation ────────────────────────────────── */
+
+describe("calculateQuote — wastage", () => {
+  it("adds the correct wastage quantity (10%)", () => {
+    const bom: BomItem[] = [{ material_id: "rockwool_50mm", quantity: 20, unit: "m2" }];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    const line = quote.lines[0];
+    expect(line.wastageQty).toBe(2); // 20 * 10% = 2
+    expect(line.designQty + line.wastageQty).toBe(22);
+  });
+
+  it("uses the full quantity (design + wastage) for material cost", () => {
+    const bom: BomItem[] = [{ material_id: "rockwool_50mm", quantity: 10, unit: "m2" }];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    const line = quote.lines[0];
+    // totalQty = 11, unitPrice = 8.0 => materialCost = 88.00
+    expect(line.materialCost).toBe(88.0);
+  });
+
+  it("honours a zero wastage percent", () => {
+    const config: QuoteConfig = { ...homeownerConfig, wastagePercent: 0 };
+    const bom: BomItem[] = [{ material_id: "pine_48x98_c24", quantity: 10, unit: "jm" }];
+    const quote = calculateQuote(bom, allMaterials, config);
+    expect(quote.lines[0].wastageQty).toBe(0);
+    expect(quote.lines[0].designQty).toBe(quote.lines[0].designQty); // unchanged
+  });
+
+  it("calculates wastageTotal as sum of wastage costs across all lines", () => {
+    const bom: BomItem[] = [
+      { material_id: "pine_48x98_c24", quantity: 10, unit: "jm" },
+      { material_id: "rockwool_50mm", quantity: 10, unit: "m2" },
+    ];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    // Lumber: 1 unit * 2.60 = 2.60; Insulation: 1 unit * 8.0 = 8.00
+    expect(quote.wastageTotal).toBeCloseTo(2.60 + 8.0, 1);
+  });
+});
+
+/* ── 4. VAT calculation ────────────────────────────────────── */
+
+describe("calculateQuote — VAT", () => {
+  it("applies VAT at 25.5% on each line's subtotal", () => {
+    const bom: BomItem[] = [{ material_id: "pine_48x98_c24", quantity: 10, unit: "jm" }];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    const line = quote.lines[0];
+    const expectedVat = Math.round(line.subtotal * 0.255 * 100) / 100;
+    expect(line.vatAmount).toBe(expectedVat);
+  });
+
+  it("sums VAT correctly at quote level", () => {
+    const bom: BomItem[] = [
+      { material_id: "pine_48x98_c24", quantity: 10, unit: "jm" },
+      { material_id: "rockwool_50mm", quantity: 5, unit: "m2" },
+    ];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    const expectedVat = Math.round(quote.subtotalExVat * 0.255 * 100) / 100;
+    expect(quote.vatTotal).toBe(expectedVat);
+  });
+
+  it("grand total equals subtotalExVat + vatTotal in homeowner mode", () => {
+    const bom: BomItem[] = [{ material_id: "metal_roof_sheet", quantity: 50, unit: "m2" }];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    expect(quote.grandTotal).toBe(
+      Math.round((quote.subtotalExVat + quote.vatTotal) * 100) / 100,
+    );
+  });
+});
+
+/* ── 5. Homeowner vs contractor mode ───────────────────────── */
+
+describe("calculateQuote — homeowner vs contractor", () => {
+  const bom: BomItem[] = [{ material_id: "pine_48x98_c24", quantity: 20, unit: "jm" }];
+
+  it("homeowner quote has no contractorMargin", () => {
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    expect(quote.contractorMargin).toBeUndefined();
+  });
+
+  it("contractor quote has a contractorMargin", () => {
+    const quote = calculateQuote(bom, allMaterials, contractorConfig);
+    expect(quote.contractorMargin).toBeGreaterThan(0);
+  });
+
+  it("contractor grand total > homeowner grand total when margin > 0", () => {
+    const homeowner = calculateQuote(bom, allMaterials, homeownerConfig);
+    const contractor = calculateQuote(bom, allMaterials, contractorConfig);
+    expect(contractor.grandTotal).toBeGreaterThan(homeowner.grandTotal);
+  });
+
+  it("contractor margin is applied after VAT", () => {
+    const quote = calculateQuote(bom, allMaterials, contractorConfig);
+    const baseWithVat = Math.round((quote.subtotalExVat + quote.vatTotal) * 100) / 100;
+    const expectedMargin = Math.round(baseWithVat * 0.15 * 100) / 100;
+    expect(quote.contractorMargin).toBe(expectedMargin);
+    expect(quote.grandTotal).toBe(Math.round((baseWithVat + expectedMargin) * 100) / 100);
+  });
+
+  it("contractor with 0% margin equals homeowner total", () => {
+    const zeroMarginConfig: QuoteConfig = { ...contractorConfig, contractorMarginPercent: 0 };
+    const homeowner = calculateQuote(bom, allMaterials, homeownerConfig);
+    const contractor = calculateQuote(bom, allMaterials, zeroMarginConfig);
+    expect(contractor.grandTotal).toBe(homeowner.grandTotal);
+  });
+});
+
+/* ── 6. Labour estimation by category ─────────────────────── */
+
+describe("calculateQuote — labour by category", () => {
+  it("uses 0.5 h/unit for lumber", () => {
+    const bom: BomItem[] = [{ material_id: "pine_48x98_c24", quantity: 10, unit: "jm" }];
+    const config: QuoteConfig = { ...homeownerConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, allMaterials, config);
+    // 10 units * 0.5 h = 5 h
+    expect(quote.lines[0].labourHours).toBe(5);
+  });
+
+  it("uses 0.3 h/unit for insulation", () => {
+    const bom: BomItem[] = [{ material_id: "rockwool_50mm", quantity: 10, unit: "m2" }];
+    const config: QuoteConfig = { ...homeownerConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, allMaterials, config);
+    expect(quote.lines[0].labourHours).toBe(3);
+  });
+
+  it("uses 0.4 h/unit for roofing", () => {
+    const bom: BomItem[] = [{ material_id: "metal_roof_sheet", quantity: 10, unit: "m2" }];
+    const config: QuoteConfig = { ...homeownerConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, allMaterials, config);
+    expect(quote.lines[0].labourHours).toBe(4);
+  });
+
+  it("uses 1.0 h/unit for concrete/foundation", () => {
+    const bom: BomItem[] = [{ material_id: "concrete_ready_mix", quantity: 5, unit: "m3" }];
+    const config: QuoteConfig = { ...homeownerConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, allMaterials, config);
+    expect(quote.lines[0].labourHours).toBe(5);
+  });
+
+  it("uses 0.2 h/unit as default for unknown category", () => {
+    const bom: BomItem[] = [{ material_id: "generic_item", quantity: 10, unit: "kpl" }];
+    const config: QuoteConfig = { ...homeownerConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, allMaterials, config);
+    expect(quote.lines[0].labourHours).toBe(2);
+  });
+});
+
+/* ── 7. Rounding ───────────────────────────────────────────── */
+
+describe("calculateQuote — rounding", () => {
+  it("rounds all monetary values to 2 decimal places", () => {
+    const bom: BomItem[] = [
+      { material_id: "pine_48x98_c24", quantity: 7, unit: "jm" },
+      { material_id: "rockwool_50mm", quantity: 13, unit: "m2" },
+    ];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+
+    for (const line of quote.lines) {
+      const decPlaces = (n: number) => {
+        const s = n.toString();
+        const dot = s.indexOf(".");
+        return dot === -1 ? 0 : s.length - dot - 1;
+      };
+      expect(decPlaces(line.materialCost)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.labourCost)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.vatAmount)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.total)).toBeLessThanOrEqual(2);
+    }
+
+    expect(Number.isFinite(quote.grandTotal)).toBe(true);
+    const grandStr = quote.grandTotal.toString();
+    const dot = grandStr.indexOf(".");
+    const decDigits = dot === -1 ? 0 : grandStr.length - dot - 1;
+    expect(decDigits).toBeLessThanOrEqual(2);
+  });
+});
+
+/* ── 8. defaultQuoteConfig ─────────────────────────────────── */
+
+describe("defaultQuoteConfig", () => {
+  it("returns homeowner defaults with 25.5% VAT", () => {
+    const cfg = defaultQuoteConfig("homeowner");
+    expect(cfg.vatRate).toBe(0.255);
+    expect(cfg.mode).toBe("homeowner");
+    expect(cfg.labourRatePerHour).toBe(45);
+    expect(cfg.wastagePercent).toBe(0.10);
+    expect(cfg.contractorMarginPercent).toBeUndefined();
+  });
+
+  it("returns contractor defaults with 15% margin", () => {
+    const cfg = defaultQuoteConfig("contractor");
+    expect(cfg.mode).toBe("contractor");
+    expect(cfg.contractorMarginPercent).toBe(0.15);
+  });
+});
+
+/* ── 9. Multi-line aggregate totals ────────────────────────── */
+
+describe("calculateQuote — multi-line aggregates", () => {
+  it("materialSubtotal equals sum of per-line materialCosts", () => {
+    const bom: BomItem[] = [
+      { material_id: "pine_48x98_c24", quantity: 10, unit: "jm" },
+      { material_id: "rockwool_50mm", quantity: 20, unit: "m2" },
+      { material_id: "metal_roof_sheet", quantity: 30, unit: "m2" },
+    ];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    const sumMat = Math.round(quote.lines.reduce((s, l) => s + l.materialCost, 0) * 100) / 100;
+    expect(quote.materialSubtotal).toBe(sumMat);
+  });
+
+  it("labourSubtotal equals sum of per-line labourCosts", () => {
+    const bom: BomItem[] = [
+      { material_id: "pine_48x98_c24", quantity: 10, unit: "jm" },
+      { material_id: "concrete_ready_mix", quantity: 2, unit: "m3" },
+    ];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    const sumLabour = Math.round(quote.lines.reduce((s, l) => s + l.labourCost, 0) * 100) / 100;
+    expect(quote.labourSubtotal).toBe(sumLabour);
+  });
+
+  it("subtotalExVat = materialSubtotal + labourSubtotal", () => {
+    const bom: BomItem[] = [
+      { material_id: "pine_48x98_c24", quantity: 5, unit: "jm" },
+      { material_id: "rockwool_50mm", quantity: 10, unit: "m2" },
+    ];
+    const quote = calculateQuote(bom, allMaterials, homeownerConfig);
+    expect(quote.subtotalExVat).toBe(
+      Math.round((quote.materialSubtotal + quote.labourSubtotal) * 100) / 100,
+    );
+  });
+});

--- a/web/src/lib/quote-engine.ts
+++ b/web/src/lib/quote-engine.ts
@@ -1,0 +1,230 @@
+/**
+ * Quote engine for Helscoop renovation platform.
+ * Implements Finnish VAT (25.5%), labour estimation, wastage, and contractor margins.
+ */
+
+import type { BomItem, Material } from "@/types";
+
+/* ── Public types ──────────────────────────────────────────── */
+
+export interface QuoteConfig {
+  mode: "homeowner" | "contractor";
+  /** VAT rate as a decimal, e.g. 0.255 for 25.5% (Finnish standard from Sept 2024) */
+  vatRate: number;
+  /** Labour rate in EUR per hour, e.g. 45 */
+  labourRatePerHour: number;
+  /** Wastage as a decimal, e.g. 0.10 for 10% */
+  wastagePercent: number;
+  /** Applied after VAT in contractor mode only */
+  contractorMarginPercent?: number;
+}
+
+export interface QuoteLineItem {
+  materialId: string;
+  materialName: string;
+  /** Quantity from the BOM before wastage */
+  designQty: number;
+  designUnit: string;
+  /** Additional quantity added for wastage */
+  wastageQty: number;
+  /** Material cost including wastage, before VAT */
+  materialCost: number;
+  labourHours: number;
+  labourCost: number;
+  /** materialCost + labourCost, before VAT */
+  subtotal: number;
+  vatAmount: number;
+  /** subtotal + vatAmount */
+  total: number;
+}
+
+export interface Quote {
+  lines: QuoteLineItem[];
+  materialSubtotal: number;
+  labourSubtotal: number;
+  wastageTotal: number;
+  /** Sum of all subtotals before VAT */
+  subtotalExVat: number;
+  vatTotal: number;
+  grandTotal: number;
+  /** Only present in contractor mode */
+  contractorMargin?: number;
+  config: QuoteConfig;
+  generatedAt: string;
+}
+
+/* ── Labour hours lookup ───────────────────────────────────── */
+
+/**
+ * Labour hours per unit by material category.
+ * Categories mirror those used in materials.json and BomPanel.
+ */
+const LABOUR_HOURS_BY_CATEGORY: Record<string, number> = {
+  // Framing / lumber
+  sahatavara: 0.5,
+  lumber: 0.5,
+  // Insulation
+  eristys: 0.3,
+  insulation: 0.3,
+  // Roofing
+  katto: 0.4,
+  roofing: 0.4,
+  // Foundation / concrete
+  perustus: 1.0,
+  foundation: 1.0,
+  // Membrane / vapour barrier
+  kalvo: 0.25,
+  membrane: 0.25,
+  // Fasteners / fixings
+  kiinnitys: 0.1,
+  fasteners: 0.1,
+  // Interior finishes
+  "sisä": 0.35,
+  interior: 0.35,
+};
+
+const DEFAULT_LABOUR_HOURS_PER_UNIT = 0.2;
+
+/** Return labour hours per unit for a given material. */
+function getLabourHoursPerUnit(material: Material | null): number {
+  if (!material) return DEFAULT_LABOUR_HOURS_PER_UNIT;
+
+  const categoryName = (material.category_name || "").toLowerCase();
+
+  // Check all known aliases
+  for (const [key, hours] of Object.entries(LABOUR_HOURS_BY_CATEGORY)) {
+    if (categoryName.includes(key)) return hours;
+  }
+
+  return DEFAULT_LABOUR_HOURS_PER_UNIT;
+}
+
+/* ── Helper ────────────────────────────────────────────────── */
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+function getMaterialName(material: Material | null, bomItem: BomItem): string {
+  if (material) return material.name_en || material.name_fi || material.name;
+  return bomItem.material_name || bomItem.material_id;
+}
+
+function getUnitPrice(material: Material | null, bomItem: BomItem): number {
+  if (bomItem.unit_price != null) return Number(bomItem.unit_price);
+  if (material?.pricing && material.pricing.length > 0) {
+    const primary = material.pricing.find((p) => p.is_primary) || material.pricing[0];
+    return Number(primary.unit_price);
+  }
+  return 0;
+}
+
+function getUnit(material: Material | null, bomItem: BomItem): string {
+  if (bomItem.unit) return bomItem.unit;
+  if (material?.pricing && material.pricing.length > 0) {
+    const primary = material.pricing.find((p) => p.is_primary) || material.pricing[0];
+    return primary.unit;
+  }
+  return "unit";
+}
+
+/* ── Core calculation ──────────────────────────────────────── */
+
+/**
+ * Calculate a full quote from a BOM and materials catalog.
+ *
+ * @param bomItems  - The bill of materials (quantity + material_id)
+ * @param materials - Full materials catalog (for names, categories, pricing)
+ * @param config    - Quote configuration (mode, VAT, labour rate, wastage, margin)
+ * @returns         A fully calculated Quote with per-line and aggregate totals
+ */
+export function calculateQuote(
+  bomItems: BomItem[],
+  materials: Material[],
+  config: QuoteConfig,
+): Quote {
+  const materialMap = new Map<string, Material>(materials.map((m) => [m.id, m]));
+
+  const lines: QuoteLineItem[] = bomItems.map((item) => {
+    const material = materialMap.get(item.material_id) ?? null;
+    const designQty = round2(Number(item.quantity) || 0);
+    const wastageQty = round2(designQty * config.wastagePercent);
+    const totalQty = round2(designQty + wastageQty);
+
+    const unitPrice = getUnitPrice(material, item);
+    const materialCost = round2(totalQty * unitPrice);
+
+    const labourHoursPerUnit = getLabourHoursPerUnit(material);
+    const labourHours = round2(totalQty * labourHoursPerUnit);
+    const labourCost = round2(labourHours * config.labourRatePerHour);
+
+    const subtotal = round2(materialCost + labourCost);
+    const vatAmount = round2(subtotal * config.vatRate);
+    const total = round2(subtotal + vatAmount);
+
+    return {
+      materialId: item.material_id,
+      materialName: getMaterialName(material, item),
+      designQty,
+      designUnit: getUnit(material, item),
+      wastageQty,
+      materialCost,
+      labourHours,
+      labourCost,
+      subtotal,
+      vatAmount,
+      total,
+    };
+  });
+
+  const materialSubtotal = round2(lines.reduce((s, l) => s + l.materialCost, 0));
+  const labourSubtotal = round2(lines.reduce((s, l) => s + l.labourCost, 0));
+  const wastageTotal = round2(
+    lines.reduce((s, l) => {
+      // Wastage cost = wastageQty * unitPrice
+      const material = materialMap.get(l.materialId) ?? null;
+      const unitPrice = material
+        ? getUnitPrice(material, bomItems.find((b) => b.material_id === l.materialId)!)
+        : 0;
+      return s + round2(l.wastageQty * unitPrice);
+    }, 0)
+  );
+
+  const subtotalExVat = round2(materialSubtotal + labourSubtotal);
+  const vatTotal = round2(subtotalExVat * config.vatRate);
+  let grandTotal = round2(subtotalExVat + vatTotal);
+
+  let contractorMargin: number | undefined;
+  if (config.mode === "contractor" && config.contractorMarginPercent != null) {
+    contractorMargin = round2(grandTotal * config.contractorMarginPercent);
+    grandTotal = round2(grandTotal + contractorMargin);
+  }
+
+  return {
+    lines,
+    materialSubtotal,
+    labourSubtotal,
+    wastageTotal,
+    subtotalExVat,
+    vatTotal,
+    grandTotal,
+    contractorMargin,
+    config,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/* ── Default config factory ────────────────────────────────── */
+
+/** Finnish standard defaults: 25.5% VAT (Sept 2024), 45€/h labour, 10% wastage */
+export function defaultQuoteConfig(
+  mode: "homeowner" | "contractor" = "homeowner",
+): QuoteConfig {
+  return {
+    mode,
+    vatRate: 0.255,
+    labourRatePerHour: 45,
+    wastagePercent: 0.10,
+    contractorMarginPercent: mode === "contractor" ? 0.15 : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

- Implements `web/src/lib/quote-engine.ts` with `calculateQuote()` — applies Finnish 25.5% VAT (Sept 2024), per-category labour hours (framing 0.5h, insulation 0.3h, roofing 0.4h, concrete 1.0h, default 0.2h), 10% wastage, and an optional 15% contractor margin applied post-VAT
- Adds `QuoteSummary` component to `BomPanel.tsx` with homeowner/contractor toggle showing explainable line items: materials, labour, wastage, subtotal ex-VAT, VAT, contractor margin, and grand total
- Adds `quote.*` i18n keys in Finnish and English covering all quote labels

Fixes #649

## Test plan

- [x] 28 new tests in `web/src/lib/__tests__/quote-engine.test.ts` — all pass
- [x] Full vitest suite: 544 tests pass (`npx vitest run`)
- [ ] Manual: open BOM panel with materials → "QUOTE SUMMARY" section appears below cost breakdown
- [ ] Manual: toggle Homeowner/Contractor — contractor total increases by 15%
- [ ] Manual: VAT shows as 25.5%

🤖 Generated with [Claude Code](https://claude.com/claude-code)