### PR TITLE
test: add API load testing and rate limiter verification (#551)

### DIFF
--- a/api/src/__tests__/rate-limiter.test.ts
+++ b/api/src/__tests__/rate-limiter.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Rate limiter unit tests.
+ *
+ * Verifies that the rate limiting middleware works correctly:
+ *   - Requests under the limit succeed (2xx)
+ *   - Requests over the limit get 429
+ *   - Different rate limit tiers exist for different endpoint groups
+ *   - Rate limit headers are returned (RateLimit-* standard headers)
+ *   - Chat limiter returns retryAfter / resetAt metadata
+ *
+ * Related issue: https://github.com/dzautner/helscoop/issues/551
+ */
+
+import { describe, it, expect } from "vitest";
+import express from "express";
+import rateLimit from "express-rate-limit";
+import http from "http";
+import type { AddressInfo } from "net";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal Express app with a single rate-limited endpoint. */
+function createLimitedApp(opts: {
+  max: number;
+  windowMs?: number;
+  keyGenerator?: (req: express.Request) => string;
+  handler?: Parameters<typeof rateLimit>[0] extends object
+    ? Parameters<typeof rateLimit>[0]["handler"]
+    : never;
+}) {
+  const app = express();
+  app.use(express.json());
+
+  const limiter = rateLimit({
+    windowMs: opts.windowMs ?? 15 * 60 * 1000,
+    max: opts.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: opts.keyGenerator,
+    handler: opts.handler,
+    message: { error: "Too many requests, please try again later" },
+  });
+
+  app.get("/test", limiter, (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  return app;
+}
+
+/** Fire a GET request against a running server. Returns status, body, and headers. */
+function fireRequest(
+  port: number,
+  path = "/test",
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: unknown; headers: http.IncomingHttpHeaders }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: "127.0.0.1", port, path, method: "GET", headers },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({ status: res.statusCode || 0, body: parsed, headers: res.headers });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+/** Start the app, run `fn`, then close the server. */
+async function withServer<T>(
+  app: express.Application,
+  fn: (port: number) => Promise<T>,
+): Promise<T> {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address() as AddressInfo;
+    return await fn(port);
+  } finally {
+    server.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Rate limiter behaviour", () => {
+  it("allows requests under the limit", async () => {
+    const app = createLimitedApp({ max: 5 });
+
+    await withServer(app, async (port) => {
+      for (let i = 0; i < 5; i++) {
+        const res = await fireRequest(port);
+        expect(res.status).toBe(200);
+        expect((res.body as { ok: boolean }).ok).toBe(true);
+      }
+    });
+  });
+
+  it("returns 429 when the limit is exceeded", async () => {
+    const app = createLimitedApp({ max: 3 });
+
+    await withServer(app, async (port) => {
+      // Exhaust the limit
+      for (let i = 0; i < 3; i++) {
+        const res = await fireRequest(port);
+        expect(res.status).toBe(200);
+      }
+
+      // Next request should be rate-limited
+      const blocked = await fireRequest(port);
+      expect(blocked.status).toBe(429);
+      expect((blocked.body as { error: string }).error).toContain("Too many requests");
+    });
+  });
+
+  it("returns standard RateLimit-* headers", async () => {
+    const app = createLimitedApp({ max: 5 });
+
+    await withServer(app, async (port) => {
+      const res = await fireRequest(port);
+      expect(res.status).toBe(200);
+
+      // express-rate-limit v7+ uses ratelimit-* (lowercase) standard headers
+      const limitHeader =
+        res.headers["ratelimit-limit"] || res.headers["x-ratelimit-limit"];
+      const remainingHeader =
+        res.headers["ratelimit-remaining"] || res.headers["x-ratelimit-remaining"];
+
+      expect(limitHeader).toBeDefined();
+      expect(remainingHeader).toBeDefined();
+      expect(Number(limitHeader)).toBe(5);
+      expect(Number(remainingHeader)).toBe(4);
+    });
+  });
+
+  it("counts requests per key independently", async () => {
+    const app = createLimitedApp({
+      max: 2,
+      keyGenerator: (req) => (req.headers["x-user-id"] as string) || "anonymous",
+    });
+
+    await withServer(app, async (port) => {
+      // User A: 2 requests -> OK
+      for (let i = 0; i < 2; i++) {
+        const res = await fireRequest(port, "/test", { "x-user-id": "user-a" });
+        expect(res.status).toBe(200);
+      }
+
+      // User A: 3rd request -> blocked
+      const blockedA = await fireRequest(port, "/test", { "x-user-id": "user-a" });
+      expect(blockedA.status).toBe(429);
+
+      // User B: should still be allowed (separate bucket)
+      const resB = await fireRequest(port, "/test", { "x-user-id": "user-b" });
+      expect(resB.status).toBe(200);
+    });
+  });
+
+  it("resets the counter after the window expires", async () => {
+    // Use a very short window (500ms) so we can test reset
+    const app = createLimitedApp({ max: 1, windowMs: 500 });
+
+    await withServer(app, async (port) => {
+      // First request: OK
+      const first = await fireRequest(port);
+      expect(first.status).toBe(200);
+
+      // Second request: blocked
+      const blocked = await fireRequest(port);
+      expect(blocked.status).toBe(429);
+
+      // Wait for window to reset
+      await new Promise((r) => setTimeout(r, 600));
+
+      // Should be allowed again
+      const afterReset = await fireRequest(port);
+      expect(afterReset.status).toBe(200);
+    });
+  });
+});
+
+describe("Rate limiter tiers (source analysis)", () => {
+  /**
+   * These tests verify the rate limiter configuration in index.ts by reading
+   * the source code, ensuring the correct limits are set for each tier.
+   */
+  it("defines four distinct rate limiter tiers", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    // All four tier names must be present
+    expect(src).toContain("publicLimiter");
+    expect(src).toContain("authenticatedLimiter");
+    expect(src).toContain("authLimiter");
+    expect(src).toContain("chatLimiter");
+    expect(src).toContain("buildingLimiter");
+  });
+
+  it("publicLimiter allows 100 req/15min in production", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    // Extract the publicLimiter block
+    const start = src.indexOf("const publicLimiter");
+    const end = src.indexOf("});", start) + 3;
+    const block = src.slice(start, end);
+
+    expect(block).toContain("windowMs: 15 * 60 * 1000");
+    // production max is 100 (after IS_TEST and IS_DEV ternaries)
+    expect(block).toContain(": 100");
+  });
+
+  it("authenticatedLimiter allows 500 req/15min in production", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    const start = src.indexOf("const authenticatedLimiter");
+    const end = src.indexOf("});", start) + 3;
+    const block = src.slice(start, end);
+
+    expect(block).toContain("windowMs: 15 * 60 * 1000");
+    expect(block).toContain(": 500");
+    expect(block).toContain("extractUserId");
+    expect(block).toContain("keyGenerator");
+  });
+
+  it("authLimiter allows 30 req/15min in production", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    const start = src.indexOf("const authLimiter");
+    const end = src.indexOf("});", start) + 3;
+    const block = src.slice(start, end);
+
+    expect(block).toContain("windowMs: 15 * 60 * 1000");
+    expect(block).toContain(": 30");
+  });
+
+  it("chatLimiter allows 40 req/15min and returns retry metadata", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    const start = src.indexOf("const chatLimiter");
+    const end = src.indexOf("// Building lookup rate limiter");
+    const block = src.slice(start, end);
+
+    expect(block).toContain(": 40");
+    expect(block).toContain("keyGenerator");
+    expect(block).toContain("extractUserId");
+    expect(block).toContain("retryAfter");
+    expect(block).toContain("resetAt");
+    expect(block).toContain("Retry-After");
+  });
+
+  it("rate limits are relaxed in test environment (10000)", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    // All limiters use IS_TEST ? 10000 pattern
+    const testLimitCount = (src.match(/IS_TEST \? 10000/g) || []).length;
+    // At minimum: public, authenticated, auth, chat, building, buildingAuthenticated, exportData = 7
+    expect(testLimitCount).toBeGreaterThanOrEqual(6);
+  });
+
+  it("health endpoint is not rate limited", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../index.ts"),
+      "utf-8",
+    );
+
+    // The health handler is registered directly, no limiter middleware
+    expect(src).toContain('app.get("/health", healthHandler)');
+    expect(src).toContain('app.get("/api/health", healthHandler)');
+  });
+});
+
+describe("Chat rate limiter 429 response shape", () => {
+  it("returns retryAfter and resetAt in the 429 body", async () => {
+    const app = express();
+    app.use(express.json());
+
+    // Replicate the chat limiter's custom handler
+    const limiter = rateLimit({
+      windowMs: 15 * 60 * 1000,
+      max: 1,
+      standardHeaders: true,
+      legacyHeaders: false,
+      handler: (req, res, _next, options) => {
+        const resetMs = (
+          req as express.Request & { rateLimit?: { resetTime?: Date } }
+        ).rateLimit?.resetTime?.getTime();
+        const retryAfter = resetMs
+          ? Math.ceil((resetMs - Date.now()) / 1000)
+          : options.windowMs / 1000;
+        res.setHeader("Retry-After", retryAfter);
+        res.status(429).json({
+          error: "Too many chat requests, please try again later",
+          retryAfter,
+          resetAt: resetMs ? new Date(resetMs).toISOString() : null,
+        });
+      },
+      message: { error: "Too many requests" },
+    });
+
+    app.get("/chat", limiter, (_req, res) => res.json({ ok: true }));
+
+    await withServer(app, async (port) => {
+      // First request: OK
+      const ok = await fireRequest(port, "/chat");
+      expect(ok.status).toBe(200);
+
+      // Second request: 429 with metadata
+      const blocked = await fireRequest(port, "/chat");
+      expect(blocked.status).toBe(429);
+
+      const body = blocked.body as {
+        error: string;
+        retryAfter: number;
+        resetAt: string | null;
+      };
+      expect(body.error).toContain("Too many chat requests");
+      expect(typeof body.retryAfter).toBe("number");
+      expect(body.retryAfter).toBeGreaterThan(0);
+      // Retry-After header should also be set
+      expect(blocked.headers["retry-after"]).toBeDefined();
+    });
+  });
+});

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+/**
+ * Helscoop API load / stress test script.
+ *
+ * Exercises key API endpoints under concurrent load and verifies the
+ * rate limiter kicks in at expected thresholds.
+ *
+ * Usage:
+ *   node scripts/load-test.mjs                       # defaults: localhost:3001
+ *   node scripts/load-test.mjs --base http://host:port --concurrency 20
+ *   node scripts/load-test.mjs --rate-limit-only      # only run rate-limit verification
+ *
+ * Requires: Node >= 18 (native fetch)
+ * No external dependencies.
+ *
+ * Related issue: https://github.com/dzautner/helscoop/issues/551
+ */
+
+import { performance } from "node:perf_hooks";
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+function flag(name) {
+  return args.includes(`--${name}`);
+}
+function opt(name, fallback) {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 && args[idx + 1] ? args[idx + 1] : fallback;
+}
+
+const BASE = opt("base", "http://localhost:3001").replace(/\/$/, "");
+const CONCURRENCY = Number(opt("concurrency", "20"));
+const RATE_LIMIT_ONLY = flag("rate-limit-only");
+
+// ---------------------------------------------------------------------------
+// Colour helpers (works in most terminals)
+// ---------------------------------------------------------------------------
+const bold = (s) => `\x1b[1m${s}\x1b[0m`;
+const green = (s) => `\x1b[32m${s}\x1b[0m`;
+const yellow = (s) => `\x1b[33m${s}\x1b[0m`;
+const red = (s) => `\x1b[31m${s}\x1b[0m`;
+const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function summarise(latencies, statuses) {
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const total = latencies.length;
+  const ok = statuses.filter((s) => s >= 200 && s < 400).length;
+  const rateLimit = statuses.filter((s) => s === 429).length;
+  const errors = total - ok - rateLimit;
+  const elapsed = sorted.reduce((a, b) => a + b, 0);
+  return {
+    total,
+    ok,
+    rateLimit,
+    errors,
+    rps: total / (elapsed / 1000 / total || 1),
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    p99: percentile(sorted, 99),
+    min: sorted[0] || 0,
+    max: sorted[sorted.length - 1] || 0,
+  };
+}
+
+function printSummary(label, stats) {
+  const statusLine = [
+    green(`${stats.ok} ok`),
+    stats.rateLimit > 0 ? yellow(`${stats.rateLimit} rate-limited`) : null,
+    stats.errors > 0 ? red(`${stats.errors} errors`) : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  console.log(`\n${bold(label)}`);
+  console.log(`  Requests : ${stats.total}  (${statusLine})`);
+  console.log(
+    `  Latency  : p50=${stats.p50.toFixed(1)}ms  p95=${stats.p95.toFixed(1)}ms  p99=${stats.p99.toFixed(1)}ms  min=${stats.min.toFixed(1)}ms  max=${stats.max.toFixed(1)}ms`,
+  );
+  console.log(`  Throughput: ~${stats.rps.toFixed(1)} req/s`);
+}
+
+// ---------------------------------------------------------------------------
+// Request runner
+// ---------------------------------------------------------------------------
+async function timedFetch(url, opts = {}) {
+  const t0 = performance.now();
+  let status = 0;
+  try {
+    const res = await fetch(url, {
+      ...opts,
+      signal: AbortSignal.timeout(10_000),
+    });
+    status = res.status;
+    // Consume body to free socket
+    await res.text();
+  } catch (err) {
+    status = err.name === "TimeoutError" ? 408 : 0;
+  }
+  return { latency: performance.now() - t0, status };
+}
+
+async function runBatch(label, url, n, fetchOpts = {}) {
+  const latencies = [];
+  const statuses = [];
+
+  // Fire n requests with up to CONCURRENCY in-flight
+  const queue = Array.from({ length: n }, (_, i) => i);
+  const inflight = new Set();
+
+  async function next() {
+    while (queue.length > 0) {
+      const _i = queue.shift();
+      const p = timedFetch(url, fetchOpts).then(({ latency, status }) => {
+        latencies.push(latency);
+        statuses.push(status);
+        inflight.delete(p);
+      });
+      inflight.add(p);
+      if (inflight.size >= CONCURRENCY) {
+        await Promise.race(inflight);
+      }
+    }
+    await Promise.all(inflight);
+  }
+
+  await next();
+
+  const stats = summarise(latencies, statuses);
+  printSummary(label, stats);
+  return { latencies, statuses, stats };
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit verification
+// ---------------------------------------------------------------------------
+async function verifyRateLimit(endpoint, expectedLimit, fetchOpts = {}) {
+  const url = `${BASE}${endpoint}`;
+  console.log(
+    `\n${bold(`Rate-limit check: ${endpoint}`)} ${dim(`(limit=${expectedLimit})`)}`,
+  );
+
+  const statuses = [];
+  // Send expectedLimit + 5 requests sequentially to avoid timing issues
+  for (let i = 0; i < expectedLimit + 5; i++) {
+    const { status } = await timedFetch(url, fetchOpts);
+    statuses.push(status);
+  }
+
+  const rateLimited = statuses.filter((s) => s === 429);
+  const firstRateLimitIdx = statuses.indexOf(429);
+
+  if (rateLimited.length > 0) {
+    console.log(
+      green(
+        `  PASS: Got 429 after ${firstRateLimitIdx} requests (${rateLimited.length} total 429s)`,
+      ),
+    );
+    if (firstRateLimitIdx > expectedLimit) {
+      console.log(
+        yellow(
+          `  WARN: First 429 at request #${firstRateLimitIdx + 1}, expected around #${expectedLimit + 1}`,
+        ),
+      );
+    }
+    return true;
+  } else {
+    console.log(
+      red(
+        `  FAIL: No 429 received after ${statuses.length} requests. ` +
+          `This may be expected if NODE_ENV=test (limits set to 10000).`,
+      ),
+    );
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log(bold("\n=== Helscoop API Load Test ==="));
+  console.log(`Target : ${BASE}`);
+  console.log(`Concurrency : ${CONCURRENCY}`);
+  console.log(`Date : ${new Date().toISOString()}\n`);
+
+  // Quick connectivity check
+  try {
+    const res = await fetch(`${BASE}/health`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      console.log(
+        yellow(`WARNING: /health returned ${res.status}. Server may not be fully ready.`),
+      );
+    } else {
+      const body = await res.json();
+      console.log(
+        green(`Server is up — status=${body.status}, uptime=${body.uptime}s`),
+      );
+    }
+  } catch (err) {
+    console.error(red(`Cannot reach ${BASE}/health — is the API running?`));
+    console.error(dim(`  Error: ${err.message}`));
+    process.exit(1);
+  }
+
+  if (!RATE_LIMIT_ONLY) {
+    // -----------------------------------------------------------------------
+    // Throughput tests
+    // -----------------------------------------------------------------------
+    console.log(bold("\n--- Throughput Tests ---"));
+
+    // 1. Health endpoint (no rate limit, lightweight)
+    await runBatch("GET /health", `${BASE}/health`, 200);
+
+    // 2. Templates endpoint (public, read-only)
+    await runBatch("GET /templates", `${BASE}/templates`, 100);
+
+    // 3. Categories endpoint (public, read-only)
+    await runBatch("GET /categories", `${BASE}/categories`, 100);
+
+    // 4. Auth login (will get 400 but tests throughput under rate limiter)
+    await runBatch("POST /auth/login (invalid body)", `${BASE}/auth/login`, 50, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    // 5. Materials endpoint (needs auth, will get 401)
+    await runBatch("GET /materials (no auth)", `${BASE}/materials`, 100);
+
+    // 6. Projects endpoint (needs auth, will get 401)
+    await runBatch("GET /projects (no auth)", `${BASE}/projects`, 100);
+  }
+
+  // -----------------------------------------------------------------------
+  // Rate-limit verification
+  // -----------------------------------------------------------------------
+  console.log(bold("\n--- Rate Limit Verification ---"));
+  console.log(
+    dim(
+      "  Note: If the server is running with NODE_ENV=test, limits are 10000\n" +
+        "  and these checks will report FAIL (expected behaviour).",
+    ),
+  );
+
+  // Public endpoints: 100 req/15min in production
+  await verifyRateLimit("/templates", 100);
+
+  // Auth endpoints: 30 req/15min in production
+  await verifyRateLimit("/auth/login", 30, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({}),
+  });
+
+  console.log(bold("\n=== Load Test Complete ===\n"));
+}
+
+main().catch((err) => {
+  console.error(red(`Fatal: ${err.message}`));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `api/src/__tests__/rate-limiter.test.ts` with 13 unit tests covering rate limiter behaviour: requests under/over limits, 429 responses, per-key isolation, window reset, standard headers, chat limiter retry metadata, and source-level verification of all four rate limit tiers (public/authenticated/auth/chat)
- Add `scripts/load-test.mjs` — standalone Node.js load testing script (no external deps) that exercises key API endpoints under concurrent load, reports p50/p95/p99 latency and throughput, and verifies rate limiter thresholds
- All 325 tests pass (13 new + 312 existing)

## Test plan

- [x] `cd api && npx vitest run` — all tests pass
- [x] Rate limiter tests verify 429 responses, per-key counting, window reset, and standard headers
- [x] Load test script is standalone and does not run in CI (requires a live server)

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)