### PR TITLE
test: add 66 tests for materials, pricing, and LoginForm

### DIFF
--- a/api/src/__tests__/materials.test.ts
+++ b/api/src/__tests__/materials.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Unit tests for the materials route.
+ *
+ * Tests CRUD operations, authorization boundaries, input validation,
+ * price aggregation via sub-queries, and 404 handling.
+ *
+ * Covers: GET /materials, GET /materials/:id, GET /materials/:id/prices,
+ *         POST /materials, PUT /materials/:id, DELETE /materials/:id
+ *
+ * Related issue: https://github.com/dzautner/helscoop/issues/684
+ */
+
+process.env.NODE_ENV = "test";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+import http from "http";
+import type { AddressInfo } from "net";
+
+const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+
+// ---------------------------------------------------------------------------
+// Mock DB and email modules BEFORE importing app
+// ---------------------------------------------------------------------------
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] }),
+  pool: { query: vi.fn() },
+}));
+
+vi.mock("../email", () => ({
+  sendEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendPriceAlertEmail: vi.fn(),
+}));
+
+import { query } from "../db";
+const mockQuery = vi.mocked(query);
+
+import app from "../index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function authToken(userId = "user-1", role = "user") {
+  return jwt.sign(
+    { id: userId, email: "test@test.com", role },
+    JWT_SECRET,
+    { expiresIn: "7d" },
+  );
+}
+
+function adminToken(userId = "admin-1") {
+  return jwt.sign(
+    { id: userId, email: "admin@test.com", role: "admin" },
+    JWT_SECRET,
+    { expiresIn: "7d" },
+  );
+}
+
+function makeRequest(
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const bodyStr = opts.body ? JSON.stringify(opts.body) : undefined;
+      const reqOpts: http.RequestOptions = {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: method.toUpperCase(),
+        headers: {
+          "Content-Type": "application/json",
+          ...opts.headers,
+        },
+      };
+
+      const req = http.request(reqOpts, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          server.close();
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({ status: res.statusCode || 0, body: parsed });
+        });
+      });
+
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] } as never);
+});
+
+// ---------------------------------------------------------------------------
+// 1. GET /materials — list all materials
+// ---------------------------------------------------------------------------
+describe("GET /materials", () => {
+  it("returns materials list (no auth required)", async () => {
+    const sampleRows = [
+      { id: "pine_48x98_c24", name: "Pine 48x98 C24", category_name: "Lumber", pricing: null },
+      { id: "osb_9mm", name: "OSB 9mm", category_name: "Panels", pricing: null },
+    ];
+    mockQuery.mockResolvedValueOnce({ rows: sampleRows } as never);
+
+    const res = await makeRequest("GET", "/materials");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect((res.body as unknown[]).length).toBe(2);
+  });
+
+  it("returns empty array when no materials exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/materials");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("includes pricing sub-query data in response", async () => {
+    const rows = [{
+      id: "pine_48x98_c24",
+      name: "Pine 48x98 C24",
+      category_name: "Lumber",
+      pricing: [{ supplier_name: "K-Rauta", unit_price: 3.50, currency: "EUR" }],
+    }];
+    mockQuery.mockResolvedValueOnce({ rows } as never);
+
+    const res = await makeRequest("GET", "/materials");
+    expect(res.status).toBe(200);
+    const materials = res.body as typeof rows;
+    expect(materials[0].pricing).toBeDefined();
+    expect(materials[0].pricing![0].supplier_name).toBe("K-Rauta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. GET /materials/:id — single material with pricing + history
+// ---------------------------------------------------------------------------
+describe("GET /materials/:id", () => {
+  it("returns 404 for non-existent material", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/materials/nonexistent");
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toContain("not found");
+  });
+
+  it("returns material with pricing and price history", async () => {
+    // First query: material itself
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "pine_48x98_c24", name: "Pine 48x98 C24", category_name: "Lumber" }],
+    } as never);
+    // Second query: pricing
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "p1", unit_price: 3.50, supplier_name: "K-Rauta" }],
+    } as never);
+    // Third query: pricing history
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ pricing_id: "p1", unit_price: 3.20, scraped_at: "2026-03-01" }],
+    } as never);
+
+    const res = await makeRequest("GET", "/materials/pine_48x98_c24");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      id: string;
+      name: string;
+      pricing: unknown[];
+      price_history: unknown[];
+    };
+    expect(body.id).toBe("pine_48x98_c24");
+    expect(body.pricing).toBeDefined();
+    expect(body.pricing.length).toBe(1);
+    expect(body.price_history).toBeDefined();
+    expect(body.price_history.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. GET /materials/:id/prices — price comparison
+// ---------------------------------------------------------------------------
+describe("GET /materials/:id/prices", () => {
+  it("returns 404 when material does not exist", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/materials/nonexistent/prices");
+    expect(res.status).toBe(404);
+    expect((res.body as { error: string }).error).toContain("not found");
+  });
+
+  it("returns price comparison with savings calculation", async () => {
+    // First query: material lookup
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "pine_48x98_c24", name: "Pine 48x98 C24" }],
+    } as never);
+    // Second query: pricing ordered by unit_price ASC
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: "p1", unit_price: "3.20", is_primary: false, supplier_name: "Bauhaus" },
+        { id: "p2", unit_price: "3.50", is_primary: true, supplier_name: "K-Rauta" },
+        { id: "p3", unit_price: "4.10", is_primary: false, supplier_name: "Stark" },
+      ],
+    } as never);
+
+    const res = await makeRequest("GET", "/materials/pine_48x98_c24/prices");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      material_id: string;
+      material_name: string;
+      prices: unknown[];
+      cheapest_price: number;
+      primary_price: number;
+      savings_per_unit: number;
+    };
+    expect(body.material_id).toBe("pine_48x98_c24");
+    expect(body.cheapest_price).toBe(3.20);
+    expect(body.primary_price).toBe(3.50);
+    expect(body.savings_per_unit).toBeCloseTo(0.30, 2);
+    expect(body.prices.length).toBe(3);
+  });
+
+  it("returns zero savings when cheapest is primary", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "mat1", name: "Material" }],
+    } as never);
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { id: "p1", unit_price: "3.20", is_primary: true, supplier_name: "K-Rauta" },
+        { id: "p2", unit_price: "4.10", is_primary: false, supplier_name: "Stark" },
+      ],
+    } as never);
+
+    const res = await makeRequest("GET", "/materials/mat1/prices");
+    expect(res.status).toBe(200);
+    const body = res.body as { savings_per_unit: number };
+    expect(body.savings_per_unit).toBe(0);
+  });
+
+  it("handles empty pricing list", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "mat1", name: "Material" }],
+    } as never);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/materials/mat1/prices");
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      cheapest_price: number | null;
+      primary_price: number | null;
+      savings_per_unit: number;
+    };
+    expect(body.cheapest_price).toBeNull();
+    expect(body.primary_price).toBeNull();
+    expect(body.savings_per_unit).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. POST /materials — create material (admin only)
+// ---------------------------------------------------------------------------
+describe("POST /materials", () => {
+  it("rejects unauthenticated request", async () => {
+    const res = await makeRequest("POST", "/materials", {
+      body: { id: "test", name: "Test Material", category_id: "cat1" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin user", async () => {
+    const res = await makeRequest("POST", "/materials", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { id: "test", name: "Test Material", category_id: "cat1" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("creates material with admin credentials", async () => {
+    const newMaterial = {
+      id: "new_mat",
+      name: "New Material",
+      category_id: "lumber",
+      tags: ["wood", "structural"],
+      description: "A test material",
+      visual_albedo: 0.7,
+      visual_roughness: 0.5,
+      visual_metallic: 0.0,
+      thermal_conductivity: 0.12,
+      thermal_thickness: 0.048,
+      waste_factor: 1.05,
+    };
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ ...newMaterial, created_at: "2026-04-20" }],
+    } as never);
+
+    const res = await makeRequest("POST", "/materials", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: newMaterial,
+    });
+    expect(res.status).toBe(201);
+    const body = res.body as { id: string; name: string };
+    expect(body.id).toBe("new_mat");
+    expect(body.name).toBe("New Material");
+  });
+
+  it("applies default waste_factor when not provided", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "mat1", waste_factor: 1.05 }],
+    } as never);
+
+    const res = await makeRequest("POST", "/materials", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: { id: "mat1", name: "Mat", category_id: "cat1" },
+    });
+    expect(res.status).toBe(201);
+
+    // Verify the query was called with the default waste_factor
+    const queryCall = mockQuery.mock.calls[0];
+    const params = queryCall[1] as unknown[];
+    // waste_factor is the 11th parameter
+    expect(params[10]).toBe(1.05);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. PUT /materials/:id — update material (admin only)
+// ---------------------------------------------------------------------------
+describe("PUT /materials/:id", () => {
+  it("rejects unauthenticated request", async () => {
+    const res = await makeRequest("PUT", "/materials/mat1", {
+      body: { name: "Updated" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin user", async () => {
+    const res = await makeRequest("PUT", "/materials/mat1", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { name: "Updated" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for non-existent material", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("PUT", "/materials/nonexistent", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: { name: "Updated", category_id: "cat1", tags: [], description: "", waste_factor: 1.05 },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("updates material with admin credentials", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "mat1", name: "Updated Name", category_id: "cat1", updated_at: "2026-04-20" }],
+    } as never);
+
+    const res = await makeRequest("PUT", "/materials/mat1", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: { name: "Updated Name", category_id: "cat1", tags: ["wood"], description: "Updated", waste_factor: 1.10 },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { name: string };
+    expect(body.name).toBe("Updated Name");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. DELETE /materials/:id — delete material (admin only)
+// ---------------------------------------------------------------------------
+describe("DELETE /materials/:id", () => {
+  it("rejects unauthenticated request", async () => {
+    const res = await makeRequest("DELETE", "/materials/mat1");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin user", async () => {
+    const res = await makeRequest("DELETE", "/materials/mat1", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("deletes material with admin credentials", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("DELETE", "/materials/mat1", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(res.status).toBe(200);
+    expect((res.body as { ok: boolean }).ok).toBe(true);
+  });
+});

--- a/api/src/__tests__/pricing.test.ts
+++ b/api/src/__tests__/pricing.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for the pricing route.
+ *
+ * Tests price comparison, price update with history tracking,
+ * price history retrieval, stale price detection, and authorization boundaries.
+ *
+ * Covers: GET /pricing/compare/:materialId, PUT /pricing/:materialId/:supplierId,
+ *         GET /pricing/history/:materialId, GET /pricing/stale
+ *
+ * Related issue: https://github.com/dzautner/helscoop/issues/685
+ */
+
+process.env.NODE_ENV = "test";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+import http from "http";
+import type { AddressInfo } from "net";
+
+const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+
+// ---------------------------------------------------------------------------
+// Mock DB and email modules BEFORE importing app
+// ---------------------------------------------------------------------------
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] }),
+  pool: { query: vi.fn() },
+}));
+
+vi.mock("../email", () => ({
+  sendEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendPriceAlertEmail: vi.fn(),
+}));
+
+import { query } from "../db";
+const mockQuery = vi.mocked(query);
+
+import app from "../index";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function authToken(userId = "user-1", role = "user") {
+  return jwt.sign(
+    { id: userId, email: "test@test.com", role },
+    JWT_SECRET,
+    { expiresIn: "7d" },
+  );
+}
+
+function adminToken(userId = "admin-1") {
+  return jwt.sign(
+    { id: userId, email: "admin@test.com", role: "admin" },
+    JWT_SECRET,
+    { expiresIn: "7d" },
+  );
+}
+
+function makeRequest(
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const bodyStr = opts.body ? JSON.stringify(opts.body) : undefined;
+      const reqOpts: http.RequestOptions = {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: method.toUpperCase(),
+        headers: {
+          "Content-Type": "application/json",
+          ...opts.headers,
+        },
+      };
+
+      const req = http.request(reqOpts, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          server.close();
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({ status: res.statusCode || 0, body: parsed });
+        });
+      });
+
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] } as never);
+});
+
+// ---------------------------------------------------------------------------
+// 1. GET /pricing/compare/:materialId — price comparison across suppliers
+// ---------------------------------------------------------------------------
+describe("GET /pricing/compare/:materialId", () => {
+  it("returns prices sorted by unit_price ascending", async () => {
+    const priceRows = [
+      { id: "p1", unit_price: 3.20, supplier_name: "Bauhaus", supplier_url: "https://bauhaus.fi" },
+      { id: "p2", unit_price: 3.50, supplier_name: "K-Rauta", supplier_url: "https://k-rauta.fi" },
+      { id: "p3", unit_price: 4.10, supplier_name: "Stark", supplier_url: "https://stark.fi" },
+    ];
+    mockQuery.mockResolvedValueOnce({ rows: priceRows } as never);
+
+    const res = await makeRequest("GET", "/pricing/compare/pine_48x98_c24");
+    expect(res.status).toBe(200);
+    const body = res.body as typeof priceRows;
+    expect(body.length).toBe(3);
+    expect(body[0].supplier_name).toBe("Bauhaus");
+    expect(body[0].unit_price).toBe(3.20);
+    // Verify ordering
+    expect(body[1].unit_price).toBe(3.50);
+    expect(body[2].unit_price).toBe(4.10);
+  });
+
+  it("returns empty array when no pricing exists for material", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/pricing/compare/nonexistent");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("does not require authentication", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/pricing/compare/mat1");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. PUT /pricing/:materialId/:supplierId — upsert price (admin only)
+// ---------------------------------------------------------------------------
+describe("PUT /pricing/:materialId/:supplierId", () => {
+  it("rejects unauthenticated request", async () => {
+    const res = await makeRequest("PUT", "/pricing/mat1/sup1", {
+      body: { unit_price: 5.00, unit: "jm" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin user", async () => {
+    const res = await makeRequest("PUT", "/pricing/mat1/sup1", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { unit_price: 5.00, unit: "jm" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("creates/updates pricing with admin credentials", async () => {
+    const pricingRow = {
+      id: "pricing-1",
+      material_id: "mat1",
+      supplier_id: "sup1",
+      unit: "jm",
+      unit_price: 5.00,
+      sku: "SKU-001",
+      ean: null,
+      link: "https://k-rauta.fi/pine",
+      is_primary: false,
+    };
+    // First call: upsert pricing
+    mockQuery.mockResolvedValueOnce({ rows: [pricingRow] } as never);
+    // Second call: insert history
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("PUT", "/pricing/mat1/sup1", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: {
+        unit_price: 5.00,
+        unit: "jm",
+        sku: "SKU-001",
+        link: "https://k-rauta.fi/pine",
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as typeof pricingRow;
+    expect(body.unit_price).toBe(5.00);
+    expect(body.material_id).toBe("mat1");
+  });
+
+  it("clears other primary flags when setting is_primary=true", async () => {
+    // First call: clear existing primary flags
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+    // Second call: upsert with is_primary=true
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "pricing-1", is_primary: true, unit_price: 3.50 }],
+    } as never);
+    // Third call: insert history
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("PUT", "/pricing/mat1/sup1", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: { unit_price: 3.50, unit: "jm", is_primary: true },
+    });
+    expect(res.status).toBe(200);
+
+    // Verify the primary-clearing query was called
+    expect(mockQuery).toHaveBeenCalledWith(
+      "UPDATE pricing SET is_primary=false WHERE material_id=$1",
+      ["mat1"],
+    );
+  });
+
+  it("records price in pricing_history with manual source", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "pricing-1", unit_price: 4.20 }],
+    } as never);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    await makeRequest("PUT", "/pricing/mat1/sup1", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+      body: { unit_price: 4.20, unit: "jm" },
+    });
+
+    // Verify history insertion
+    const historyCalls = mockQuery.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("pricing_history"),
+    );
+    expect(historyCalls.length).toBe(1);
+    const historyParams = historyCalls[0][1] as unknown[];
+    expect(historyParams[0]).toBe("pricing-1"); // pricing_id
+    expect(historyParams[1]).toBe(4.20);        // unit_price
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. GET /pricing/history/:materialId — price history
+// ---------------------------------------------------------------------------
+describe("GET /pricing/history/:materialId", () => {
+  it("returns price history for material", async () => {
+    const historyRows = [
+      { id: "h1", unit_price: 3.50, scraped_at: "2026-04-15", supplier_name: "K-Rauta" },
+      { id: "h2", unit_price: 3.20, scraped_at: "2026-03-01", supplier_name: "K-Rauta" },
+    ];
+    mockQuery.mockResolvedValueOnce({ rows: historyRows } as never);
+
+    const res = await makeRequest("GET", "/pricing/history/pine_48x98_c24");
+    expect(res.status).toBe(200);
+    const body = res.body as typeof historyRows;
+    expect(body.length).toBe(2);
+    // Should be ordered by scraped_at DESC (most recent first)
+    expect(body[0].scraped_at).toBe("2026-04-15");
+  });
+
+  it("returns empty array when no history exists", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/pricing/history/nonexistent");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("does not require authentication", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/pricing/history/mat1");
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. GET /pricing/stale — stale price detection (admin only)
+// ---------------------------------------------------------------------------
+describe("GET /pricing/stale", () => {
+  it("rejects unauthenticated request", async () => {
+    const res = await makeRequest("GET", "/pricing/stale");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin user", async () => {
+    const res = await makeRequest("GET", "/pricing/stale", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns stale prices for admin", async () => {
+    const staleRows = [
+      {
+        id: "mat1",
+        name: "Pine 48x98",
+        supplier_name: "K-Rauta",
+        unit_price: 3.50,
+        last_scraped_at: "2026-02-01",
+        days_stale: 78,
+      },
+    ];
+    mockQuery.mockResolvedValueOnce({ rows: staleRows } as never);
+
+    const res = await makeRequest("GET", "/pricing/stale", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as typeof staleRows;
+    expect(body.length).toBe(1);
+    expect(body[0].days_stale).toBe(78);
+    expect(body[0].name).toBe("Pine 48x98");
+  });
+
+  it("returns empty array when no stale prices", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/pricing/stale", {
+      headers: { Authorization: `Bearer ${adminToken()}` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});

--- a/web/src/__tests__/LoginForm.test.tsx
+++ b/web/src/__tests__/LoginForm.test.tsx
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for the LoginForm component.
+ *
+ * Tests cover: login/register form rendering, form validation, password
+ * strength indicator, error display, terms checkbox, mode toggle between
+ * login and register, loading state, and accessibility attributes.
+ *
+ * Related issue: https://github.com/dzautner/helscoop/issues/691
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import LoginForm from "@/components/LoginForm";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock LocaleProvider
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      const map: Record<string, string> = {
+        "auth.loginTitle": "Kirjaudu sisaan",
+        "auth.registerTitle": "Luo tili",
+        "auth.loginSubtitle": "Kirjaudu jatkaaksesi",
+        "auth.registerSubtitle": "Luo tili aloittaaksesi",
+        "auth.loginSubtitleBuilding": "Kirjaudu tallentaaksesi: ",
+        "auth.name": "Nimi",
+        "auth.namePlaceholder": "Nimesi",
+        "auth.email": "Sahkoposti",
+        "auth.emailPlaceholder": "sahkoposti@esimerkki.fi",
+        "auth.password": "Salasana",
+        "auth.passwordPlaceholder": "Salasana",
+        "auth.login": "Kirjaudu",
+        "auth.register": "Rekisteroidy",
+        "auth.noAccount": "Ei tilia? Rekisteroidy",
+        "auth.hasAccount": "Onko jo tili? Kirjaudu",
+        "auth.forgotPassword": "Unohditko salasanan?",
+        "auth.loginFailed": "Kirjautuminen epaonnistui",
+        "auth.passwordStrong": "Vahva",
+        "auth.passwordMedium": "Keskitaso",
+        "auth.passwordWeak": "Heikko",
+        "auth.passwordStrength": "Salasanan vahvuus",
+        "legal.acceptTerms": "Hyvaksyn kayttohehdot ja tietosuojakaytannon",
+        "legal.acceptTermsRequired": "Sinun taytyy hyvaksya kayttoehdot",
+        "legal.termsOfService": "kayttohehdot",
+        "legal.privacyPolicy": "tietosuojakaytanto",
+        "legal.and": "ja",
+        "brand.description": "Finnish home renovation planning",
+        "brand.tagline": "Built for Finnish homes",
+        "brand.featureMaterials": "Materiaalit",
+        "brand.featureMaterialsDesc": "Kaikki materiaalit",
+        "brand.featureSuppliers": "Toimittajat",
+        "brand.featureSuppliersDesc": "Vertailu",
+        "brand.featureAI": "AI-avustaja",
+        "brand.featureAIDesc": "Suunnittele",
+        "search.sectionLabel": "Etsi osoitteella",
+        "upgrade.aiQuotaDesc": `AI limit: ${params?.limit ?? "10"}`,
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+// Mock useAnalytics
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({
+    track: vi.fn(),
+  }),
+}));
+
+// Mock api module
+const mockLogin = vi.fn();
+const mockRegister = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: {
+    login: (...args: unknown[]) => mockLogin(...args),
+    register: (...args: unknown[]) => mockRegister(...args),
+  },
+  setToken: vi.fn(),
+}));
+
+// Mock child components that are not under test
+vi.mock("@/components/HeroIllustration", () => ({
+  default: () => <div data-testid="hero-illustration" />,
+}));
+
+vi.mock("@/components/TrustLayer", () => ({
+  default: () => <div data-testid="trust-layer" />,
+}));
+
+vi.mock("@/components/ScrollReveal", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/LanguageSwitcher", () => ({
+  LanguageSwitcher: () => <div data-testid="language-switcher" />,
+}));
+
+vi.mock("@/components/ThemeToggle", () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+const defaultProps = {
+  onLogin: vi.fn(),
+  pendingBuilding: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLogin.mockReset();
+  mockRegister.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Login form rendering
+// ---------------------------------------------------------------------------
+describe("LoginForm — login mode", () => {
+  it("renders login title by default", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByText("Kirjaudu sisaan")).toBeDefined();
+  });
+
+  it("renders email and password inputs", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByLabelText("Sahkoposti")).toBeDefined();
+    expect(screen.getByLabelText("Salasana")).toBeDefined();
+  });
+
+  it("renders login button", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "Kirjaudu" })).toBeDefined();
+  });
+
+  it("does not render name input in login mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.queryByLabelText("Nimi")).toBeNull();
+  });
+
+  it("renders forgot password link in login mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByText("Unohditko salasanan?")).toBeDefined();
+  });
+
+  it("renders switch-to-register link", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByText("Ei tilia? Rekisteroidy")).toBeDefined();
+  });
+
+  it("shows pending building address in subtitle", () => {
+    render(
+      <LoginForm
+        {...defaultProps}
+        pendingBuilding={{
+          address: "Ribbingintie 109",
+          coordinates: { lat: 60.17, lon: 24.94 },
+          building_info: { type: "omakotitalo", year_built: 1985, material: "puu", floors: 2, area_m2: 135, heating: "kaukolampo" },
+          scene_js: "",
+          bom_suggestion: [],
+          confidence: "verified",
+          data_sources: [],
+        }}
+      />,
+    );
+    expect(screen.getByText(/Ribbingintie 109/)).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Register mode
+// ---------------------------------------------------------------------------
+describe("LoginForm — register mode", () => {
+  it("switches to register mode when toggle is clicked", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    expect(screen.getByText("Luo tili")).toBeDefined();
+  });
+
+  it("renders name input in register mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    expect(screen.getByLabelText("Nimi")).toBeDefined();
+  });
+
+  it("renders terms checkbox in register mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    expect(screen.getByRole("checkbox")).toBeDefined();
+  });
+
+  it("renders register button in register mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    expect(screen.getByRole("button", { name: "Rekisteroidy" })).toBeDefined();
+  });
+
+  it("switches back to login mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.click(screen.getByText("Onko jo tili? Kirjaudu"));
+    expect(screen.getByText("Kirjaudu sisaan")).toBeDefined();
+  });
+
+  it("clears errors when switching modes", () => {
+    render(<LoginForm {...defaultProps} />);
+    // Switch to register, submit without terms to trigger error
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+
+    // Fill required fields
+    fireEvent.change(screen.getByLabelText("Nimi"), { target: { value: "Test" } });
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "test@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "Password1!" } });
+
+    // Submit without checking terms
+    fireEvent.submit(screen.getByRole("button", { name: "Rekisteroidy" }).closest("form")!);
+
+    // Error should appear
+    expect(screen.getByRole("alert")).toBeDefined();
+
+    // Switch back to login — error should disappear
+    fireEvent.click(screen.getByText("Onko jo tili? Kirjaudu"));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Password strength indicator
+// ---------------------------------------------------------------------------
+describe("LoginForm — password strength", () => {
+  it("shows weak indicator for short passwords", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "abc" } });
+    expect(screen.getByText("Heikko")).toBeDefined();
+  });
+
+  it("shows medium indicator for password with length and number", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "password1" } });
+    expect(screen.getByText("Keskitaso")).toBeDefined();
+  });
+
+  it("shows strong indicator for complex password", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "MyPass1!x" } });
+    expect(screen.getByText("Vahva")).toBeDefined();
+  });
+
+  it("does not show strength indicator in login mode", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "password" } });
+    expect(screen.queryByText("Heikko")).toBeNull();
+    expect(screen.queryByText("Keskitaso")).toBeNull();
+    expect(screen.queryByText("Vahva")).toBeNull();
+  });
+
+  it("renders password strength meter with aria attributes", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "MyPass1!x" } });
+    const meter = screen.getByRole("meter");
+    expect(meter).toBeDefined();
+    expect(meter.getAttribute("aria-label")).toBe("Salasanan vahvuus");
+    expect(meter.getAttribute("aria-valuenow")).toBe("3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Form submission
+// ---------------------------------------------------------------------------
+describe("LoginForm — form submission", () => {
+  it("calls api.login on login submit", async () => {
+    mockLogin.mockResolvedValue({ token: "jwt-token", token_expires_at: 9999999999 });
+
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "password123" } });
+    fireEvent.submit(screen.getByRole("button", { name: "Kirjaudu" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith("user@test.com", "password123");
+    });
+  });
+
+  it("calls onLogin after successful login", async () => {
+    const onLogin = vi.fn();
+    mockLogin.mockResolvedValue({ token: "jwt-token", token_expires_at: 9999999999 });
+
+    render(<LoginForm onLogin={onLogin} pendingBuilding={null} />);
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "password123" } });
+    fireEvent.submit(screen.getByRole("button", { name: "Kirjaudu" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(onLogin).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("displays error message on login failure", async () => {
+    mockLogin.mockRejectedValue(new Error("Invalid credentials"));
+
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "wrong" } });
+    fireEvent.submit(screen.getByRole("button", { name: "Kirjaudu" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+      expect(screen.getByText("Invalid credentials")).toBeDefined();
+    });
+  });
+
+  it("displays generic error when error is not an Error instance", async () => {
+    mockLogin.mockRejectedValue("something went wrong");
+
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "user@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "wrong" } });
+    fireEvent.submit(screen.getByRole("button", { name: "Kirjaudu" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+      expect(screen.getByText("Kirjautuminen epaonnistui")).toBeDefined();
+    });
+  });
+
+  it("rejects register without accepting terms", () => {
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.change(screen.getByLabelText("Nimi"), { target: { value: "Test" } });
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "test@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "StrongPass1!" } });
+
+    fireEvent.submit(screen.getByRole("button", { name: "Rekisteroidy" }).closest("form")!);
+
+    expect(screen.getByRole("alert")).toBeDefined();
+    expect(screen.getByText("Sinun taytyy hyvaksya kayttoehdot")).toBeDefined();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("calls api.register when terms are accepted", async () => {
+    mockRegister.mockResolvedValue({ token: "jwt-token", token_expires_at: 9999999999 });
+
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByText("Ei tilia? Rekisteroidy"));
+    fireEvent.change(screen.getByLabelText("Nimi"), { target: { value: "Test User" } });
+    fireEvent.change(screen.getByLabelText("Sahkoposti"), { target: { value: "test@test.com" } });
+    fireEvent.change(screen.getByLabelText("Salasana"), { target: { value: "StrongPass1!" } });
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    fireEvent.submit(screen.getByRole("button", { name: "Rekisteroidy" }).closest("form")!);
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledWith("test@test.com", "StrongPass1!", "Test User");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Address search slot
+// ---------------------------------------------------------------------------
+describe("LoginForm — address search", () => {
+  it("renders address search slot when provided", () => {
+    render(
+      <LoginForm
+        {...defaultProps}
+        addressSearch={<div data-testid="custom-search">Search</div>}
+      />,
+    );
+    expect(screen.getByTestId("custom-search")).toBeDefined();
+  });
+
+  it("does not render address search section when not provided", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.queryByText("Etsi osoitteella")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Branding elements
+// ---------------------------------------------------------------------------
+describe("LoginForm — branding", () => {
+  it("renders hero illustration", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByTestId("hero-illustration")).toBeDefined();
+  });
+
+  it("renders trust layer", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByTestId("trust-layer")).toBeDefined();
+  });
+
+  it("renders language switcher", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByTestId("language-switcher")).toBeDefined();
+  });
+
+  it("renders theme toggle", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByTestId("theme-toggle")).toBeDefined();
+  });
+
+  it("renders privacy and terms links", () => {
+    render(<LoginForm {...defaultProps} />);
+    const privacyLinks = screen.getAllByText("tietosuojakaytanto");
+    const termsLinks = screen.getAllByText("kayttohehdot");
+    expect(privacyLinks.length).toBeGreaterThanOrEqual(1);
+    expect(termsLinks.length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **Materials route** (20 tests): Full CRUD coverage including admin authorization boundaries, price aggregation sub-queries, 404 handling, default waste_factor application, and empty state handling.
- **Pricing route** (15 tests): Price comparison ordering, upsert with primary flag clearing, pricing_history recording with manual source, stale price detection for admins, and auth boundary enforcement.
- **LoginForm component** (31 tests): Login/register mode toggle, password strength indicator (weak/medium/strong with aria-meter), form submission with API mocks, error display for failures, terms checkbox validation, pending building address display, address search slot rendering, and branding element presence.

Test count: API 235 -> 270 (+35), Web 553 -> 584 (+31)

Closes #684, #685, #691

## Test plan
- [x] All 66 new tests pass locally
- [x] Full API suite passes (270 tests, 0 failures)
- [x] Full web suite passes (584 tests, 0 failures)
- [x] No existing tests broken by the additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)