### PR TITLE
fix: batch prio-7 — responsive chart, skeleton loading, aria-labels, i18n (#706, #711, #712, #687, #696, #679)

### DIFF
--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -8,6 +8,7 @@ import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import { resetOnboarding } from "@/components/OnboardingTour";
+import { Skeleton, SkeletonBlock } from "@/components/Skeleton";
 import Link from "next/link";
 
 interface UserProfile {
@@ -148,15 +149,54 @@ export default function SettingsPage() {
 
   if (loading) {
     return (
-      <div
-        style={{
-          minHeight: "100vh",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <span style={{ color: "var(--text-muted)" }}>{t("auth.loading")}</span>
+      <div style={{ minHeight: "100vh" }}>
+        {/* Top bar skeleton */}
+        <div className="nav-bar">
+          <div className="nav-inner" style={{ maxWidth: 720 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <SkeletonBlock width={100} height={20} />
+              <div style={{ width: 1, height: 20, background: "var(--border-strong)", margin: "0 4px" }} />
+              <SkeletonBlock width={70} height={14} />
+            </div>
+            <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+              <SkeletonBlock width={32} height={32} />
+              <SkeletonBlock width={32} height={32} />
+              <SkeletonBlock width={120} height={32} />
+            </div>
+          </div>
+        </div>
+        <div style={{ maxWidth: 720, margin: "0 auto", padding: "40px 24px 80px" }}>
+          {/* Title skeleton */}
+          <div style={{ marginBottom: 40 }}>
+            <SkeletonBlock width={200} height={36} />
+          </div>
+          {/* Card skeletons */}
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="card settings-card"
+              style={{
+                marginBottom: 20,
+                padding: "24px 28px",
+                animation: `fadeIn 0.3s ease ${i * 0.08}s both`,
+              }}
+            >
+              <Skeleton variant="text" width={160} height={20} style={{ marginBottom: 8 }} />
+              <Skeleton variant="text" width="80%" height={14} style={{ marginBottom: 24 }} />
+              <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                <div>
+                  <Skeleton variant="text" width={60} height={10} style={{ marginBottom: 8 }} />
+                  <Skeleton variant="rect" width="100%" height={40} />
+                </div>
+                <div>
+                  <Skeleton variant="text" width={80} height={10} style={{ marginBottom: 8 }} />
+                  <Skeleton variant="rect" width="100%" height={40} />
+                </div>
+              </div>
+              <Skeleton variant="rect" width={140} height={40} style={{ marginTop: 16 }} />
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -34,19 +34,28 @@ const Viewport3D = dynamic(() => import("@/components/Viewport3D"), {
   loading: () => <Viewport3DLoading />,
 });
 
-const BUILDING_TYPE_LABELS: Record<string, Record<string, string>> = {
-  fi: { omakotitalo: "Omakotitalo", rivitalo: "Rivitalo", kerrostalo: "Kerrostalo", paritalo: "Paritalo" },
-  en: { omakotitalo: "Detached house", rivitalo: "Terraced house", kerrostalo: "Apartment block", paritalo: "Semi-detached" },
+/** Map building type API keys to i18n keys */
+const BUILDING_TYPE_I18N: Record<string, string> = {
+  omakotitalo: "building.omakotitalo",
+  rivitalo: "building.rivitalo",
+  kerrostalo: "building.kerrostalo",
+  paritalo: "building.paritalo",
 };
 
-const MATERIAL_LABELS: Record<string, Record<string, string>> = {
-  fi: { puu: "Puu", tiili: "Tiili", betoni: "Betoni", hirsi: "Hirsi" },
-  en: { puu: "Wood", tiili: "Brick", betoni: "Concrete", hirsi: "Log" },
+/** Map material API keys to i18n keys */
+const MATERIAL_I18N: Record<string, string> = {
+  puu: "building.materialWood",
+  tiili: "building.materialBrick",
+  betoni: "building.materialConcrete",
+  hirsi: "building.materialLog",
 };
 
-const HEATING_LABELS: Record<string, Record<string, string>> = {
-  fi: { kaukolampo: "Kaukolämpö", sahko: "Sähkö", maalampopumppu: "Maalämpöpumppu", oljy: "Öljy" },
-  en: { kaukolampo: "District heating", sahko: "Electric", maalampopumppu: "Ground source heat pump", oljy: "Oil" },
+/** Map heating API keys to i18n keys */
+const HEATING_I18N: Record<string, string> = {
+  kaukolampo: "building.heatingDistrict",
+  sahko: "building.heatingElectric",
+  maalampopumppu: "building.heatingGroundSource",
+  oljy: "building.heatingOil",
 };
 
 function DataSourcesSection({ label, sources }: { label: string; sources: string[] }) {
@@ -127,9 +136,9 @@ export default function AddressSearch({
     setLoading(false);
   }, [query, track]);
 
-  const buildingTypeLabels = BUILDING_TYPE_LABELS[locale] || BUILDING_TYPE_LABELS.fi;
-  const materialLabels = MATERIAL_LABELS[locale] || MATERIAL_LABELS.fi;
-  const heatingLabels = HEATING_LABELS[locale] || HEATING_LABELS.fi;
+  const resolveBuildingType = (type: string) => BUILDING_TYPE_I18N[type] ? t(BUILDING_TYPE_I18N[type]) : type;
+  const resolveMaterial = (mat: string) => MATERIAL_I18N[mat] ? t(MATERIAL_I18N[mat]) : mat;
+  const resolveHeating = (heat: string) => HEATING_I18N[heat] ? t(HEATING_I18N[heat]) : heat;
 
   if (compact) {
     return (
@@ -191,7 +200,7 @@ export default function AddressSearch({
                   </div>
                   <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
                     <span className="badge badge-amber" style={{ fontSize: 11 }}>
-                      {buildingTypeLabels[result.building_info.type] || result.building_info.type}
+                      {resolveBuildingType(result.building_info.type)}
                     </span>
                     <ConfidenceBadge provenance={buildingResultToProvenance(result)} />
                     <span style={{ color: "var(--text-muted)", fontSize: 11 }}>
@@ -332,7 +341,7 @@ export default function AddressSearch({
                   </h3>
                   <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
                     <span className="badge badge-amber">
-                      {buildingTypeLabels[result.building_info.type] || result.building_info.type}
+                      {resolveBuildingType(result.building_info.type)}
                     </span>
                     <ConfidenceBadge provenance={buildingResultToProvenance(result)} />
                   </div>
@@ -355,8 +364,8 @@ export default function AddressSearch({
                   { label: t('search.yearBuilt'), value: String(result.building_info.year_built) },
                   { label: t('search.area'), value: `${result.building_info.area_m2} m\u00B2` },
                   { label: t('search.floors'), value: String(result.building_info.floors) },
-                  { label: t('search.material'), value: materialLabels[result.building_info.material] || result.building_info.material },
-                  { label: t('search.heating'), value: heatingLabels[result.building_info.heating] || result.building_info.heating },
+                  { label: t('search.material'), value: resolveMaterial(result.building_info.material) },
+                  { label: t('search.heating'), value: resolveHeating(result.building_info.heating) },
                   { label: t('search.bomRows'), value: `${result.bom_suggestion.length} ${locale === 'fi' ? 'kpl' : 'pcs'}` },
                 ].map((item, i) => (
                   <div key={i} style={{

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -433,8 +433,24 @@ function PriceHistoryChart({
 }) {
   const { t } = useTranslation();
   const [range, setRange] = useState<TimeRange>("90d");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
   const days = TIME_RANGE_DAYS[range];
   const cutoff = Date.now() - days * 86400000;
+
+  // Measure container width and update on resize
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(el);
+    setContainerWidth(el.clientWidth);
+    return () => observer.disconnect();
+  }, []);
 
   const filtered = useMemo(
     () =>
@@ -461,7 +477,7 @@ function PriceHistoryChart({
 
   if (filtered.length === 0) {
     return (
-      <div style={{ textAlign: "center", padding: 16, color: "var(--text-muted)", fontSize: 12 }}>
+      <div ref={containerRef} style={{ textAlign: "center", padding: 16, color: "var(--text-muted)", fontSize: 12 }}>
         {t("pricing.limitedHistory")}
       </div>
     );
@@ -478,7 +494,7 @@ function PriceHistoryChart({
   const maxT = Math.max(...allTimes);
   const timeRange = maxT - minT || 1;
 
-  const chartW = 380;
+  const chartW = Math.max(containerWidth, 200);
   const chartH = 120;
   const padX = 4;
   const padY = 6;
@@ -492,7 +508,7 @@ function PriceHistoryChart({
   }
 
   return (
-    <div style={{ marginTop: 12 }}>
+    <div ref={containerRef} style={{ marginTop: 12 }}>
       {/* Time range selector */}
       <div style={{ display: "flex", gap: 4, marginBottom: 8 }}>
         {(["30d", "90d", "180d", "1y"] as TimeRange[]).map((r) => (
@@ -509,11 +525,10 @@ function PriceHistoryChart({
 
       {/* SVG chart */}
       <svg
-        width={chartW}
+        width="100%"
         height={chartH}
         style={{
-          width: "100%",
-          height: "auto",
+          display: "block",
           background: "var(--bg-tertiary)",
           borderRadius: "var(--radius-sm)",
           border: "1px solid var(--border)",

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -343,6 +343,7 @@ export default function CommandPalette({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={t("commandPalette.placeholder")}
+            aria-label={t("commandPalette.searchAriaLabel")}
             autoComplete="off"
             autoCorrect="off"
             spellCheck={false}

--- a/web/src/components/SceneParamsPanel.tsx
+++ b/web/src/components/SceneParamsPanel.tsx
@@ -135,6 +135,7 @@ function ParamSlider({
   param: SceneParam;
   onChange: (name: string, value: number) => void;
 }) {
+  const { t } = useTranslation();
   const [localValue, setLocalValue] = useState(param.value);
   const [dragging, setDragging] = useState(false);
 
@@ -186,7 +187,7 @@ function ParamSlider({
           step={param.step}
           value={localValue}
           disabled={param.max === param.min}
-          aria-label={`${param.label} slider`}
+          aria-label={t("editor.paramSliderLabel", { name: param.label })}
           aria-valuemin={param.min}
           aria-valuemax={param.max}
           aria-valuenow={localValue}

--- a/web/src/components/ScreenshotPopover.tsx
+++ b/web/src/components/ScreenshotPopover.tsx
@@ -129,7 +129,7 @@ export default function ScreenshotPopover({
       >
         <img
           src={imageDataUrl}
-          alt="Screenshot preview"
+          alt={t("screenshot.previewAlt")}
           style={{
             width: "100%",
             aspectRatio: "16 / 9",

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -275,6 +275,7 @@ const translations = {
       closeFindReplace: 'Sulje haku',
       exportProject: 'Vie projekti (.helscoop)',
       toBuy: 'Osta',
+      paramSliderLabel: '{{name}} — liukusäädin',
     },
     share: {
       title: 'Jaa projekti',
@@ -500,6 +501,7 @@ const translations = {
     screenshot: {
       dialogTitle: 'Kuvakaappaus',
       popoverLabel: 'Kuvakaappauksen esikatselu',
+      previewAlt: 'Kuvakaappauksen esikatselu',
       download: 'Lataa',
       copy: 'Kopioi',
       copied: 'Kopioitu!',
@@ -507,6 +509,7 @@ const translations = {
     commandPalette: {
       title: 'Komentovalikko',
       placeholder: 'Hae komentoa...',
+      searchAriaLabel: 'Hae komentoja',
       noResults: 'Ei tuloksia',
       navigate: 'navigoi',
       execute: 'suorita',
@@ -617,6 +620,14 @@ const translations = {
       rivitalo: 'Rivitalo',
       kerrostalo: 'Kerrostalo',
       paritalo: 'Paritalo',
+      materialWood: 'Puu',
+      materialBrick: 'Tiili',
+      materialConcrete: 'Betoni',
+      materialLog: 'Hirsi',
+      heatingDistrict: 'Kaukolämpö',
+      heatingElectric: 'Sähkö',
+      heatingGroundSource: 'Maalämpöpumppu',
+      heatingOil: 'Öljy',
       material: {
         puu: 'Puu',
         tiili: 'Tiili',
@@ -954,6 +965,7 @@ const translations = {
       closeFindReplace: 'Close find',
       exportProject: 'Export project (.helscoop)',
       toBuy: 'Buy',
+      paramSliderLabel: '{{name}} slider',
     },
     share: {
       title: 'Share project',
@@ -1179,6 +1191,7 @@ const translations = {
     screenshot: {
       dialogTitle: 'Screenshot',
       popoverLabel: 'Screenshot preview',
+      previewAlt: 'Screenshot preview',
       download: 'Download',
       copy: 'Copy',
       copied: 'Copied!',
@@ -1186,6 +1199,7 @@ const translations = {
     commandPalette: {
       title: 'Command palette',
       placeholder: 'Search commands...',
+      searchAriaLabel: 'Search commands',
       noResults: 'No results',
       navigate: 'navigate',
       execute: 'execute',
@@ -1296,6 +1310,14 @@ const translations = {
       rivitalo: 'Terraced house',
       kerrostalo: 'Apartment block',
       paritalo: 'Semi-detached',
+      materialWood: 'Wood',
+      materialBrick: 'Brick',
+      materialConcrete: 'Concrete',
+      materialLog: 'Log',
+      heatingDistrict: 'District heating',
+      heatingElectric: 'Electric',
+      heatingGroundSource: 'Ground source heat pump',
+      heatingOil: 'Oil',
       material: {
         puu: 'Wood',
         tiili: 'Brick',


### PR DESCRIPTION
## Summary
- **#706** PriceHistoryChart: responsive width via ResizeObserver
- **#711** SettingsPage: skeleton loading state
- **#712** CommandPalette: aria-label on search input
- **#687** ScreenshotPopover: i18n for preview alt text
- **#696** SceneParamsPanel: i18n for slider aria-label
- **#679** AddressSearch: i18n for building/material/heating labels

## Test plan
- [ ] PriceHistoryChart adapts to container width on resize
- [ ] SettingsPage shows skeleton cards while loading
- [ ] Screen readers announce correct labels
- [ ] Finnish/English translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)