### PR TITLE
fix: batch prio-6 — ConfirmDialog newlines, locale labels, resend feedback, responsive popup (#697, #699, #702, #705)

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -36,9 +36,10 @@ export default function Home() {
   async function createProjectFromBuilding(building: BuildingResult) {
     track("project_created", { source: "address", building_type: building.building_info.type });
     const buildingTypeLabel = t(`building.${building.building_info.type}`) || building.building_info.type;
+    const materialLabel = t(`building.material.${building.building_info.material}`) || building.building_info.material;
     const project = await api.createProject({
       name: building.address,
-      description: `${buildingTypeLabel}, ${building.building_info.year_built}, ${building.building_info.area_m2} m²`,
+      description: `${buildingTypeLabel}, ${materialLabel}, ${building.building_info.year_built}, ${building.building_info.area_m2} m²`,
       scene_js: building.scene_js,
     });
     if (building.bom_suggestion.length > 0) {

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -687,11 +687,13 @@ function PriceComparisonPopup({
           background: "var(--bg-secondary)",
           border: "1px solid var(--border-strong)",
           borderRadius: "var(--radius-lg)",
-          width: 480,
+          width: "100%",
+          maxWidth: 480,
           maxHeight: "80vh",
           display: "flex",
           flexDirection: "column",
           boxShadow: "var(--shadow-lg)",
+          margin: "0 16px",
         }}
       >
         {/* Header */}

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -166,6 +166,7 @@ export default function ConfirmDialog({
             lineHeight: 1.6,
             color: "var(--text-secondary)",
             margin: "0 0 24px",
+            whiteSpace: "pre-wrap",
           }}
         >
           {message}

--- a/web/src/components/EmailVerificationBanner.tsx
+++ b/web/src/components/EmailVerificationBanner.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { api } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
+import { useToast } from "@/components/ToastProvider";
 
 interface Props {
   emailVerified: boolean;
@@ -10,6 +11,7 @@ interface Props {
 
 export default function EmailVerificationBanner({ emailVerified }: Props) {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const [resending, setResending] = useState(false);
   const [resent, setResent] = useState(false);
   const [dismissed, setDismissed] = useState(false);
@@ -22,7 +24,7 @@ export default function EmailVerificationBanner({ emailVerified }: Props) {
       await api.resendVerification();
       setResent(true);
     } catch {
-      // Silently fail — user can try again
+      toast(t('emailVerification.resendFailed'), "error");
     }
     setResending(false);
   }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -561,6 +561,7 @@ const translations = {
       banner: 'Vahvista sähköpostiosoitteesi. Tarkista postilaatikkosi.',
       resent: 'Lähetetty!',
       resend: 'Lähetä uudelleen',
+      resendFailed: 'Vahvistusviestin lähetys epäonnistui. Yritä uudelleen.',
       dismiss: 'Sulje',
     },
     aria: {
@@ -616,6 +617,12 @@ const translations = {
       rivitalo: 'Rivitalo',
       kerrostalo: 'Kerrostalo',
       paritalo: 'Paritalo',
+      material: {
+        puu: 'Puu',
+        tiili: 'Tiili',
+        betoni: 'Betoni',
+        hirsi: 'Hirsi',
+      },
     },
     viewport: {
       contextMenuLabel: 'Näkymän toiminnot',
@@ -1210,6 +1217,7 @@ const translations = {
       banner: 'Please verify your email. Check your inbox.',
       resent: 'Sent!',
       resend: 'Resend',
+      resendFailed: 'Failed to resend verification email. Please try again.',
       dismiss: 'Dismiss',
     },
     aria: {
@@ -1265,6 +1273,12 @@ const translations = {
       rivitalo: 'Terraced house',
       kerrostalo: 'Apartment block',
       paritalo: 'Semi-detached',
+      material: {
+        puu: 'Wood',
+        tiili: 'Brick',
+        betoni: 'Concrete',
+        hirsi: 'Log',
+      },
     },
     viewport: {
       contextMenuLabel: 'Viewport actions',


### PR DESCRIPTION
## Summary
- **#697** — ConfirmDialog message now preserves newlines via `white-space: pre-wrap`
- **#699** — `createProjectFromBuilding` translates building material labels (`puu`→`Wood`, etc.) via i18n `t()` instead of passing raw Finnish API strings; added `building.material.*` keys to both `fi` and `en`
- **#702** — `EmailVerificationBanner` resend error now shows a toast (`emailVerification.resendFailed`) instead of being silently swallowed
- **#705** — `PriceComparisonPopup` changed from fixed `width: 480px` to `width: 100%; max-width: 480px` with horizontal margin so it works on mobile screens

## Test plan
- [ ] Open a ConfirmDialog with a message containing `\n` — verify line breaks render visually
- [ ] Switch locale to English, create a project from address search — verify description uses "Wood"/"Brick" not "Puu"/"Tiili"
- [ ] Trigger email verification resend with network disabled — verify error toast appears
- [ ] Open PriceComparisonPopup on a narrow viewport (<480px) — verify it does not overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)