### PR TITLE
feat: admin backoffice API for user/project ops (#653)

### DIFF
--- a/api/src/__tests__/admin.test.ts
+++ b/api/src/__tests__/admin.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Tests for admin backoffice API endpoints.
+ *
+ * Covers:
+ *   - GET /admin/users (paginated list, search, role filter)
+ *   - GET /admin/users/:id (user detail with project count)
+ *   - PATCH /admin/users/:id/role (role update)
+ *   - GET /admin/stats (dashboard statistics)
+ *   - Auth and permission checks for all endpoints
+ */
+
+process.env.NODE_ENV = "test";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import jwt from "jsonwebtoken";
+import http from "http";
+import type { AddressInfo } from "net";
+
+const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+
+// Mock the database module BEFORE any app import
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] }),
+  pool: { query: vi.fn() },
+}));
+
+// Mock email to avoid Resend initialization
+vi.mock("../email", () => ({
+  sendEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendPriceAlertEmail: vi.fn(),
+}));
+
+import { query } from "../db";
+const mockQuery = vi.mocked(query);
+
+import app from "../index";
+
+// ---------------------------------------------------------------------------
+// Helper: create a JWT auth token
+// ---------------------------------------------------------------------------
+function authToken(userId = "user-1", role = "admin") {
+  return jwt.sign(
+    { id: userId, email: "test@helscoop.fi", role },
+    JWT_SECRET,
+    { expiresIn: "7d" }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: make HTTP requests against the Express app
+// ---------------------------------------------------------------------------
+function makeRequest(
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {}
+): Promise<{ status: number; body: unknown; headers: Record<string, string> }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const bodyStr = opts.body ? JSON.stringify(opts.body) : undefined;
+      const reqOpts: http.RequestOptions = {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: method.toUpperCase(),
+        headers: {
+          "Content-Type": "application/json",
+          ...opts.headers,
+        },
+      };
+
+      const req = http.request(reqOpts, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          server.close();
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({
+            status: res.statusCode || 0,
+            body: parsed,
+            headers: res.headers as Record<string, string>,
+          });
+        });
+      });
+
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/users
+// ---------------------------------------------------------------------------
+describe("GET /admin/users", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("GET", "/admin/users");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin users", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/admin/users", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns paginated user list for admin", async () => {
+    const fakeUsers = [
+      {
+        id: "user-1",
+        email: "alice@test.com",
+        name: "Alice",
+        role: "homeowner",
+        email_verified: true,
+        created_at: "2025-01-01T00:00:00Z",
+      },
+      {
+        id: "user-2",
+        email: "bob@test.com",
+        name: "Bob",
+        role: "contractor",
+        email_verified: false,
+        created_at: "2025-01-02T00:00:00Z",
+      },
+    ];
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: fakeUsers } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "2" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users?limit=10&offset=0", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { users: unknown[]; total: number; limit: number; offset: number };
+    expect(body.users).toHaveLength(2);
+    expect(body.total).toBe(2);
+    expect(body.limit).toBe(10);
+    expect(body.offset).toBe(0);
+  });
+
+  it("normalizes roles in response", async () => {
+    const fakeUsers = [
+      {
+        id: "user-1",
+        email: "legacy@test.com",
+        name: "Legacy",
+        role: "user",
+        email_verified: true,
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ];
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: fakeUsers } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "1" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { users: Array<{ role: string }> };
+    expect(body.users[0].role).toBe("homeowner");
+  });
+
+  it("applies search filter", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "0" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users?search=alice", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    // Verify the search parameter was passed to the query
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("ILIKE"),
+      expect.arrayContaining(["%alice%"])
+    );
+  });
+
+  it("applies role filter", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "0" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users?role=contractor", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("role = $"),
+      expect.arrayContaining(["contractor"])
+    );
+  });
+
+  it("caps limit at 100", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "0" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users?limit=500", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { limit: number };
+    expect(body.limit).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/users/:id
+// ---------------------------------------------------------------------------
+describe("GET /admin/users/:id", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("GET", "/admin/users/user-1");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin users", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/admin/users/user-1", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for non-existent user", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users/nonexistent", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns user detail with project count", async () => {
+    const fakeUser = {
+      id: "user-1",
+      email: "alice@test.com",
+      name: "Alice",
+      role: "homeowner",
+      email_verified: true,
+      created_at: "2025-01-01T00:00:00Z",
+    };
+
+    mockQuery
+      .mockResolvedValueOnce({ rows: [fakeUser] } as any)
+      .mockResolvedValueOnce({ rows: [{ project_count: "5" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/users/user-1", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { id: string; project_count: number; role: string };
+    expect(body.id).toBe("user-1");
+    expect(body.project_count).toBe(5);
+    expect(body.role).toBe("homeowner");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /admin/users/:id/role
+// ---------------------------------------------------------------------------
+describe("PATCH /admin/users/:id/role", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("PATCH", "/admin/users/user-1/role", {
+      body: { role: "contractor" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin users", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("PATCH", "/admin/users/user-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "contractor" },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects missing role", async () => {
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("PATCH", "/admin/users/user-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: {},
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toContain("Role is required");
+  });
+
+  it("rejects invalid role", async () => {
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("PATCH", "/admin/users/user-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "superuser" },
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toContain("Invalid role");
+  });
+
+  it("prevents admin from demoting themselves", async () => {
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("PATCH", "/admin/users/admin-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "homeowner" },
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as any).error).toContain("Cannot change your own role");
+  });
+
+  it("returns 404 for non-existent user", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("PATCH", "/admin/users/nonexistent/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "contractor" },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("updates user role successfully", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "user-1", role: "homeowner" }] } as any)
+      .mockResolvedValueOnce({
+        rows: [{ id: "user-1", email: "alice@test.com", name: "Alice", role: "contractor" }],
+      } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("PATCH", "/admin/users/user-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "contractor" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { id: string; role: string };
+    expect(body.id).toBe("user-1");
+    expect(body.role).toBe("contractor");
+  });
+
+  it("allows admin to keep their own admin role", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "admin-1", role: "admin" }] } as any)
+      .mockResolvedValueOnce({
+        rows: [{ id: "admin-1", email: "admin@test.com", name: "Admin", role: "admin" }],
+      } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("PATCH", "/admin/users/admin-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "admin" },
+    });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/stats
+// ---------------------------------------------------------------------------
+describe("GET /admin/stats", () => {
+  it("rejects unauthenticated requests", async () => {
+    const res = await makeRequest("GET", "/admin/stats");
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-admin users", async () => {
+    const token = authToken("user-1", "homeowner");
+    const res = await makeRequest("GET", "/admin/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns dashboard stats for admin", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: "42" }] } as any) // user count
+      .mockResolvedValueOnce({ rows: [{ total: "15" }] } as any) // project count
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "user-new",
+            email: "new@test.com",
+            name: "New User",
+            role: "homeowner",
+            created_at: "2025-04-01T00:00:00Z",
+          },
+        ],
+      } as any) // recent signups
+      .mockResolvedValueOnce({
+        rows: [
+          { role: "homeowner", count: "35" },
+          { role: "contractor", count: "5" },
+          { role: "admin", count: "2" },
+        ],
+      } as any); // role distribution
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      user_count: number;
+      project_count: number;
+      recent_signups: unknown[];
+      role_distribution: Array<{ role: string; count: number }>;
+    };
+    expect(body.user_count).toBe(42);
+    expect(body.project_count).toBe(15);
+    expect(body.recent_signups).toHaveLength(1);
+    expect(body.role_distribution).toHaveLength(3);
+    expect(body.role_distribution[0].role).toBe("homeowner");
+    expect(body.role_distribution[0].count).toBe(35);
+  });
+
+  it("normalizes roles in recent signups", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ total: "1" }] } as any)
+      .mockResolvedValueOnce({ rows: [{ total: "0" }] } as any)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "legacy-user",
+            email: "legacy@test.com",
+            name: "Legacy",
+            role: "user",
+            created_at: "2025-04-01T00:00:00Z",
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ role: "user", count: "1" }] } as any);
+
+    const token = authToken("admin-1", "admin");
+    const res = await makeRequest("GET", "/admin/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      recent_signups: Array<{ role: string }>;
+      role_distribution: Array<{ role: string }>;
+    };
+    expect(body.recent_signups[0].role).toBe("homeowner");
+    expect(body.role_distribution[0].role).toBe("homeowner");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contractor role access tests
+// ---------------------------------------------------------------------------
+describe("contractor cannot access admin endpoints", () => {
+  it("rejects contractor from GET /admin/users", async () => {
+    const token = authToken("contractor-1", "contractor");
+    const res = await makeRequest("GET", "/admin/users", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects contractor from GET /admin/stats", async () => {
+    const token = authToken("contractor-1", "contractor");
+    const res = await makeRequest("GET", "/admin/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects contractor from PATCH /admin/users/:id/role", async () => {
+    const token = authToken("contractor-1", "contractor");
+    const res = await makeRequest("PATCH", "/admin/users/user-1/role", {
+      headers: { Authorization: `Bearer ${token}` },
+      body: { role: "admin" },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partner role access tests
+// ---------------------------------------------------------------------------
+describe("partner cannot access admin endpoints", () => {
+  it("rejects partner from GET /admin/users", async () => {
+    const token = authToken("partner-1", "partner");
+    const res = await makeRequest("GET", "/admin/users", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects partner from GET /admin/stats", async () => {
+    const token = authToken("partner-1", "partner");
+    const res = await makeRequest("GET", "/admin/stats", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,6 +18,7 @@ import buildingRouter from "./routes/building";
 import entitlementsRouter from "./routes/entitlements";
 import rolesRouter from "./routes/roles";
 import auditRouter from "./routes/audit";
+import adminRouter from "./routes/admin";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
 
@@ -592,6 +593,7 @@ app.use("/chat", chatLimiter, chatRouter);
 app.use("/entitlements", authenticatedLimiter, entitlementsRouter);
 app.use("/roles", authenticatedLimiter, rolesRouter);
 app.use("/audit", authenticatedLimiter, auditRouter);
+app.use("/admin", authenticatedLimiter, adminRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated
 app.use("/building", buildingLimiter, buildingLimiterAuthenticated, buildingRouter);
 

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -1,0 +1,205 @@
+import { Router } from "express";
+import { query } from "../db";
+import { requireAuth } from "../auth";
+import { requirePermission, isValidRole, normalizeRole, ROLES } from "../permissions";
+import { logAuditEvent } from "../audit";
+
+const router = Router();
+
+// All admin routes require authentication + admin:access permission
+router.use(requireAuth);
+
+// ---------------------------------------------------------------------------
+// GET /admin/users — list users (paginated, admin only)
+// ---------------------------------------------------------------------------
+router.get("/users", requirePermission("admin:access", "user:read_any"), async (req, res) => {
+  const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+  const offset = parseInt(req.query.offset as string) || 0;
+  const search = (req.query.search as string) || "";
+  const role = (req.query.role as string) || "";
+
+  try {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = 1;
+
+    if (search) {
+      conditions.push(`(email ILIKE $${paramIdx} OR name ILIKE $${paramIdx})`);
+      params.push(`%${search}%`);
+      paramIdx++;
+    }
+
+    if (role && isValidRole(role)) {
+      conditions.push(`role = $${paramIdx}`);
+      params.push(role);
+      paramIdx++;
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const result = await query(
+      `SELECT id, email, name, role, email_verified, created_at
+       FROM users
+       ${whereClause}
+       ORDER BY created_at DESC
+       LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`,
+      [...params, limit, offset]
+    );
+
+    const countResult = await query(
+      `SELECT COUNT(*) AS total FROM users ${whereClause}`,
+      params
+    );
+
+    res.json({
+      users: result.rows.map((u) => ({
+        ...u,
+        role: normalizeRole(u.role),
+      })),
+      total: parseInt(countResult.rows[0].total),
+      limit,
+      offset,
+    });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch users" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /admin/users/:id — user detail with project count
+// ---------------------------------------------------------------------------
+router.get("/users/:id", requirePermission("admin:access", "user:read_any"), async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const userResult = await query(
+      `SELECT id, email, name, role, email_verified, created_at
+       FROM users WHERE id = $1`,
+      [id]
+    );
+
+    if (userResult.rows.length === 0) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const user = userResult.rows[0];
+
+    const projectCountResult = await query(
+      "SELECT COUNT(*) AS project_count FROM projects WHERE user_id = $1",
+      [id]
+    );
+
+    res.json({
+      ...user,
+      role: normalizeRole(user.role),
+      project_count: parseInt(projectCountResult.rows[0].project_count),
+    });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch user" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /admin/users/:id/role — update user role (admin only)
+// ---------------------------------------------------------------------------
+router.patch(
+  "/users/:id/role",
+  requirePermission("admin:access", "user:update_role"),
+  async (req, res) => {
+    const { id } = req.params;
+    const { role } = req.body;
+
+    if (!role || typeof role !== "string") {
+      return res.status(400).json({ error: "Role is required" });
+    }
+
+    if (!isValidRole(role)) {
+      return res.status(400).json({
+        error: `Invalid role. Must be one of: ${ROLES.join(", ")}`,
+      });
+    }
+
+    // Prevent admins from demoting themselves
+    if (id === req.user!.id && role !== "admin") {
+      return res.status(400).json({
+        error: "Cannot change your own role away from admin",
+      });
+    }
+
+    try {
+      const existing = await query(
+        "SELECT id, role FROM users WHERE id = $1",
+        [id]
+      );
+
+      if (existing.rows.length === 0) {
+        return res.status(404).json({ error: "User not found" });
+      }
+
+      const oldRole = normalizeRole(existing.rows[0].role);
+
+      const result = await query(
+        "UPDATE users SET role = $1 WHERE id = $2 RETURNING id, email, name, role",
+        [role, id]
+      );
+
+      logAuditEvent(req.user!.id, "admin.user.role_change", {
+        targetId: id,
+        oldRole,
+        newRole: role,
+        ip: req.ip,
+      });
+
+      const updatedUser = result.rows[0];
+      res.json({
+        ...updatedUser,
+        role: normalizeRole(updatedUser.role),
+      });
+    } catch (err) {
+      res.status(500).json({ error: "Failed to update role" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// GET /admin/stats — dashboard stats (user count, project count, recent signups)
+// ---------------------------------------------------------------------------
+router.get("/stats", requirePermission("admin:access"), async (_req, res) => {
+  try {
+    const [userCountResult, projectCountResult, recentSignupsResult, roleDistributionResult] =
+      await Promise.all([
+        query("SELECT COUNT(*) AS total FROM users"),
+        query("SELECT COUNT(*) AS total FROM projects"),
+        query(
+          `SELECT id, email, name, role, created_at
+           FROM users
+           WHERE created_at >= NOW() - INTERVAL '30 days'
+           ORDER BY created_at DESC
+           LIMIT 10`
+        ),
+        query(
+          `SELECT role, COUNT(*) AS count
+           FROM users
+           GROUP BY role
+           ORDER BY count DESC`
+        ),
+      ]);
+
+    res.json({
+      user_count: parseInt(userCountResult.rows[0].total),
+      project_count: parseInt(projectCountResult.rows[0].total),
+      recent_signups: recentSignupsResult.rows.map((u) => ({
+        ...u,
+        role: normalizeRole(u.role),
+      })),
+      role_distribution: roleDistributionResult.rows.map((r) => ({
+        role: normalizeRole(r.role),
+        count: parseInt(r.count),
+      })),
+    });
+  } catch (err) {
+    res.status(500).json({ error: "Failed to fetch stats" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- Adds `GET /admin/users` endpoint with pagination, search, and role filtering
- Adds `GET /admin/users/:id` endpoint returning user detail with project count
- Adds `PATCH /admin/users/:id/role` endpoint for admin role updates with self-demotion prevention
- Adds `GET /admin/stats` endpoint returning user count, project count, recent signups, and role distribution
- All endpoints require `admin:access` permission
- Includes 28 tests covering auth, permissions, pagination, filters, and edge cases

Closes #653

## Test plan
- [x] All 28 admin endpoint tests pass
- [x] Full API test suite (425 tests) passes with no regressions
- [ ] Verify CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)