### PR TITLE
feat: affiliate settlement ledger for commission tracking (#651)

### DIFF
--- a/api/src/__tests__/affiliates.test.ts
+++ b/api/src/__tests__/affiliates.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Unit tests for the affiliate settlement ledger routes.
+ * All tests run without a real database -- the db module is mocked.
+ */
+
+process.env.NODE_ENV = "test";
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock the DB module BEFORE importing anything that uses it
+// ---------------------------------------------------------------------------
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+  pool: { query: vi.fn() },
+}));
+
+import { query } from "../db";
+const mockQuery = vi.mocked(query);
+
+// ---------------------------------------------------------------------------
+// Mock auth — requireAuth attaches req.user from x-test-user-* headers
+// ---------------------------------------------------------------------------
+vi.mock("../auth", () => ({
+  requireAuth: (
+    req: import("express").Request,
+    _res: import("express").Response,
+    next: import("express").NextFunction
+  ) => {
+    const id = req.headers["x-test-user-id"] as string;
+    if (!id) {
+      return (_res as any).status(401).json({ error: "Authentication required" });
+    }
+    (req as any).user = {
+      id,
+      email: req.headers["x-test-user-email"] || "test@helscoop.fi",
+      role: req.headers["x-test-user-role"] || "homeowner",
+    };
+    next();
+  },
+}));
+
+import express from "express";
+import affiliatesRouter from "../routes/affiliates";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/affiliates", affiliatesRouter);
+  return app;
+}
+
+function adminHeaders(extra: Record<string, string> = {}) {
+  return {
+    "x-test-user-id": "admin-1",
+    "x-test-user-role": "admin",
+    ...extra,
+  };
+}
+
+function userHeaders(extra: Record<string, string> = {}) {
+  return {
+    "x-test-user-id": "user-1",
+    "x-test-user-role": "homeowner",
+    ...extra,
+  };
+}
+
+/** Minimal supertest-like helper using Node fetch against an ephemeral server. */
+async function request(
+  app: express.Express,
+  method: "GET" | "POST",
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {}
+) {
+  return new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address() as import("net").AddressInfo;
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(opts.headers || {}),
+        },
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+      })
+        .then(async (res) => {
+          const body = await res.json().catch(() => null);
+          resolve({ status: res.status, body });
+        })
+        .catch(reject)
+        .finally(() => server.close());
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rows: [] } as any);
+});
+
+// ---------------------------------------------------------------------------
+// 1. POST /affiliates/click
+// ---------------------------------------------------------------------------
+describe("POST /affiliates/click", () => {
+  it("records a click and returns 201", async () => {
+    const clickRow = {
+      id: "click-1",
+      user_id: "user-1",
+      material_id: "mat-1",
+      supplier_id: "sup-1",
+      partner_id: null,
+      click_url: "https://shop.example.com/product/123",
+      created_at: new Date().toISOString(),
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [clickRow] } as any);
+
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/click", {
+      headers: userHeaders(),
+      body: {
+        material_id: "mat-1",
+        supplier_id: "sup-1",
+        click_url: "https://shop.example.com/product/123",
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("click-1");
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO affiliate_clicks"),
+      expect.arrayContaining(["user-1", "mat-1", "sup-1"])
+    );
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/click", {
+      headers: userHeaders(),
+      body: { material_id: "mat-1" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("required");
+  });
+
+  it("returns 400 when click_url is too long", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/click", {
+      headers: userHeaders(),
+      body: {
+        material_id: "mat-1",
+        supplier_id: "sup-1",
+        click_url: "x".repeat(2049),
+      },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("click_url");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/click", {
+      body: {
+        material_id: "mat-1",
+        supplier_id: "sup-1",
+        click_url: "https://shop.example.com",
+      },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. GET /affiliates/clicks (admin only)
+// ---------------------------------------------------------------------------
+describe("GET /affiliates/clicks", () => {
+  it("returns clicks for admin user", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "click-1",
+          user_email: "u@helscoop.fi",
+          material_name: "Pine",
+          supplier_name: "K-Rauta",
+        },
+      ],
+    } as any);
+
+    const app = buildApp();
+    const res = await request(app, "GET", "/affiliates/clicks", {
+      headers: adminHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].id).toBe("click-1");
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    const app = buildApp();
+    const res = await request(app, "GET", "/affiliates/clicks", {
+      headers: userHeaders(),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. POST /affiliates/commissions (admin only)
+// ---------------------------------------------------------------------------
+describe("POST /affiliates/commissions", () => {
+  it("creates a commission record and returns 201", async () => {
+    const row = {
+      id: "com-1",
+      click_id: "click-1",
+      partner_id: "partner-1",
+      order_ref: "ORD-123",
+      amount: 12.5,
+      currency: "EUR",
+      status: "pending",
+    };
+    mockQuery.mockResolvedValueOnce({ rows: [row] } as any);
+
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/commissions", {
+      headers: adminHeaders(),
+      body: {
+        click_id: "click-1",
+        partner_id: "partner-1",
+        order_ref: "ORD-123",
+        amount: 12.5,
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe("com-1");
+    expect(res.body.status).toBe("pending");
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/commissions", {
+      headers: adminHeaders(),
+      body: { click_id: "click-1" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("required");
+  });
+
+  it("returns 400 for invalid status", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/commissions", {
+      headers: adminHeaders(),
+      body: {
+        click_id: "click-1",
+        partner_id: "partner-1",
+        order_ref: "ORD-1",
+        amount: 10,
+        status: "invalid_status",
+      },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("status");
+  });
+
+  it("returns 400 for negative amount", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/commissions", {
+      headers: adminHeaders(),
+      body: {
+        click_id: "click-1",
+        partner_id: "partner-1",
+        order_ref: "ORD-1",
+        amount: -5,
+      },
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("amount");
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    const app = buildApp();
+    const res = await request(app, "POST", "/affiliates/commissions", {
+      headers: userHeaders(),
+      body: {
+        click_id: "click-1",
+        partner_id: "partner-1",
+        order_ref: "ORD-1",
+        amount: 10,
+      },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. GET /affiliates/commissions (admin only)
+// ---------------------------------------------------------------------------
+describe("GET /affiliates/commissions", () => {
+  it("returns commission list for admin", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "com-1", amount: 12.5, status: "pending" }],
+    } as any);
+
+    const app = buildApp();
+    const res = await request(app, "GET", "/affiliates/commissions", {
+      headers: adminHeaders(),
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it("supports status filter", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const app = buildApp();
+    const res = await request(
+      app,
+      "GET",
+      "/affiliates/commissions?status=paid",
+      { headers: adminHeaders() }
+    );
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("acom.status"),
+      expect.arrayContaining(["paid"])
+    );
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    const app = buildApp();
+    const res = await request(app, "GET", "/affiliates/commissions", {
+      headers: userHeaders(),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. GET /affiliates/report (admin only)
+// ---------------------------------------------------------------------------
+describe("GET /affiliates/report", () => {
+  it("returns summary report for admin", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          partner_id: "p-1",
+          partner_name: "K-Rauta Affiliate",
+          commission_rate: 0.05,
+          total_clicks: 42,
+          total_commissions: 5,
+          pending_amount: 100,
+          confirmed_amount: 200,
+          paid_amount: 50,
+          reversed_amount: 10,
+          net_amount: 350,
+        },
+      ],
+    } as any);
+
+    const app = buildApp();
+    const res = await request(app, "GET", "/affiliates/report", {
+      headers: adminHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.period).toHaveProperty("start");
+    expect(res.body.period).toHaveProperty("end");
+    expect(res.body.partners).toHaveLength(1);
+    expect(res.body.partners[0].partner_name).toBe("K-Rauta Affiliate");
+    expect(res.body.partners[0].net_amount).toBe(350);
+  });
+
+  it("accepts custom date range parameters", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] } as any);
+
+    const app = buildApp();
+    const res = await request(
+      app,
+      "GET",
+      "/affiliates/report?start=2025-01-01&end=2025-02-01",
+      { headers: adminHeaders() }
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.period.start).toBe("2025-01-01");
+    expect(res.body.period.end).toBe("2025-02-01");
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("affiliate_partners"),
+      expect.arrayContaining(["2025-01-01", "2025-02-01"])
+    );
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    const app = buildApp();
+    const res = await request(app, "GET", "/affiliates/report", {
+      headers: userHeaders(),
+    });
+    expect(res.status).toBe(403);
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -19,6 +19,7 @@ import entitlementsRouter from "./routes/entitlements";
 import rolesRouter from "./routes/roles";
 import auditRouter from "./routes/audit";
 import adminRouter from "./routes/admin";
+import affiliatesRouter from "./routes/affiliates";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
 
@@ -594,6 +595,7 @@ app.use("/entitlements", authenticatedLimiter, entitlementsRouter);
 app.use("/roles", authenticatedLimiter, rolesRouter);
 app.use("/audit", authenticatedLimiter, auditRouter);
 app.use("/admin", authenticatedLimiter, adminRouter);
+app.use("/affiliates", authenticatedLimiter, affiliatesRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated
 app.use("/building", buildingLimiter, buildingLimiterAuthenticated, buildingRouter);
 

--- a/api/src/routes/affiliates.ts
+++ b/api/src/routes/affiliates.ts
@@ -1,0 +1,253 @@
+import { Router } from "express";
+import { query } from "../db";
+import { requireAuth } from "../auth";
+import { requirePermission } from "../permissions";
+
+const router = Router();
+
+// ---------------------------------------------------------------------------
+// POST /affiliates/click — record a click-through (any authenticated user)
+// ---------------------------------------------------------------------------
+router.post("/click", requireAuth, async (req, res) => {
+  const { material_id, supplier_id, click_url, partner_id } = req.body;
+  const userId = req.user!.id;
+
+  if (!material_id || !supplier_id || !click_url) {
+    return res
+      .status(400)
+      .json({ error: "material_id, supplier_id, and click_url are required" });
+  }
+
+  if (typeof click_url !== "string" || click_url.length > 2048) {
+    return res.status(400).json({ error: "Invalid click_url" });
+  }
+
+  try {
+    const result = await query(
+      `INSERT INTO affiliate_clicks (user_id, material_id, supplier_id, partner_id, click_url)
+       VALUES ($1, $2, $3, $4, $5)
+       RETURNING *`,
+      [userId, material_id, supplier_id, partner_id || null, click_url]
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (err) {
+    res.status(500).json({ error: "Failed to record click" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /affiliates/clicks — list all clicks (admin only, paginated)
+// ---------------------------------------------------------------------------
+router.get(
+  "/clicks",
+  requireAuth,
+  requirePermission("admin:access"),
+  async (req, res) => {
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const partnerId = req.query.partner_id as string | undefined;
+
+    try {
+      let sql = `
+        SELECT ac.*,
+          u.email AS user_email,
+          m.name  AS material_name,
+          s.name  AS supplier_name,
+          ap.name AS partner_name
+        FROM affiliate_clicks ac
+        JOIN users     u  ON ac.user_id     = u.id
+        JOIN materials m  ON ac.material_id = m.id
+        JOIN suppliers s  ON ac.supplier_id = s.id
+        LEFT JOIN affiliate_partners ap ON ac.partner_id = ap.id`;
+      const params: unknown[] = [];
+
+      if (partnerId) {
+        params.push(partnerId);
+        sql += ` WHERE ac.partner_id = $${params.length}`;
+      }
+
+      sql += ` ORDER BY ac.created_at DESC`;
+      params.push(limit);
+      sql += ` LIMIT $${params.length}`;
+      params.push(offset);
+      sql += ` OFFSET $${params.length}`;
+
+      const result = await query(sql, params);
+      res.json(result.rows);
+    } catch (err) {
+      res.status(500).json({ error: "Failed to fetch clicks" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// POST /affiliates/commissions — record a commission (admin only)
+// ---------------------------------------------------------------------------
+router.post(
+  "/commissions",
+  requireAuth,
+  requirePermission("admin:access"),
+  async (req, res) => {
+    const { click_id, partner_id, order_ref, amount, currency, status } =
+      req.body;
+
+    if (!click_id || !partner_id || !order_ref || amount == null) {
+      return res.status(400).json({
+        error: "click_id, partner_id, order_ref, and amount are required",
+      });
+    }
+
+    if (typeof amount !== "number" || amount < 0) {
+      return res.status(400).json({ error: "amount must be a non-negative number" });
+    }
+
+    const validStatuses = ["pending", "confirmed", "paid", "reversed"];
+    const commissionStatus = status || "pending";
+    if (!validStatuses.includes(commissionStatus)) {
+      return res.status(400).json({
+        error: `status must be one of: ${validStatuses.join(", ")}`,
+      });
+    }
+
+    try {
+      const result = await query(
+        `INSERT INTO affiliate_commissions (click_id, partner_id, order_ref, amount, currency, status)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING *`,
+        [
+          click_id,
+          partner_id,
+          order_ref,
+          amount,
+          currency || "EUR",
+          commissionStatus,
+        ]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      res.status(500).json({ error: "Failed to record commission" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// GET /affiliates/commissions — list commissions (admin only, paginated)
+// ---------------------------------------------------------------------------
+router.get(
+  "/commissions",
+  requireAuth,
+  requirePermission("admin:access"),
+  async (req, res) => {
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const status = req.query.status as string | undefined;
+    const partnerId = req.query.partner_id as string | undefined;
+
+    try {
+      let sql = `
+        SELECT acom.*,
+          ap.name AS partner_name,
+          ac.user_id,
+          ac.material_id,
+          ac.supplier_id,
+          u.email AS user_email
+        FROM affiliate_commissions acom
+        JOIN affiliate_clicks   ac ON acom.click_id   = ac.id
+        JOIN affiliate_partners ap ON acom.partner_id  = ap.id
+        JOIN users              u  ON ac.user_id       = u.id`;
+      const params: unknown[] = [];
+      const conditions: string[] = [];
+
+      if (status) {
+        params.push(status);
+        conditions.push(`acom.status = $${params.length}`);
+      }
+      if (partnerId) {
+        params.push(partnerId);
+        conditions.push(`acom.partner_id = $${params.length}`);
+      }
+
+      if (conditions.length > 0) {
+        sql += ` WHERE ${conditions.join(" AND ")}`;
+      }
+
+      sql += ` ORDER BY acom.created_at DESC`;
+      params.push(limit);
+      sql += ` LIMIT $${params.length}`;
+      params.push(offset);
+      sql += ` OFFSET $${params.length}`;
+
+      const result = await query(sql, params);
+      res.json(result.rows);
+    } catch (err) {
+      res.status(500).json({ error: "Failed to fetch commissions" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// GET /affiliates/report — summary report by partner/period (admin only)
+//
+// Query params:
+//   - start: ISO date string (inclusive, default: 30 days ago)
+//   - end:   ISO date string (exclusive, default: now)
+//   - partner_id: optional filter
+// ---------------------------------------------------------------------------
+router.get(
+  "/report",
+  requireAuth,
+  requirePermission("admin:access"),
+  async (req, res) => {
+    const now = new Date();
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const start = (req.query.start as string) || thirtyDaysAgo.toISOString();
+    const end = (req.query.end as string) || now.toISOString();
+    const partnerId = req.query.partner_id as string | undefined;
+
+    try {
+      const params: unknown[] = [start, end];
+      let partnerFilter = "";
+
+      if (partnerId) {
+        params.push(partnerId);
+        partnerFilter = `AND acom.partner_id = $${params.length}`;
+      }
+
+      const result = await query(
+        `SELECT
+           ap.id            AS partner_id,
+           ap.name          AS partner_name,
+           ap.commission_rate,
+           COUNT(DISTINCT ac.id)   AS total_clicks,
+           COUNT(acom.id)          AS total_commissions,
+           COALESCE(SUM(acom.amount) FILTER (WHERE acom.status = 'pending'),   0) AS pending_amount,
+           COALESCE(SUM(acom.amount) FILTER (WHERE acom.status = 'confirmed'), 0) AS confirmed_amount,
+           COALESCE(SUM(acom.amount) FILTER (WHERE acom.status = 'paid'),      0) AS paid_amount,
+           COALESCE(SUM(acom.amount) FILTER (WHERE acom.status = 'reversed'),  0) AS reversed_amount,
+           COALESCE(SUM(acom.amount) FILTER (WHERE acom.status IN ('pending','confirmed','paid')), 0) AS net_amount
+         FROM affiliate_partners ap
+         LEFT JOIN affiliate_clicks ac
+           ON ac.partner_id = ap.id
+           AND ac.created_at >= $1 AND ac.created_at < $2
+         LEFT JOIN affiliate_commissions acom
+           ON acom.partner_id = ap.id
+           AND acom.created_at >= $1 AND acom.created_at < $2
+           ${partnerFilter}
+         WHERE ap.active = true
+         GROUP BY ap.id, ap.name, ap.commission_rate
+         ORDER BY net_amount DESC`,
+        params
+      );
+
+      res.json({
+        period: { start, end },
+        partners: result.rows,
+      });
+    } catch (err) {
+      res.status(500).json({ error: "Failed to generate report" });
+    }
+  }
+);
+
+export default router;

--- a/db/migrations/012_affiliate_ledger.sql
+++ b/db/migrations/012_affiliate_ledger.sql
@@ -1,0 +1,65 @@
+-- Migration 012: Affiliate settlement ledger
+--
+-- Tracks affiliate click-throughs, commission attribution, and payout
+-- reporting for material supplier partnerships.
+
+-- ---------------------------------------------------------------------------
+-- affiliate_partners — the supplier/affiliate organizations we pay commissions to
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS affiliate_partners (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name            TEXT NOT NULL,
+  commission_rate NUMERIC(5,4) NOT NULL DEFAULT 0.0000, -- e.g. 0.0500 = 5%
+  payment_terms   TEXT NOT NULL DEFAULT 'net30',          -- net30, net60, etc.
+  active          BOOLEAN NOT NULL DEFAULT true,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_partners_active
+  ON affiliate_partners (active);
+
+-- ---------------------------------------------------------------------------
+-- affiliate_clicks — records each user click-through to a supplier product
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS affiliate_clicks (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  material_id UUID NOT NULL REFERENCES materials(id) ON DELETE CASCADE,
+  supplier_id UUID NOT NULL REFERENCES suppliers(id) ON DELETE CASCADE,
+  partner_id  UUID REFERENCES affiliate_partners(id) ON DELETE SET NULL,
+  click_url   TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_user_id
+  ON affiliate_clicks (user_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_supplier_id
+  ON affiliate_clicks (supplier_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_partner_id
+  ON affiliate_clicks (partner_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_clicks_created_at
+  ON affiliate_clicks (created_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- affiliate_commissions — commission entries attributed to clicks
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS affiliate_commissions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  click_id    UUID NOT NULL REFERENCES affiliate_clicks(id) ON DELETE CASCADE,
+  partner_id  UUID NOT NULL REFERENCES affiliate_partners(id) ON DELETE CASCADE,
+  order_ref   TEXT NOT NULL,                    -- external order reference
+  amount      NUMERIC(12,2) NOT NULL,           -- commission amount
+  currency    TEXT NOT NULL DEFAULT 'EUR',
+  status      TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'confirmed', 'paid', 'reversed')),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_affiliate_commissions_click_id
+  ON affiliate_commissions (click_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_commissions_partner_id
+  ON affiliate_commissions (partner_id);
+CREATE INDEX IF NOT EXISTS idx_affiliate_commissions_status
+  ON affiliate_commissions (status);
+CREATE INDEX IF NOT EXISTS idx_affiliate_commissions_created_at
+  ON affiliate_commissions (created_at DESC);

--- a/db/migrations/012_affiliate_ledger.sql
+++ b/db/migrations/012_affiliate_ledger.sql
@@ -24,8 +24,8 @@ CREATE INDEX IF NOT EXISTS idx_affiliate_partners_active
 CREATE TABLE IF NOT EXISTS affiliate_clicks (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  material_id UUID NOT NULL REFERENCES materials(id) ON DELETE CASCADE,
-  supplier_id UUID NOT NULL REFERENCES suppliers(id) ON DELETE CASCADE,
+  material_id TEXT NOT NULL REFERENCES materials(id) ON DELETE CASCADE,
+  supplier_id TEXT NOT NULL REFERENCES suppliers(id) ON DELETE CASCADE,
   partner_id  UUID REFERENCES affiliate_partners(id) ON DELETE SET NULL,
   click_url   TEXT NOT NULL,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now()


### PR DESCRIPTION
## Summary

- Added `db/migrations/012_affiliate_ledger.sql` with three tables: `affiliate_partners`, `affiliate_clicks`, and `affiliate_commissions` (with indexes for reporting queries)
- Added `api/src/routes/affiliates.ts` with five endpoints: click recording (authenticated), click listing (admin), commission creation (admin), commission listing with status/partner filters (admin), and summary report by partner/period (admin)
- Mounted affiliates router in `api/src/index.ts`
- Added comprehensive test suite (`api/src/__tests__/affiliates.test.ts`) covering all endpoints, auth gating, input validation, and filter behavior

Closes #651

## Test plan

- [x] All 17 new affiliate tests pass
- [x] Full test suite passes (414 tests, 0 failures)
- [ ] Verify migration runs cleanly against a real PostgreSQL instance
- [ ] Verify click recording works end-to-end with real material/supplier IDs
- [ ] Verify admin-only endpoints reject homeowner/contractor/partner roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)