### PR TITLE
feat(auth): JWT refresh flow — silent session extension

### DIFF
--- a/api/src/__tests__/auth.test.ts
+++ b/api/src/__tests__/auth.test.ts
@@ -3,9 +3,9 @@ import jwt from "jsonwebtoken";
 
 const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
 
-// Import the auth module - signToken and requireAuth are pure functions
-// that don't need a database connection
-import { signToken, requireAuth, requireAdmin } from "../auth";
+// Import the auth module - signToken, requireAuth, and verifyForRefresh
+// are pure functions that don't need a database connection
+import { signToken, tokenExpiresAt, verifyForRefresh, requireAuth, requireAdmin } from "../auth";
 import type { AuthUser } from "../auth";
 
 describe("signToken", () => {
@@ -25,12 +25,12 @@ describe("signToken", () => {
     expect(decoded.role).toBe("admin");
   });
 
-  it("sets a 7-day expiration", () => {
+  it("sets a 15-minute expiration", () => {
     const user: AuthUser = { id: "user-1", email: "test@test.com", role: "user" };
     const token = signToken(user);
     const decoded = jwt.verify(token, JWT_SECRET) as { iat: number; exp: number };
-    const days = (decoded.exp - decoded.iat) / (60 * 60 * 24);
-    expect(days).toBe(7);
+    const minutes = (decoded.exp - decoded.iat) / 60;
+    expect(minutes).toBe(15);
   });
 
   it("produces different tokens for different users", () => {
@@ -180,6 +180,81 @@ describe("requireAdmin middleware", () => {
     requireAdmin(req, res, next);
     expect(res._status).toBe(403);
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("tokenExpiresAt", () => {
+  it("returns an epoch-seconds value ~15 minutes in the future", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const exp = tokenExpiresAt();
+    const after = Math.floor(Date.now() / 1000);
+    // Should be between 14 and 16 minutes from now (allowing 1 min clock tolerance)
+    expect(exp).toBeGreaterThanOrEqual(before + 14 * 60);
+    expect(exp).toBeLessThanOrEqual(after + 16 * 60);
+  });
+});
+
+describe("verifyForRefresh", () => {
+  it("accepts a valid (non-expired) token", () => {
+    const user: AuthUser = { id: "user-1", email: "test@test.com", role: "user" };
+    const token = signToken(user);
+    const result = verifyForRefresh(token);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("user-1");
+    expect(result!.email).toBe("test@test.com");
+    expect(result!.role).toBe("user");
+  });
+
+  it("strips extra JWT fields and returns only id, email, role", () => {
+    const user: AuthUser = { id: "user-1", email: "test@test.com", role: "user" };
+    const token = signToken(user);
+    const result = verifyForRefresh(token);
+    expect(result).toEqual({ id: "user-1", email: "test@test.com", role: "user" });
+    // Should not have iat, exp, etc.
+    expect(result).not.toHaveProperty("iat");
+    expect(result).not.toHaveProperty("exp");
+  });
+
+  it("accepts a token that expired within the 60-second grace window", () => {
+    // Create a token that expired 30 seconds ago
+    const token = jwt.sign(
+      { id: "user-1", email: "test@test.com", role: "user" },
+      JWT_SECRET,
+      { expiresIn: "-30s" }  // Expired 30 seconds ago — within 60s grace
+    );
+    // Normal verify should reject it
+    expect(() => jwt.verify(token, JWT_SECRET)).toThrow();
+    // But refresh verify should accept it
+    const result = verifyForRefresh(token);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("user-1");
+  });
+
+  it("rejects a token that expired beyond the grace window", () => {
+    // Create a token that expired 2 minutes ago
+    const token = jwt.sign(
+      { id: "user-1", email: "test@test.com", role: "user" },
+      JWT_SECRET,
+      { expiresIn: "-120s" }
+    );
+    const result = verifyForRefresh(token);
+    expect(result).toBeNull();
+  });
+
+  it("rejects a token signed with the wrong secret", () => {
+    const token = jwt.sign(
+      { id: "user-1", email: "test@test.com", role: "user" },
+      "wrong-secret",
+      { expiresIn: "15m" }
+    );
+    const result = verifyForRefresh(token);
+    expect(result).toBeNull();
+  });
+
+  it("rejects a completely invalid token", () => {
+    expect(verifyForRefresh("not.a.valid.token")).toBeNull();
+    expect(verifyForRefresh("")).toBeNull();
+    expect(verifyForRefresh("abc")).toBeNull();
   });
 });
 

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -4,6 +4,7 @@ import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import { query } from "./db";
 import { sendPasswordResetEmail, sendVerificationEmail } from "./email";
+import { Role, normalizeRole, ROLES, isValidRole } from "./permissions";
 
 const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
 
@@ -13,6 +14,8 @@ export interface AuthUser {
   role: string;
 }
 
+export { Role, ROLES, isValidRole, normalizeRole };
+
 declare global {
   namespace Express {
     interface Request {
@@ -21,8 +24,50 @@ declare global {
   }
 }
 
+// Access token lifetime: 15 minutes for security; refresh extends the session.
+const ACCESS_TOKEN_EXPIRES = "15m";
+const ACCESS_TOKEN_SECONDS = 15 * 60;
+
+// Grace window (seconds) within which an expired token can still be refreshed.
+// Prevents race conditions when a request is in-flight at the moment of expiry.
+const REFRESH_GRACE_SECONDS = 60;
+
 export function signToken(user: AuthUser): string {
-  return jwt.sign(user, JWT_SECRET, { expiresIn: "7d" });
+  return jwt.sign(user, JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRES });
+}
+
+/** Returns the absolute expiry timestamp (epoch seconds) for a freshly-signed token. */
+export function tokenExpiresAt(): number {
+  return Math.floor(Date.now() / 1000) + ACCESS_TOKEN_SECONDS;
+}
+
+/**
+ * Verify a token for refresh purposes.
+ * Accepts tokens that are still valid OR expired within the grace window.
+ * Returns the decoded user payload, or null if the token is invalid / too old.
+ */
+export function verifyForRefresh(token: string): AuthUser | null {
+  // First try normal verification
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as AuthUser;
+    return { id: payload.id, email: payload.email, role: payload.role };
+  } catch (err) {
+    // If expired, check grace window
+    if (err instanceof jwt.TokenExpiredError) {
+      try {
+        const payload = jwt.verify(token, JWT_SECRET, {
+          ignoreExpiration: true,
+        }) as AuthUser & { exp: number };
+        const expiredAgo = Math.floor(Date.now() / 1000) - payload.exp;
+        if (expiredAgo <= REFRESH_GRACE_SECONDS) {
+          return { id: payload.id, email: payload.email, role: payload.role };
+        }
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
 }
 
 export function requireAuth(req: Request, res: Response, next: NextFunction) {

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -4,7 +4,6 @@ import jwt from "jsonwebtoken";
 import bcrypt from "bcryptjs";
 import { query } from "./db";
 import { sendPasswordResetEmail, sendVerificationEmail } from "./email";
-import { Role, normalizeRole, ROLES, isValidRole } from "./permissions";
 
 const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
 
@@ -14,7 +13,6 @@ export interface AuthUser {
   role: string;
 }
 
-export { Role, ROLES, isValidRole, normalizeRole };
 
 declare global {
   namespace Express {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,7 +6,7 @@ import jwt from "jsonwebtoken";
 import rateLimit from "express-rate-limit";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
-import { login, register, signToken, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, AuthUser } from "./auth";
+import { login, register, signToken, tokenExpiresAt, verifyForRefresh, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, AuthUser } from "./auth";
 import { query, pool } from "./db";
 import { kanalaSceneJs } from "./templates/kanala";
 import materialsRouter from "./routes/materials";
@@ -16,6 +16,7 @@ import pricingRouter from "./routes/pricing";
 import chatRouter from "./routes/chat";
 import buildingRouter from "./routes/building";
 import entitlementsRouter from "./routes/entitlements";
+import rolesRouter from "./routes/roles";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
 
@@ -266,7 +267,7 @@ app.post("/auth/login", authLimiter, async (req, res) => {
   }
   const user = await login(email, password);
   if (!user) return res.status(401).json({ error: "Invalid credentials" });
-  res.json({ token: signToken(user), user });
+  res.json({ token: signToken(user), token_expires_at: tokenExpiresAt(), user });
 });
 
 app.post("/auth/register", authLimiter, async (req, res) => {
@@ -286,7 +287,7 @@ app.post("/auth/register", authLimiter, async (req, res) => {
   const sanitizedName = sanitize(name);
   try {
     const user = await register(email, password, sanitizedName);
-    res.status(201).json({ token: signToken(user), user });
+    res.status(201).json({ token: signToken(user), token_expires_at: tokenExpiresAt(), user });
   } catch (e: unknown) {
     logger.error({ err: e }, "Registration error");
     Sentry.captureException(e);
@@ -342,7 +343,7 @@ app.put("/auth/profile", authenticatedLimiter, requireAuth, async (req, res) => 
     }
     // Return a fresh token with updated user info
     const user = result.rows[0];
-    res.json({ user, token: signToken(user) });
+    res.json({ user, token: signToken(user), token_expires_at: tokenExpiresAt() });
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : "Update failed";
     if (msg.includes("duplicate key")) {
@@ -549,6 +550,21 @@ app.post("/auth/resend-verification", authenticatedLimiter, requireAuth, async (
   }
 });
 
+// Refresh token endpoint — accepts a valid or recently-expired JWT and returns
+// a new access token.  Uses authLimiter to prevent abuse.
+app.post("/auth/refresh", authLimiter, (req, res) => {
+  const header = req.headers.authorization;
+  if (!header?.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Missing authorization header" });
+  }
+  const oldToken = header.slice(7);
+  const user = verifyForRefresh(oldToken);
+  if (!user) {
+    return res.status(401).json({ error: "Token expired or invalid" });
+  }
+  res.json({ token: signToken(user), token_expires_at: tokenExpiresAt() });
+});
+
 // Authenticated routes get the relaxed rate limiter (500 req/15min per user)
 app.use("/materials", authenticatedLimiter, materialsRouter);
 app.use("/projects", authenticatedLimiter, projectsRouter);
@@ -556,6 +572,7 @@ app.use("/suppliers", authenticatedLimiter, suppliersRouter);
 app.use("/pricing", authenticatedLimiter, pricingRouter);
 app.use("/chat", chatLimiter, chatRouter);
 app.use("/entitlements", authenticatedLimiter, entitlementsRouter);
+app.use("/roles", authenticatedLimiter, rolesRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated
 app.use("/building", buildingLimiter, buildingLimiterAuthenticated, buildingRouter);
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,7 +16,6 @@ import pricingRouter from "./routes/pricing";
 import chatRouter from "./routes/chat";
 import buildingRouter from "./routes/building";
 import entitlementsRouter from "./routes/entitlements";
-import rolesRouter from "./routes/roles";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
 
@@ -572,7 +571,6 @@ app.use("/suppliers", authenticatedLimiter, suppliersRouter);
 app.use("/pricing", authenticatedLimiter, pricingRouter);
 app.use("/chat", chatLimiter, chatRouter);
 app.use("/entitlements", authenticatedLimiter, entitlementsRouter);
-app.use("/roles", authenticatedLimiter, rolesRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated
 app.use("/building", buildingLimiter, buildingLimiterAuthenticated, buildingRouter);
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -68,7 +68,7 @@ export default function SettingsPage() {
       const result = await api.updateProfile({ name, email });
       setUser(result.user);
       if (result.token) {
-        setToken(result.token);
+        setToken(result.token, result.token_expires_at);
       }
       toast(t("settings.profileUpdated"), "success");
     } catch (err) {

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -57,7 +57,7 @@ export default function LoginForm({
       const result = isRegister
         ? await api.register(email, password, name)
         : await api.login(email, password);
-      setToken(result.token);
+      setToken(result.token, result.token_expires_at);
       track(isRegister ? "auth_register" : "auth_login", {} as Record<string, never>);
       onLogin();
     } catch (err) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,16 +2,28 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 
 let token: string | null = null;
 
-export function setToken(t: string | null) {
+// Epoch-seconds timestamp of when the current access token expires.
+// Set when we receive `token_expires_at` from the API (login, register, refresh).
+let tokenExpiresAt: number | null = null;
+
+export function setToken(t: string | null, expiresAt?: number) {
   token = t;
-  if (t) localStorage.setItem("helscoop_token", t);
-  else localStorage.removeItem("helscoop_token");
+  tokenExpiresAt = expiresAt ?? null;
+  if (t) {
+    localStorage.setItem("helscoop_token", t);
+    if (expiresAt) localStorage.setItem("helscoop_token_expires_at", String(expiresAt));
+  } else {
+    localStorage.removeItem("helscoop_token");
+    localStorage.removeItem("helscoop_token_expires_at");
+  }
 }
 
 export function getToken(): string | null {
   if (token) return token;
   if (typeof window !== "undefined") {
     token = localStorage.getItem("helscoop_token");
+    const exp = localStorage.getItem("helscoop_token_expires_at");
+    if (exp) tokenExpiresAt = parseInt(exp, 10);
   }
   return token;
 }
@@ -39,7 +51,71 @@ const ERROR_MESSAGES: Record<number, string> = {
   500: "Palvelinvirhe / Server error",
 };
 
+// ---------------------------------------------------------------------------
+// Token refresh helpers
+// ---------------------------------------------------------------------------
+
+// Proactive refresh threshold: refresh if the token expires within 5 minutes.
+const REFRESH_THRESHOLD_SECONDS = 5 * 60;
+
+// Serialize concurrent refresh attempts — only one in-flight at a time.
+let refreshPromise: Promise<boolean> | null = null;
+
+/**
+ * Call POST /auth/refresh with the current token.
+ * Returns true if the token was successfully refreshed, false otherwise.
+ */
+async function refreshAccessToken(): Promise<boolean> {
+  const t = getToken();
+  if (!t) return false;
+  try {
+    const res = await fetch(`${API_URL}/auth/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${t}`,
+      },
+    });
+    if (!res.ok) return false;
+    const body = await res.json();
+    if (body.token) {
+      setToken(body.token, body.token_expires_at);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Deduplicated refresh: multiple callers share a single in-flight refresh. */
+function refreshOnce(): Promise<boolean> {
+  if (!refreshPromise) {
+    refreshPromise = refreshAccessToken().finally(() => {
+      refreshPromise = null;
+    });
+  }
+  return refreshPromise;
+}
+
+/** Returns true if the current token is about to expire. */
+function tokenNeedsRefresh(): boolean {
+  if (!tokenExpiresAt) return false;
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return tokenExpiresAt - nowSeconds < REFRESH_THRESHOLD_SECONDS;
+}
+
+// ---------------------------------------------------------------------------
+// Core fetch wrapper with automatic token refresh
+// ---------------------------------------------------------------------------
+
 async function apiFetch(path: string, opts?: RequestInit) {
+  // Proactive refresh: if token expires soon, refresh before the request.
+  const isRefreshEndpoint = path === "/auth/refresh";
+  if (!isRefreshEndpoint && getToken() && tokenNeedsRefresh()) {
+    await refreshOnce();
+  }
+
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     ...(opts?.headers as Record<string, string>),
@@ -50,8 +126,27 @@ async function apiFetch(path: string, opts?: RequestInit) {
   const res = await fetch(`${API_URL}${path}`, { ...opts, headers });
 
   if (!res.ok) {
-    const isAuthEndpoint = path.startsWith("/auth/login") || path.startsWith("/auth/register");
+    const isAuthEndpoint =
+      path.startsWith("/auth/login") ||
+      path.startsWith("/auth/register") ||
+      isRefreshEndpoint;
+
+    // On 401 for a non-auth endpoint, attempt a single token refresh
     if (res.status === 401 && !isAuthEndpoint) {
+      const refreshed = await refreshOnce();
+      if (refreshed) {
+        // Retry the original request with the new token
+        const retryHeaders: Record<string, string> = {
+          "Content-Type": "application/json",
+          ...(opts?.headers as Record<string, string>),
+        };
+        const newToken = getToken();
+        if (newToken) retryHeaders.Authorization = `Bearer ${newToken}`;
+        const retryRes = await fetch(`${API_URL}${path}`, { ...opts, headers: retryHeaders });
+        if (retryRes.ok) return retryRes.json();
+        // Retry also failed — fall through to logout
+      }
+
       setToken(null);
       if (typeof window !== "undefined") {
         window.location.href = "/";


### PR DESCRIPTION
## Summary

- Shortens JWT access tokens from 7 days to 15 minutes for improved security
- Adds `POST /auth/refresh` endpoint that accepts valid or recently-expired tokens (60s grace window) and issues fresh access tokens
- Frontend `apiFetch()` now proactively refreshes tokens expiring within 5 minutes and retries once on 401 before redirecting to login
- Auth responses (`login`, `register`, `profile update`) include `token_expires_at` so the client knows when to refresh
- Concurrent refresh calls are deduplicated to prevent race conditions during parallel requests

Fixes #363

## Files changed

| File | Change |
|------|--------|
| `api/src/auth.ts` | `signToken()` → 15m expiry; new `tokenExpiresAt()`, `verifyForRefresh()` |
| `api/src/index.ts` | New `POST /auth/refresh` route; `token_expires_at` in login/register/profile responses |
| `web/src/lib/api.ts` | Proactive + reactive refresh interceptor; `setToken()` accepts `expiresAt` |
| `web/src/components/LoginForm.tsx` | Pass `token_expires_at` to `setToken()` |
| `web/src/app/settings/page.tsx` | Pass `token_expires_at` to `setToken()` on profile update |
| `api/src/__tests__/auth.test.ts` | Updated expiry test (7d → 15m); new tests for `verifyForRefresh` and `tokenExpiresAt` |

## Test plan

- [x] `cd api && npx vitest run` — 235 tests pass (10 suites)
- [x] `cd web && npx tsc --noEmit` — clean type check
- [ ] Manual: login, wait for token to approach expiry, verify silent refresh in Network tab
- [ ] Manual: force-expire token (e.g. via dev tools), verify 401 triggers refresh then retries
- [ ] Manual: fully expired token (>60s past expiry) correctly redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)