### PR TITLE
fix: prio-7 batch — locale, i18n, a11y, clamp, touch

### DIFF
--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -210,7 +210,7 @@ function CostBreakdownChart({
   materials: Material[];
   total: number;
 }) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   const slices = useMemo<CategorySlice[]>(() => {
     if (total <= 0) return [];
@@ -302,7 +302,7 @@ function CostBreakdownChart({
               className="heading-display"
               style={{ fontSize: 14, lineHeight: 1.1, color: "var(--text-primary)" }}
             >
-              {total.toLocaleString("fi-FI", { maximumFractionDigits: 0 })}
+              {total.toLocaleString(locale, { maximumFractionDigits: 0 })}
             </span>
             <span style={{ fontSize: 9, color: "var(--text-muted)" }}>&euro;</span>
           </div>
@@ -347,7 +347,7 @@ function CostBreakdownChart({
                   fontVariantNumeric: "tabular-nums",
                 }}
               >
-                {s.pct.toFixed(0)}% &middot; {s.total.toLocaleString("fi-FI", { maximumFractionDigits: 0 })}&euro;
+                {s.pct.toFixed(0)}% &middot; {s.total.toLocaleString(locale, { maximumFractionDigits: 0 })}&euro;
               </span>
             </div>
           ))}
@@ -961,7 +961,7 @@ function QuoteSummary({
   bom: BomItem[];
   materials: Material[];
 }) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const [quoteMode, setQuoteMode] = useState<"homeowner" | "contractor">("homeowner");
 
   const quote = useMemo(() => {
@@ -1000,7 +1000,7 @@ function QuoteSummary({
   };
 
   const formatEur = (n: number) =>
-    n.toLocaleString("fi-FI", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " \u20ac";
+    n.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " \u20ac";
 
   return (
     <div
@@ -1612,7 +1612,7 @@ export default function BomPanel({
           </div>
           <div style={{ display: "flex", alignItems: "baseline", gap: 6 }}>
             <span style={{ fontSize: 24, fontWeight: 600, letterSpacing: "-0.025em", color: "var(--text-primary)", fontVariantNumeric: "tabular-nums" }}>
-              {animatedTotal > 0 ? Math.round(animatedTotal).toLocaleString('fi-FI', { maximumFractionDigits: 0 }) : '0'}
+              {animatedTotal > 0 ? Math.round(animatedTotal).toLocaleString(locale, { maximumFractionDigits: 0 }) : '0'}
             </span>
             <span style={{ fontSize: 14, color: "var(--text-muted)" }}>&euro;</span>
             {total > 0 && (
@@ -1697,7 +1697,7 @@ export default function BomPanel({
             onMouseEnter={(e) => { e.currentTarget.style.background = "var(--amber-glow)"; }}
             onMouseLeave={(e) => { e.currentTarget.style.background = "none"; }}
           >
-            {t('editor.syncFromScene') || 'Add them'}
+            {t('editor.syncFromScene')}
           </button>
         </div>
       )}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -229,7 +229,7 @@ export default function ChatPanel({
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <polyline points="18 15 12 9 6 15" />
           </svg>
-          <span>{messages.length} {messages.length === 1 ? t('editor.message') || "message" : t('editor.messages') || "messages"}</span>
+          <span>{messages.length} {messages.length === 1 ? t('editor.message') : t('editor.messages')}</span>
         </button>
       )}
 

--- a/web/src/components/ConnectionBanner.tsx
+++ b/web/src/components/ConnectionBanner.tsx
@@ -192,6 +192,7 @@ export default function ConnectionBanner() {
         <button
           onClick={handleRetryNow}
           className="connection-banner-retry"
+          style={{ minHeight: 44, minWidth: 44 }}
         >
           {t("errors.retryNow")}
         </button>

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -345,6 +345,7 @@ export default function ProjectList({
             <input
               className="input"
               placeholder={t('project.newProjectPlaceholder')}
+              aria-label={t('project.newProjectPlaceholder')}
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && createProject()}
@@ -471,6 +472,7 @@ export default function ProjectList({
                 <input
                   className="input"
                   placeholder={t('project.searchPlaceholder')}
+                  aria-label={t('project.searchPlaceholder')}
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   style={{ paddingLeft: 36 }}

--- a/web/src/components/TemplateGrid.tsx
+++ b/web/src/components/TemplateGrid.tsx
@@ -113,6 +113,10 @@ export default function TemplateGrid({
                 color: "var(--text-muted)",
                 fontSize: 13,
                 lineHeight: 1.5,
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical" as const,
+                overflow: "hidden",
               }}>
                 {tmpl.description}
               </div>

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -786,7 +786,7 @@ export default function Viewport3D({
             <span style={{ color: "var(--text-secondary)", fontSize: 12, fontFamily: "var(--font-sans)" }}>
               {tessProgress && tessProgress.total > 0
                 ? `${Math.round((tessProgress.done / tessProgress.total) * 100)}%`
-                : "Computing\u2026"}
+                : t('editor.computing')}
             </span>
           </div>
         </>

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -276,6 +276,7 @@ const translations = {
       exportProject: 'Vie projekti (.helscoop)',
       toBuy: 'Osta',
       paramSliderLabel: '{{name}} — liukusäädin',
+      computing: 'Laskee\u2026',
     },
     share: {
       title: 'Jaa projekti',
@@ -966,6 +967,7 @@ const translations = {
       exportProject: 'Export project (.helscoop)',
       toBuy: 'Buy',
       paramSliderLabel: '{{name}} slider',
+      computing: 'Computing\u2026',
     },
     share: {
       title: 'Share project',


### PR DESCRIPTION
## Summary
- **BomPanel**: use dynamic `locale` for `toLocaleString()` instead of hardcoded `fi-FI` (#737)
- **ChatPanel**: remove hardcoded English `|| "message"` fallback (#742)
- **ConnectionBanner**: increase retry button touch target to 44×44 (#758)
- **ProjectList**: add `aria-label` to new-project and search inputs (#754, #755)
- **TemplateGrid**: add 3-line CSS clamp to description overflow (#756)
- **Viewport3D**: use i18n key for "Computing…" status text (#748)
- **i18n**: add `editor.computing` key (fi + en) (#748)
- **BomPanel**: remove hardcoded English fallback from syncFromScene button (#740)

## Test plan
- [ ] Verify BOM panel formats numbers using browser locale
- [ ] Verify chat message count uses i18n strings
- [ ] Verify retry button meets 44px touch target
- [ ] Verify project list inputs have accessible labels
- [ ] Verify template descriptions truncate at 3 lines
- [ ] Verify computing status shows localized text

Closes #737, #740, #742, #748, #754, #755, #756, #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)