### PR TITLE
fix: batch prio-7 — diacritics, theming, overflow protection (#678, #695, #698, #700, #701)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -90,8 +90,22 @@
   --focus-ring-danger: 0 0 0 2px var(--danger);
   --focus-ring-danger-offset: 0 0 0 4px var(--danger-dim);
 
+  /* ── Syntax highlighting ───────────────────────────────────────── */
+  --syntax-keyword: #e5a04b;
+  --syntax-primitive: #e5a04b;
+  --syntax-transform: #7ab3e0;
+  --syntax-boolean: #8bc48b;
+  --syntax-scene-add: #f0b86a;
+  --syntax-number: #d4a0e0;
+  --syntax-comment: #5a5a64;
+  --syntax-string: #c4a06e;
+  --syntax-default: #9a9aa6;
+
   /* ── Backdrop ──────────────────────────────────────────────────── */
   --backdrop: rgba(0, 0, 0, 0.6);
+
+  /* ── Danger button contrast text ─────────────────────────────── */
+  --danger-contrast: #ffffff;
 }
 
 /* ── Reduced-contrast mode for late-night sessions ────────────────── */
@@ -167,6 +181,20 @@
   --focus-ring-danger-offset: 0 0 0 4px var(--danger-dim);
 
   --backdrop: rgba(0, 0, 0, 0.6);
+
+  /* ── Syntax highlighting (light) ────────────────────────────── */
+  --syntax-keyword: #b45309;
+  --syntax-primitive: #b45309;
+  --syntax-transform: #2563eb;
+  --syntax-boolean: #16a34a;
+  --syntax-scene-add: #92400e;
+  --syntax-number: #7c3aed;
+  --syntax-comment: #a1a1aa;
+  --syntax-string: #92400e;
+  --syntax-default: #3f3f46;
+
+  /* ── Danger button contrast text ─────────────────────────────── */
+  --danger-contrast: #ffffff;
 }
 
 /* Light theme component overrides */

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -32,7 +32,7 @@ const MATERIAL_LABELS: Record<string, Record<string, string>> = {
 };
 
 const HEATING_LABELS: Record<string, Record<string, string>> = {
-  fi: { kaukolampo: "Kaukolampo", sahko: "Sahko", maalampopumppu: "Maalampopumppu", oljy: "Oljy" },
+  fi: { kaukolampo: "Kaukolämpö", sahko: "Sähkö", maalampopumppu: "Maalämpöpumppu", oljy: "Öljy" },
   en: { kaukolampo: "District heating", sahko: "Electric", maalampopumppu: "Ground source heat pump", oljy: "Oil" },
 };
 

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -197,7 +197,7 @@ export default function ConfirmDialog({
               ...(isDanger
                 ? {
                     background: "var(--danger)",
-                    color: "#09090b",
+                    color: "var(--danger-contrast)",
                     border: "1px solid var(--danger)",
                   }
                 : {}),

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -61,16 +61,16 @@ export default function ProjectCard({
       </div>
       <div style={{ padding: "14px 22px 18px" }}>
         <div style={{ minWidth: 0 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6 }}>
-            <h3 className="heading-display" style={{ fontSize: 18 }}>{project.name}</h3>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6, minWidth: 0 }}>
+            <h3 className="heading-display" style={{ fontSize: 18, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{project.name}</h3>
             {project.estimated_cost > 0 && (
               <span className="badge badge-amber">
                 {Number(project.estimated_cost).toFixed(0)} &euro;
               </span>
             )}
           </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 12, color: "var(--text-muted)", fontSize: 13 }}>
-            <span>{project.description || t('project.emptyDescription')}</span>
+          <div style={{ display: "flex", alignItems: "center", gap: 12, color: "var(--text-muted)", fontSize: 13, minWidth: 0 }}>
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{project.description || t('project.emptyDescription')}</span>
             <span style={{ opacity: 0.5 }}>&middot;</span>
             <span style={{ fontFamily: "var(--font-mono)", fontSize: 11 }}>
               {new Date(project.updated_at).toLocaleDateString(locale === 'fi' ? 'fi-FI' : 'en-GB')}

--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -21,17 +21,17 @@ function findAllMatches(text: string, query: string): FindMatch[] {
   return matches;
 }
 
-/* ── Syntax highlighting colours ─────────────────────────────────── */
+/* ── Syntax highlighting colours (CSS custom properties with fallbacks) ── */
 const COLORS = {
-  primitive: "#e5a04b",   // box, cylinder, sphere — warm amber
-  transform: "#7ab3e0",   // translate, rotate, scale — cool steel blue
-  boolean:   "#8bc48b",   // union, subtract, intersect — muted sage
-  sceneAdd:  "#f0b86a",   // scene.add — bright amber
-  number:    "#d4a0e0",   // numbers — soft lavender
-  comment:   "#5a5a64",   // comments — dim zinc
-  string:    "#c4a06e",   // strings — warm tan
-  keyword:   "#e5a04b",   // keywords — amber
-  default:   "#9a9aa6",   // default text — warm grey
+  primitive: "var(--syntax-primitive, #e5a04b)",
+  transform: "var(--syntax-transform, #7ab3e0)",
+  boolean:   "var(--syntax-boolean, #8bc48b)",
+  sceneAdd:  "var(--syntax-scene-add, #f0b86a)",
+  number:    "var(--syntax-number, #d4a0e0)",
+  comment:   "var(--syntax-comment, #5a5a64)",
+  string:    "var(--syntax-string, #c4a06e)",
+  keyword:   "var(--syntax-keyword, #e5a04b)",
+  default:   "var(--syntax-default, #9a9aa6)",
 };
 
 /* ── Token types & patterns ──────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- **#678** — Restore Finnish diacritics in AddressSearch heating labels (`Kaukolämpö`, `Sähkö`, `Maalämpöpumppu`, `Öljy`)
- **#695** — Replace hardcoded hex colors in SceneEditor syntax highlighting with CSS custom properties (`--syntax-keyword`, `--syntax-primitive`, etc.) that respect the app's dark/light theming; added light-theme overrides in globals.css
- **#698** — Replace hardcoded `#09090b` text color on ConfirmDialog danger button with `var(--danger-contrast)`, ensuring visibility on both dark and light themes
- **#700** — Add `overflow: hidden; text-overflow: ellipsis` to ProjectCard description text to prevent long descriptions from pushing action buttons off-screen
- **#701** — Add overflow protection (truncate with ellipsis) to ProjectCard heading so long project names don't break card layout

## Test plan

- [ ] Switch between fi/en locale and verify heating labels show proper diacritics (Kaukolämpö, Sähkö, Maalämpöpumppu, Öljy)
- [ ] Toggle light/dark theme and verify SceneEditor syntax colors adapt correctly
- [ ] Open a ConfirmDialog with `variant="danger"` in light theme — confirm button text should be visible (white on red)
- [ ] Create a project with a very long name and verify the card heading truncates with ellipsis
- [ ] Create a project with a very long description and verify it truncates without pushing buttons off-screen
- [ ] Run `npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)