### PR TITLE
feat: Google Sign-In OAuth login (#502)

### DIFF
--- a/api/src/__tests__/google-auth.test.ts
+++ b/api/src/__tests__/google-auth.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the db module before importing auth
+vi.mock("../db", () => ({
+  query: vi.fn(),
+  pool: { query: vi.fn() },
+}));
+
+// Mock the email module
+vi.mock("../email", () => ({
+  sendPasswordResetEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+}));
+
+import { verifyGoogleToken, googleLogin } from "../auth";
+import { query } from "../db";
+
+const mockedQuery = vi.mocked(query);
+
+// ---------------------------------------------------------------------------
+// verifyGoogleToken
+// ---------------------------------------------------------------------------
+
+describe("verifyGoogleToken", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when the token verification request fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+    const result = await verifyGoogleToken("bad-token");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response is missing required fields", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ aud: "test-client-id" }), // missing email and sub
+      })
+    );
+    const result = await verifyGoogleToken("incomplete-token");
+    expect(result).toBeNull();
+  });
+
+  it("returns the payload for a valid token response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            sub: "google-uid-123",
+            email: "user@gmail.com",
+            email_verified: "true",
+            name: "Test User",
+            picture: "https://lh3.googleusercontent.com/photo.jpg",
+            aud: "some-client-id",
+          }),
+      })
+    );
+    const result = await verifyGoogleToken("valid-token");
+    expect(result).not.toBeNull();
+    expect(result!.sub).toBe("google-uid-123");
+    expect(result!.email).toBe("user@gmail.com");
+    expect(result!.email_verified).toBe(true);
+    expect(result!.name).toBe("Test User");
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+    const result = await verifyGoogleToken("any-token");
+    expect(result).toBeNull();
+  });
+
+  it("falls back to email prefix when name is missing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            sub: "google-uid-456",
+            email: "matti.meikalainen@gmail.com",
+            email_verified: true,
+          }),
+      })
+    );
+    const result = await verifyGoogleToken("valid-token");
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("matti.meikalainen");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// googleLogin
+// ---------------------------------------------------------------------------
+
+describe("googleLogin", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockedQuery.mockReset();
+  });
+
+  const payload = {
+    sub: "google-uid-789",
+    email: "test@gmail.com",
+    email_verified: true,
+    name: "Test User",
+  };
+
+  it("returns existing user when google_id matches", async () => {
+    const existingUser = { id: "user-1", email: "test@gmail.com", name: "Test User", role: "homeowner" };
+    mockedQuery.mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] });
+
+    const result = await googleLogin(payload);
+    expect(result).toEqual(existingUser);
+    // Should only query once (by google_id)
+    expect(mockedQuery).toHaveBeenCalledTimes(1);
+    expect(mockedQuery).toHaveBeenCalledWith(
+      "SELECT id, email, name, role FROM users WHERE google_id = $1",
+      ["google-uid-789"]
+    );
+  });
+
+  it("links Google account to existing email user", async () => {
+    const existingUser = { id: "user-2", email: "test@gmail.com", name: "Existing User", role: "homeowner" };
+    // First query (by google_id) returns empty
+    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
+    // Second query (by email) returns existing user
+    mockedQuery.mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] });
+    // Third query (UPDATE to link google_id)
+    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] });
+
+    const result = await googleLogin(payload);
+    expect(result).toEqual(existingUser);
+    expect(mockedQuery).toHaveBeenCalledTimes(3);
+    // Verify the UPDATE was called to link google_id
+    expect(mockedQuery).toHaveBeenCalledWith(
+      "UPDATE users SET google_id = $1, email_verified = true WHERE id = $2",
+      ["google-uid-789", "user-2"]
+    );
+  });
+
+  it("creates a new user when no match exists", async () => {
+    const newUser = { id: "user-new", email: "test@gmail.com", name: "Test User", role: "homeowner" };
+    // First query (by google_id) returns empty
+    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
+    // Second query (by email) returns empty
+    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
+    // Third query (INSERT) returns new user
+    mockedQuery.mockResolvedValueOnce({ rows: [newUser], command: "", rowCount: 1, oid: 0, fields: [] });
+
+    const result = await googleLogin(payload);
+    expect(result).toEqual(newUser);
+    expect(mockedQuery).toHaveBeenCalledTimes(3);
+    // Verify the INSERT was called with correct values
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO users"),
+      ["test@gmail.com", "Test User", "google-uid-789"]
+    );
+  });
+});

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -185,6 +185,91 @@ export async function resendVerification(userId: string): Promise<boolean> {
   return sendVerificationEmail(result.rows[0].email, token);
 }
 
