### PR TITLE
fix(i18n+a11y): batch prio-5 — translate aria-labels, add screen reader support

### DIFF
--- a/web/src/__tests__/UserMenu.test.tsx
+++ b/web/src/__tests__/UserMenu.test.tsx
@@ -4,12 +4,20 @@ import UserMenu from "@/components/UserMenu";
 
 vi.mock("@/components/LocaleProvider", () => ({
   useTranslation: () => ({
-    t: (key: string) => {
+    t: (key: string, params?: Record<string, string | number>) => {
       const translations: Record<string, string> = {
         "nav.settings": "Settings",
         "nav.logout": "Log out",
+        "userMenu.avatarAriaLabel": "User menu for {{name}}",
+        "userMenu.menuAriaLabel": "{{name}} menu",
       };
-      return translations[key] ?? key;
+      let value = translations[key] ?? key;
+      if (params) {
+        for (const [k, v] of Object.entries(params)) {
+          value = value.replace(`{{${k}}}`, String(v));
+        }
+      }
+      return value;
     },
   }),
 }));

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -240,6 +240,10 @@ function CostBreakdownChart({
       >
         {/* Donut */}
         <div
+          role="img"
+          aria-label={t('bom.donutChartAriaLabel', {
+            categories: slices.map((s) => `${s.name} ${s.pct.toFixed(0)}%`).join(', '),
+          })}
           style={{
             width: 100,
             height: 100,
@@ -348,7 +352,7 @@ function Sparkline({
     .join(" ");
 
   return (
-    <svg width={width} height={height} style={{ display: "block", flexShrink: 0 }}>
+    <svg width={width} height={height} aria-hidden="true" style={{ display: "block", flexShrink: 0 }}>
       <polyline
         points={points}
         fill="none"

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -300,7 +300,7 @@ export default function ProjectList({
           <button
             className="nav-hamburger"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            aria-label="Menu"
+            aria-label={t('projectList.menuAriaLabel')}
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               {mobileMenuOpen ? (

--- a/web/src/components/UserMenu.tsx
+++ b/web/src/components/UserMenu.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "@/components/LocaleProvider";
 import Link from "next/link";
 
 function UserAvatar({ name, onClick, expanded }: { name: string; onClick?: () => void; expanded: boolean }) {
+  const { t } = useTranslation();
   const initials = name
     .split(/\s+/)
     .map((w) => w[0])
@@ -17,7 +18,7 @@ function UserAvatar({ name, onClick, expanded }: { name: string; onClick?: () =>
   return (
     <button
       onClick={onClick}
-      aria-label={`User menu for ${name}`}
+      aria-label={t('userMenu.avatarAriaLabel', { name })}
       aria-haspopup="true"
       aria-expanded={expanded}
       style={{
@@ -132,7 +133,7 @@ export default function UserMenu({ userName }: { userName: string }) {
           <div
             className="card anim-fade"
             role="menu"
-            aria-label={`${userName} menu`}
+            aria-label={t('userMenu.menuAriaLabel', { name: userName })}
             ref={menuRef}
             style={{
               position: "absolute",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -631,6 +631,16 @@ const translations = {
       stalePrice: 'Vanha hinta',
       stalePriceDetail: 'Hintatieto on yli 90 paivaa vanha — tarkista toimittajalta',
     },
+    projectList: {
+      menuAriaLabel: 'Valikko',
+    },
+    userMenu: {
+      avatarAriaLabel: 'Käyttäjävalikko: {{name}}',
+      menuAriaLabel: '{{name}} — valikko',
+    },
+    bom: {
+      donutChartAriaLabel: 'Kustannuserittelyn kaavio: {{categories}}',
+    },
     upgrade: {
       title: 'Päivitä tilaus',
       subtitle: 'Tämä ominaisuus vaatii korkeamman tilauksen.',
@@ -1279,6 +1289,16 @@ const translations = {
       dataQuality: 'Data quality',
       stalePrice: 'Stale price',
       stalePriceDetail: 'Price data is over 90 days old \u2014 verify with supplier',
+    },
+    projectList: {
+      menuAriaLabel: 'Menu',
+    },
+    userMenu: {
+      avatarAriaLabel: 'User menu for {{name}}',
+      menuAriaLabel: '{{name}} menu',
+    },
+    bom: {
+      donutChartAriaLabel: 'Cost breakdown chart: {{categories}}',
     },
     upgrade: {
       title: 'Upgrade your plan',


### PR DESCRIPTION
## Summary

- **#686**: ProjectList hamburger menu `aria-label` was hardcoded English `"Menu"` — now uses `t('projectList.menuAriaLabel')`
- **#690**: UserMenu avatar `aria-label` used hardcoded English template `User menu for ${name}` — now uses `t('userMenu.avatarAriaLabel', { name })`
- **#692**: UserMenu dropdown `aria-label` used hardcoded English template `${userName} menu` — now uses `t('userMenu.menuAriaLabel', { name: userName })`
- **#703**: BomPanel cost breakdown donut chart had no accessible alternative — now has `role="img"` with a descriptive `aria-label` listing each category and its percentage
- **#704**: BomPanel sparkline SVGs had no accessible description — marked `aria-hidden="true"` as they are decorative (price data is already available as text)

All new i18n keys added to both `fi` and `en` sections in `i18n.ts`. Finnish translations use proper diacritics (ä/ö).

Closes #686, #690, #692, #703, #704

## Test plan

- [ ] Verify Finnish locale shows `"Valikko"` for hamburger menu aria-label
- [ ] Verify English locale shows `"Menu"` for hamburger menu aria-label
- [ ] Verify UserMenu avatar reads translated label with user name in both locales
- [ ] Verify UserMenu dropdown reads translated label with user name in both locales
- [ ] Verify donut chart is announced by screen reader with category breakdown
- [ ] Verify sparkline SVGs are invisible to screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)