### PR TITLE
feat: compliance export audit trail with immutable source snapshots (#654)

### DIFF
--- a/api/src/__tests__/audit.test.ts
+++ b/api/src/__tests__/audit.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Unit and integration tests for the compliance export audit trail.
+ *
+ * Tests cover:
+ *   - The audit helper functions (hashArtifact, createAuditLog)
+ *   - The /audit REST endpoints (auth, authorization, pagination)
+ *
+ * All tests run without a real database — the db module is mocked.
+ */
+
+process.env.NODE_ENV = "test";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+import http from "http";
+import type { AddressInfo } from "net";
+
+const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+
+// Mock the database module BEFORE any app import
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] }),
+  pool: { query: vi.fn() },
+}));
+
+// Mock email to avoid Resend initialization
+vi.mock("../email", () => ({
+  sendEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendPriceAlertEmail: vi.fn(),
+}));
+
+import { query } from "../db";
+const mockQuery = vi.mocked(query);
+
+import {
+  hashArtifact,
+  createAuditLog,
+  logAuditEvent,
+} from "../audit";
+
+import app from "../index";
+
+// ---------------------------------------------------------------------------
+// Helper: create a JWT auth token
+// ---------------------------------------------------------------------------
+function authToken(userId = "user-1", role = "admin") {
+  return jwt.sign(
+    { id: userId, email: "test@helscoop.fi", role },
+    JWT_SECRET,
+    { expiresIn: "7d" }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: make HTTP requests against the Express app
+// ---------------------------------------------------------------------------
+function makeRequest(
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {}
+): Promise<{ status: number; body: unknown; headers: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const bodyStr = opts.body ? JSON.stringify(opts.body) : undefined;
+      const reqOpts: http.RequestOptions = {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: method.toUpperCase(),
+        headers: {
+          "Content-Type": "application/json",
+          ...opts.headers,
+        },
+      };
+
+      const req = http.request(reqOpts, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          server.close();
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({
+            status: res.statusCode || 0,
+            body: parsed,
+            headers: res.headers as Record<string, string>,
+          });
+        });
+      });
+
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
+});
+
+// ---------------------------------------------------------------------------
+// 1. hashArtifact
+// ---------------------------------------------------------------------------
+describe("hashArtifact", () => {
+  it("returns a 64-character hex SHA-256 hash for a string", () => {
+    const hash = hashArtifact("hello world");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns a 64-character hex SHA-256 hash for a Buffer", () => {
+    const hash = hashArtifact(Buffer.from("hello world"));
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces the same hash for string and Buffer with same content", () => {
+    const content = "test content for hashing";
+    expect(hashArtifact(content)).toBe(hashArtifact(Buffer.from(content)));
+  });
+
+  it("produces different hashes for different content", () => {
+    expect(hashArtifact("content A")).not.toBe(hashArtifact("content B"));
+  });
+
+  it("produces the known SHA-256 for an empty string", () => {
+    // SHA-256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    expect(hashArtifact("")).toBe(
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. createAuditLog
+// ---------------------------------------------------------------------------
+describe("createAuditLog", () => {
+  it("inserts a row into audit_logs and returns it", async () => {
+    const fakeRow = {
+      id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      user_id: "user-1",
+      project_id: "proj-1",
+      action: "export_pdf",
+      artifact_type: "pdf_quote",
+      artifact_hash: "abc123",
+      source_snapshot: {},
+      metadata: {},
+      created_at: new Date().toISOString(),
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [fakeRow] } as any);
+
+    const result = await createAuditLog(
+      "user-1",
+      "proj-1",
+      "export_pdf",
+      "pdf_quote",
+      "abc123",
+      {},
+      {}
+    );
+
+    expect(result).toEqual(fakeRow);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO audit_logs"),
+      expect.arrayContaining(["user-1", "proj-1", "export_pdf", "pdf_quote", "abc123"])
+    );
+  });
+
+  it("returns null gracefully when the table does not exist", async () => {
+    mockQuery.mockImplementationOnce(() => {
+      throw new Error('relation "audit_logs" does not exist');
+    });
+
+    const result = await createAuditLog("user-1", null, "export_csv", null, null);
+    expect(result).toBeNull();
+  });
+
+  it("accepts null project_id", async () => {
+    const fakeRow = {
+      id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      user_id: "user-1",
+      project_id: null,
+      action: "account.delete",
+      artifact_type: null,
+      artifact_hash: null,
+      source_snapshot: {},
+      metadata: {},
+      created_at: new Date().toISOString(),
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [fakeRow] } as any);
+
+    const result = await createAuditLog("user-1", null, "account.delete", null, null);
+    expect(result).not.toBeNull();
+    expect(result!.project_id).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. logAuditEvent (structured logger — backwards compat)
+// ---------------------------------------------------------------------------
+describe("logAuditEvent", () => {
+  it("does not throw and completes synchronously", () => {
+    expect(() => logAuditEvent("u1", "test.action", { ip: "127.0.0.1" })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. GET /audit/logs — admin list
+// ---------------------------------------------------------------------------
+describe("GET /audit/logs", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("GET", "/audit/logs");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin users", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/audit/logs", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns paginated audit logs for admin", async () => {
+    const fakeLogs = [
+      {
+        id: "log-1",
+        user_id: "user-1",
+        project_id: "proj-1",
+        action: "export_pdf",
+        artifact_type: "pdf_quote",
+        artifact_hash: "abc",
+        source_snapshot: {},
+        metadata: {},
+        created_at: new Date().toISOString(),
+      },
+    ];
+
+    // First call: SELECT * FROM audit_logs ... LIMIT/OFFSET
+    // Second call: SELECT COUNT(*)
+    mockQuery
+      .mockResolvedValueOnce({ rows: fakeLogs } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "1" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/audit/logs?limit=10&offset=0", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { logs: unknown[]; total: number };
+    expect(body.logs).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. GET /audit/logs/:id — single entry
+// ---------------------------------------------------------------------------
+describe("GET /audit/logs/:id", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("GET", "/audit/logs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid UUID format", async () => {
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/audit/logs/not-a-uuid", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for non-existent audit log", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/audit/logs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns the audit log entry for admin", async () => {
+    const fakeLog = {
+      id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      user_id: "user-1",
+      project_id: "proj-1",
+      action: "export_pdf",
+      artifact_type: "pdf_quote",
+      artifact_hash: "abc",
+      source_snapshot: { bom: [] },
+      metadata: { format: "A4" },
+      created_at: new Date().toISOString(),
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [fakeLog] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/audit/logs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).id).toBe(fakeLog.id);
+    expect((res.body as any).source_snapshot).toEqual({ bom: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. GET /audit/project/:projectId — project-scoped logs
+// ---------------------------------------------------------------------------
+describe("GET /audit/project/:projectId", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("GET", "/audit/project/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects invalid project ID format", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/audit/project/bad-id", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for non-existent project (non-admin)", async () => {
+    // Project lookup returns empty
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/audit/project/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when non-admin requests another user's project", async () => {
+    // Project belongs to a different user
+    mockQuery.mockResolvedValueOnce({ rows: [{ user_id: "other-user" }] } as any);
+
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/audit/project/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns audit logs for project owner", async () => {
+    const projectId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    // 1st call: project ownership check
+    mockQuery.mockResolvedValueOnce({ rows: [{ user_id: "user-1" }] } as any);
+    // 2nd call: audit logs
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "log-1", action: "export_pdf", project_id: projectId }],
+    } as any);
+    // 3rd call: count
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: "1" }] } as any);
+
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", `/audit/project/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { logs: unknown[]; total: number };
+    expect(body.logs).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+
+  it("admin can access any project's audit logs without ownership check", async () => {
+    const projectId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+    // Admin skips ownership check — goes straight to audit logs query
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ id: "log-1", action: "generate_quote", project_id: projectId }],
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "1" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", `/audit/project/${projectId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).logs).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. POST /audit/log — create audit entry
+// ---------------------------------------------------------------------------
+describe("POST /audit/log", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("POST", "/audit/log", {
+      body: { action: "export_pdf" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin users", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("POST", "/audit/log", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { action: "export_pdf" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects requests without action", async () => {
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("POST", "/audit/log", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: {},
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toContain("action");
+  });
+
+  it("creates audit log entry for admin", async () => {
+    const fakeLog = {
+      id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      user_id: "admin-1",
+      project_id: "proj-1",
+      action: "export_pdf",
+      artifact_type: "pdf_quote",
+      artifact_hash: "def456",
+      source_snapshot: { items: [1, 2, 3] },
+      metadata: { format: "A4" },
+      created_at: new Date().toISOString(),
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [fakeLog] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("POST", "/audit/log", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: {
+        projectId: "proj-1",
+        action: "export_pdf",
+        artifactType: "pdf_quote",
+        artifactHash: "def456",
+        sourceSnapshot: { items: [1, 2, 3] },
+        metadata: { format: "A4" },
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect((res.body as any).id).toBe(fakeLog.id);
+    expect((res.body as any).action).toBe("export_pdf");
+  });
+});

--- a/api/src/audit.ts
+++ b/api/src/audit.ts
@@ -1,4 +1,6 @@
+import crypto from "crypto";
 import logger from "./logger";
+import { query } from "./db";
 
 export interface AuditEventDetails {
   targetId?: string;
@@ -25,4 +27,124 @@ export function logAuditEvent(
     timestamp: new Date().toISOString(),
     ...details,
   });
+}
+
+// ---------------------------------------------------------------------------
+// Compliance audit trail — immutable database records for export artifacts
+// ---------------------------------------------------------------------------
+
+export interface AuditLogEntry {
+  id: string;
+  user_id: string;
+  project_id: string | null;
+  action: string;
+  artifact_type: string | null;
+  artifact_hash: string | null;
+  source_snapshot: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+/**
+ * Compute SHA-256 hash of an artifact (Buffer or string).
+ */
+export function hashArtifact(content: Buffer | string): string {
+  return crypto.createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Record a compliance audit event in the database.
+ *
+ * This is the primary function called by export routes to create an immutable
+ * record of what was generated, from what inputs, and by whom.
+ *
+ * Returns the created audit log entry, or null if the table doesn't exist yet.
+ */
+export async function createAuditLog(
+  userId: string,
+  projectId: string | null,
+  action: string,
+  artifactType: string | null,
+  artifactHash: string | null,
+  sourceSnapshot: Record<string, unknown> = {},
+  metadata: Record<string, unknown> = {}
+): Promise<AuditLogEntry | null> {
+  try {
+    const result = await query(
+      `INSERT INTO audit_logs (user_id, project_id, action, artifact_type, artifact_hash, source_snapshot, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING *`,
+      [
+        userId,
+        projectId,
+        action,
+        artifactType,
+        artifactHash,
+        JSON.stringify(sourceSnapshot),
+        JSON.stringify(metadata),
+      ]
+    );
+    return result.rows[0] as AuditLogEntry;
+  } catch (err) {
+    // Log but don't fail the calling operation — audit is best-effort
+    // until the migration has been applied.
+    logger.warn(
+      { err, userId, action },
+      "Failed to write audit log (table may not exist yet)"
+    );
+    return null;
+  }
+}
+
+/**
+ * List audit log entries with pagination. Admin-only in practice.
+ */
+export async function listAuditLogs(
+  limit = 50,
+  offset = 0
+): Promise<{ logs: AuditLogEntry[]; total: number }> {
+  const [logsResult, countResult] = await Promise.all([
+    query(
+      `SELECT * FROM audit_logs ORDER BY created_at DESC LIMIT $1 OFFSET $2`,
+      [limit, offset]
+    ),
+    query(`SELECT COUNT(*) AS total FROM audit_logs`),
+  ]);
+  return {
+    logs: logsResult.rows as AuditLogEntry[],
+    total: parseInt(countResult.rows[0].total, 10),
+  };
+}
+
+/**
+ * Get a single audit log entry by ID.
+ */
+export async function getAuditLog(
+  id: string
+): Promise<AuditLogEntry | null> {
+  const result = await query(`SELECT * FROM audit_logs WHERE id = $1`, [id]);
+  return (result.rows[0] as AuditLogEntry) ?? null;
+}
+
+/**
+ * List audit log entries for a specific project.
+ */
+export async function listAuditLogsByProject(
+  projectId: string,
+  limit = 50,
+  offset = 0
+): Promise<{ logs: AuditLogEntry[]; total: number }> {
+  const [logsResult, countResult] = await Promise.all([
+    query(
+      `SELECT * FROM audit_logs WHERE project_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [projectId, limit, offset]
+    ),
+    query(`SELECT COUNT(*) AS total FROM audit_logs WHERE project_id = $1`, [
+      projectId,
+    ]),
+  ]);
+  return {
+    logs: logsResult.rows as AuditLogEntry[],
+    total: parseInt(countResult.rows[0].total, 10),
+  };
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -17,6 +17,7 @@ import chatRouter from "./routes/chat";
 import buildingRouter from "./routes/building";
 import entitlementsRouter from "./routes/entitlements";
 import rolesRouter from "./routes/roles";
+import auditRouter from "./routes/audit";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
 
@@ -590,6 +591,7 @@ app.use("/pricing", authenticatedLimiter, pricingRouter);
 app.use("/chat", chatLimiter, chatRouter);
 app.use("/entitlements", authenticatedLimiter, entitlementsRouter);
 app.use("/roles", authenticatedLimiter, rolesRouter);
+app.use("/audit", authenticatedLimiter, auditRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated
 app.use("/building", buildingLimiter, buildingLimiterAuthenticated, buildingRouter);
 

--- a/api/src/routes/audit.ts
+++ b/api/src/routes/audit.ts
@@ -1,0 +1,130 @@
+import { Router } from "express";
+import { requireAuth } from "../auth";
+import { requirePermission } from "../permissions";
+import { query } from "../db";
+import {
+  createAuditLog,
+  listAuditLogs,
+  getAuditLog,
+  listAuditLogsByProject,
+} from "../audit";
+
+const router = Router();
+
+// All audit routes require authentication
+router.use(requireAuth);
+
+// ---------------------------------------------------------------------------
+// GET /audit/logs — list all audit entries (admin only, paginated)
+// ---------------------------------------------------------------------------
+router.get("/logs", requirePermission("admin:access"), async (req, res) => {
+  const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+  const offset = parseInt(req.query.offset as string) || 0;
+
+  try {
+    const result = await listAuditLogs(limit, offset);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch audit logs" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /audit/logs/:id — get a single audit entry (admin only)
+// ---------------------------------------------------------------------------
+router.get("/logs/:id", requirePermission("admin:access"), async (req, res) => {
+  const { id } = req.params;
+
+  // Basic UUID format validation
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id)) {
+    return res.status(400).json({ error: "Invalid audit log ID" });
+  }
+
+  try {
+    const log = await getAuditLog(id);
+    if (!log) {
+      return res.status(404).json({ error: "Audit log not found" });
+    }
+    res.json(log);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch audit log" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /audit/project/:projectId — get audit entries for a project
+// (project owner or admin)
+// ---------------------------------------------------------------------------
+router.get("/project/:projectId", async (req, res) => {
+  const { projectId } = req.params;
+
+  if (!projectId || !/^[0-9a-f-]{36}$/i.test(projectId)) {
+    return res.status(400).json({ error: "Invalid project ID" });
+  }
+
+  const userId = req.user!.id;
+  const userRole = req.user!.role;
+
+  // Check project ownership for non-admins
+  if (userRole !== "admin") {
+    try {
+      const projectResult = await query(
+        "SELECT user_id FROM projects WHERE id = $1",
+        [projectId]
+      );
+      if (projectResult.rows.length === 0) {
+        return res.status(404).json({ error: "Project not found" });
+      }
+      if (projectResult.rows[0].user_id !== userId) {
+        return res.status(403).json({ error: "Access denied" });
+      }
+    } catch (err) {
+      return res.status(500).json({ error: "Failed to verify project access" });
+    }
+  }
+
+  const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+  const offset = parseInt(req.query.offset as string) || 0;
+
+  try {
+    const result = await listAuditLogsByProject(projectId, limit, offset);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch audit logs" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /audit/log — create an audit entry (internal use)
+// Requires admin:access to prevent abuse. Export routes should call
+// createAuditLog() directly from the audit module instead.
+// ---------------------------------------------------------------------------
+router.post("/log", requirePermission("admin:access"), async (req, res) => {
+  const { projectId, action, artifactType, artifactHash, sourceSnapshot, metadata } = req.body;
+
+  if (!action || typeof action !== "string") {
+    return res.status(400).json({ error: "action is required" });
+  }
+
+  try {
+    const log = await createAuditLog(
+      req.user!.id,
+      projectId || null,
+      action,
+      artifactType || null,
+      artifactHash || null,
+      sourceSnapshot || {},
+      metadata || {}
+    );
+
+    if (!log) {
+      return res.status(500).json({ error: "Failed to create audit log" });
+    }
+
+    res.status(201).json(log);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to create audit log" });
+  }
+});
+
+export default router;

--- a/db/migrations/011_audit_logs.sql
+++ b/db/migrations/011_audit_logs.sql
@@ -1,0 +1,29 @@
+-- Migration 011: Create audit_logs table for compliance export audit trail
+--
+-- Provides immutable traceability for every generated artifact (PDF quotes,
+-- CSV BOMs, carbon reports, etc.). Each row captures the artifact hash,
+-- a frozen snapshot of the inputs, and arbitrary metadata.
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  project_id    UUID REFERENCES projects(id) ON DELETE SET NULL,
+  action        TEXT NOT NULL,
+  artifact_type TEXT,
+  artifact_hash TEXT,
+  source_snapshot JSONB DEFAULT '{}'::jsonb,
+  metadata      JSONB DEFAULT '{}'::jsonb,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for fast lookups by project
+CREATE INDEX IF NOT EXISTS idx_audit_logs_project_id ON audit_logs (project_id);
+
+-- Index for fast lookups by user
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs (user_id);
+
+-- Index for chronological listing (admin view)
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs (created_at DESC);
+
+-- Index for filtering by action type
+CREATE INDEX IF NOT EXISTS idx_audit_logs_action ON audit_logs (action);


### PR DESCRIPTION
## Summary

- Adds `audit_logs` table (migration 011) with columns for user, project, action, artifact type, SHA-256 artifact hash, frozen source snapshot (JSONB), and metadata (JSONB)
- Extends `api/src/audit.ts` with database-backed `createAuditLog()`, `hashArtifact()`, and query helpers (`listAuditLogs`, `getAuditLog`, `listAuditLogsByProject`) while preserving the existing `logAuditEvent()` structured logger
- Adds `api/src/routes/audit.ts` with four endpoints: `GET /audit/logs` (admin, paginated), `GET /audit/logs/:id` (admin), `GET /audit/project/:projectId` (owner or admin), `POST /audit/log` (admin/internal)
- Mounts the audit router in `index.ts` with the standard authenticated rate limiter

## Test plan

- [x] 26 new tests in `audit.test.ts` covering hashArtifact, createAuditLog, logAuditEvent, and all four route endpoints
- [x] Tests verify auth (401), authorization (403 for non-admin), input validation (400), not-found (404), and happy paths (200/201)
- [x] All 367 tests pass (no regressions)
- [x] Graceful degradation: `createAuditLog` returns null if the migration hasn't been applied yet

Closes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)