+// ---------------------------------------------------------------------------
+// Google OAuth
+// ---------------------------------------------------------------------------
+
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "";
+
+interface GoogleTokenPayload {
+  sub: string;       // Google unique user ID
+  email: string;
+  email_verified: boolean;
+  name?: string;
+  picture?: string;
+}
+
+/**
+ * Verify a Google ID token via Google's tokeninfo endpoint.
+ * Returns the decoded payload or null if verification fails.
+ */
+export async function verifyGoogleToken(idToken: string): Promise<GoogleTokenPayload | null> {
+  try {
+    const res = await fetch(
+      `https://oauth2.googleapis.com/tokeninfo?id_token=${encodeURIComponent(idToken)}`
+    );
+    if (!res.ok) return null;
+    const payload = await res.json();
+
+    // Verify the token was issued for our application
+    if (GOOGLE_CLIENT_ID && payload.aud !== GOOGLE_CLIENT_ID) {
+      return null;
+    }
+
+    if (!payload.email || !payload.sub) return null;
+
+    return {
+      sub: payload.sub,
+      email: payload.email,
+      email_verified: payload.email_verified === "true" || payload.email_verified === true,
+      name: payload.name || payload.email.split("@")[0],
+      picture: payload.picture,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find or create a user from a verified Google token payload.
+ * - If a user with the same google_id exists, return them.
+ * - If a user with the same email exists (local signup), link the Google account.
+ * - Otherwise, create a new user.
+ */
+export async function googleLogin(payload: GoogleTokenPayload) {
+  // 1. Check by google_id first (returning Google user)
+  const byGoogleId = await query(
+    "SELECT id, email, name, role FROM users WHERE google_id = $1",
+    [payload.sub]
+  );
+  if (byGoogleId.rows.length > 0) {
+    return byGoogleId.rows[0];
+  }
+
+  // 2. Check by email (existing local user signing in with Google for the first time)
+  const byEmail = await query(
+    "SELECT id, email, name, role FROM users WHERE email = $1",
+    [payload.email]
+  );
+  if (byEmail.rows.length > 0) {
+    // Link Google account to existing user
+    await query(
+      "UPDATE users SET google_id = $1, email_verified = true WHERE id = $2",
+      [payload.sub, byEmail.rows[0].id]
+    );
+    return byEmail.rows[0];
+  }
+
+  // 3. Create new user
+  const result = await query(
+    `INSERT INTO users (email, name, google_id, auth_provider, email_verified, accepted_terms_at)
+     VALUES ($1, $2, $3, 'google', true, NOW())
+     RETURNING id, email, name, role`,
+    [payload.email, payload.name || payload.email.split("@")[0], payload.sub]
+  );
+  return result.rows[0];
+}
+
 // Validate a reset token and update the user's password. Returns true on success.
 export async function resetPassword(token: string, newPassword: string): Promise<boolean> {
   const result = await query(

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,7 +6,7 @@ import jwt from "jsonwebtoken";
 import rateLimit from "express-rate-limit";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
-import { login, register, signToken, tokenExpiresAt, verifyForRefresh, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, AuthUser } from "./auth";
+import { login, register, signToken, tokenExpiresAt, verifyForRefresh, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, verifyGoogleToken, googleLogin, AuthUser } from "./auth";
 import { query, pool } from "./db";
 import { kanalaSceneJs } from "./templates/kanala";
 import materialsRouter from "./routes/materials";
@@ -297,6 +297,26 @@ app.post("/auth/register", authLimiter, async (req, res) => {
       return res.status(409).json({ error: "Email already registered" });
     }
     res.status(400).json({ error: msg || "Registration failed" });
+  }
+});
+
+app.post("/auth/google", authLimiter, async (req, res) => {
+  const { credential } = req.body;
+  if (!credential) {
+    return res.status(400).json({ error: "Google credential is required" });
+  }
+  try {
+    const payload = await verifyGoogleToken(credential);
+    if (!payload) {
+      return res.status(401).json({ error: "Invalid Google credential" });
+    }
+    const user = await googleLogin(payload);
+    res.json({ token: signToken(user), token_expires_at: tokenExpiresAt(), user });
+  } catch (e: unknown) {
+    logger.error({ err: e }, "Google auth error");
+    Sentry.captureException(e);
+    const msg = e instanceof Error ? e.message : "Google authentication failed";
+    res.status(500).json({ error: msg });
   }
 });
 

--- a/db/migrations/012_google_oauth.sql
+++ b/db/migrations/012_google_oauth.sql
@@ -1,0 +1,13 @@
+-- Migration 012: Add Google OAuth support
+--
+-- Adds google_id and auth_provider columns to the users table to support
+-- Google Sign-In as an alternative login method (Issue #502).
+
+-- google_id: the Google account's unique subject identifier (from the ID token "sub" claim)
+ALTER TABLE users ADD COLUMN IF NOT EXISTS google_id TEXT UNIQUE;
+
+-- auth_provider: tracks how the user registered ('local' = email/password, 'google' = Google OAuth)
+ALTER TABLE users ADD COLUMN IF NOT EXISTS auth_provider TEXT NOT NULL DEFAULT 'local';
+
+-- Allow password_hash to be NULL for Google-only accounts (they have no local password)
+ALTER TABLE users ALTER COLUMN password_hash DROP NOT NULL;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -92,6 +92,8 @@ export default function RootLayout({
             __html: `(function(){try{var l=localStorage.getItem("helscoop_locale")||"fi";document.documentElement.lang=l}catch(e){}})()`
           }}
         />
+        {/* Google Identity Services — for Google Sign-In */}
+        <script src="https://accounts.google.com/gsi/client" async defer />
         {/* Plausible Analytics — privacy-first, no cookies, GDPR-compliant */}
         <script
           defer

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -26,6 +26,7 @@ export default function LoginForm({
   const [isRegister, setIsRegister] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const { t } = useTranslation();
   const { track } = useAnalytics();
@@ -64,6 +65,41 @@ export default function LoginForm({
       setError(err instanceof Error ? err.message : t('auth.loginFailed'));
     }
     setLoading(false);
+  }
+
+  async function handleGoogleSignIn() {
+    setError("");
+    setGoogleLoading(true);
+    try {
+      // Use Google Identity Services popup flow
+      const google = (window as unknown as { google?: { accounts: { id: {
+        initialize: (config: { client_id: string; callback: (response: { credential: string }) => void }) => void;
+        prompt: () => void;
+      } } } }).google;
+      if (!google) {
+        setError(t("auth.googleSignInError"));
+        setGoogleLoading(false);
+        return;
+      }
+      google.accounts.id.initialize({
+        client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
+        callback: async (response: { credential: string }) => {
+          try {
+            const result = await api.googleLogin(response.credential);
+            setToken(result.token, result.token_expires_at);
+            track("auth_google_login", {} as Record<string, never>);
+            onLogin();
+          } catch (err) {
+            setError(err instanceof Error ? err.message : t("auth.googleSignInError"));
+          }
+          setGoogleLoading(false);
+        },
+      });
+      google.accounts.id.prompt();
+    } catch {
+      setError(t("auth.googleSignInError"));
+      setGoogleLoading(false);
+    }
   }
 
   const features = [
@@ -322,7 +358,59 @@ export default function LoginForm({
             </button>
           </form>
 
-          <div className="divider-amber" style={{ marginTop: 32, marginBottom: 24 }} />
+          {/* Google Sign-In */}
+          <div style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            marginTop: 24,
+            marginBottom: 24,
+          }}>
+            <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+            <span style={{ fontSize: 12, color: "var(--text-muted)", textTransform: "lowercase" }}>
+              {t("auth.orContinueWith")}
+            </span>
+            <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+          </div>
+
+          <button
+            type="button"
+            onClick={handleGoogleSignIn}
+            disabled={googleLoading}
+            style={{
+              width: "100%",
+              padding: "12px 16px",
+              fontSize: 14,
+              fontWeight: 500,
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-md)",
+              background: "var(--surface)",
+              color: "var(--text-primary)",
+              cursor: googleLoading ? "not-allowed" : "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 10,
+              opacity: googleLoading ? 0.7 : 1,
+              transition: "border-color 0.15s ease, background 0.15s ease",
+            }}
+          >
+            {googleLoading ? (
+              <span className="btn-spinner" />
+            ) : (
+              <>
+                <svg width="18" height="18" viewBox="0 0 48 48">
+                  <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                  <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                  <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+                  <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+                </svg>
+                {t("auth.googleSignIn")}
+              </>
+            )}
+          </button>
+
+          <div className="divider-amber" style={{ marginTop: 24, marginBottom: 24 }} />
 
           <div style={{ textAlign: "center" }}>
             <button

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -27,6 +27,7 @@ export type AnalyticsEvent =
   | "chat_code_applied"
   | "auth_register"
   | "auth_login"
+  | "auth_google_login"
   | "page_view";
 
 // ── Property maps per event ────────────────────────────────────────
@@ -44,6 +45,7 @@ export interface AnalyticsEventProps {
   chat_code_applied: Record<string, never>;
   auth_register: Record<string, never>;
   auth_login: Record<string, never>;
+  auth_google_login: Record<string, never>;
   page_view: { path: string };
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -224,6 +224,11 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ email, password, name }),
     }),
+  googleLogin: (credential: string) =>
+    apiFetch("/auth/google", {
+      method: "POST",
+      body: JSON.stringify({ credential }),
+    }),
   me: () => apiFetch("/auth/me"),
   updateProfile: (data: { name?: string; email?: string }) =>
     apiFetch("/auth/profile", { method: "PUT", body: JSON.stringify(data) }),

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -47,6 +47,9 @@ const translations = {
       passwordMedium: 'Keskiverto',
       passwordStrong: 'Vahva',
       passwordStrength: 'Salasanan vahvuus',
+      googleSignIn: 'Kirjaudu Google-tilill\u00e4',
+      googleSignInError: 'Google-kirjautuminen ep\u00e4onnistui',
+      orContinueWith: 'tai jatka',
     },
     brand: {
       tagline: 'N\u00c4E TALOSI \u00b7 MUUTA \u00b7 RAKENNA',
@@ -746,6 +749,9 @@ const translations = {
       passwordMedium: 'Medium',
       passwordStrong: 'Strong',
       passwordStrength: 'Password strength',
+      googleSignIn: 'Sign in with Google',
+      googleSignInError: 'Google sign-in failed',
+      orContinueWith: 'or continue with',
     },
     brand: {
       tagline: 'SEE YOUR HOUSE \u00b7 CHANGE IT \u00b7 BUILD',


### PR DESCRIPTION
## Summary
- Add Google OAuth as an alternative login method via `POST /auth/google` endpoint
- Verify Google ID tokens against `https://oauth2.googleapis.com/tokeninfo` with `GOOGLE_CLIENT_ID` audience check
- Find-or-create user flow: match by `google_id`, link existing email account, or create new user
- Add "Sign in with Google" button to `LoginForm.tsx` using Google Identity Services
- Add DB migration (012) for `google_id` and `auth_provider` columns on `users` table
- Add Finnish and English i18n keys (`auth.googleSignIn`, `auth.googleSignInError`, `auth.orContinueWith`)
- Add `auth_google_login` analytics event type

Closes #502

## Test plan
- [x] 8 new unit tests in `google-auth.test.ts` (token verification + find-or-create logic)
- [x] All 405 existing tests pass (`npx vitest run`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Manual: set `GOOGLE_CLIENT_ID` and `NEXT_PUBLIC_GOOGLE_CLIENT_ID` env vars, click "Sign in with Google" button
- [ ] Manual: verify new Google user is created with `auth_provider = 'google'`
- [ ] Manual: verify existing email user gets `google_id` linked on first Google sign-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)