### PR TITLE
feat: add waste disposal panel to BOM

### DIFF
--- a/api/src/__tests__/waste.test.ts
+++ b/api/src/__tests__/waste.test.ts
@@ -161,12 +161,14 @@ describe("GET /waste/estimate", () => {
 
     const body = res.body as {
       totalWeightKg: number;
+      totalVolumeM3: number;
       categories: unknown[];
       containerRecommendation: { size: string; count: number; totalCost: number };
       sortingGuide: unknown[];
       totalDisposalCost: number;
     };
     expect(body.totalWeightKg).toBe(0);
+    expect(body.totalVolumeM3).toBe(0);
     expect(body.categories).toHaveLength(0);
     expect(body.totalDisposalCost).toBe(0);
     // Even empty projects get a minimum container recommendation
@@ -315,6 +317,7 @@ describe("GET /waste/estimate", () => {
     const body = res.body as Record<string, unknown>;
     // Top-level fields
     expect(body).toHaveProperty("totalWeightKg");
+    expect(body).toHaveProperty("totalVolumeM3");
     expect(body).toHaveProperty("categories");
     expect(body).toHaveProperty("containerRecommendation");
     expect(body).toHaveProperty("sortingGuide");

--- a/api/src/routes/waste.ts
+++ b/api/src/routes/waste.ts
@@ -25,6 +25,7 @@ interface WasteCategory {
 
 interface WasteEstimateResponse {
   totalWeightKg: number;
+  totalVolumeM3: number;
   categories: WasteCategory[];
   containerRecommendation: {
     size: string;
@@ -146,6 +147,7 @@ router.get("/estimate", requireAuth, async (req, res) => {
 
   const response: WasteEstimateResponse = {
     totalWeightKg: Math.round(totalWeightKg * 100) / 100,
+    totalVolumeM3: Math.round(totalVolumeM3 * 1000) / 1000,
     categories,
     containerRecommendation: {
       size: `${container.size.sizeM3}m\u00B3`,

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1683,6 +1683,7 @@ export default function ProjectPage() {
               sceneJs={sceneJs}
               projectName={projectName}
               buildingInfo={project?.building_info ?? null}
+              projectId={projectId}
             />
           </>
         )}

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "@/components/LocaleProvider";
 import { SkeletonPriceComparison } from "@/components/Skeleton";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import SubsidyCalculator from "@/components/SubsidyCalculator";
+import WasteEstimatePanel from "@/components/WasteEstimatePanel";
 import { api } from "@/lib/api";
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { interpretScene, extractSceneMaterials } from "@/lib/scene-interpreter";
@@ -1570,6 +1571,7 @@ export default function BomPanel({
   sceneJs,
   projectName,
   buildingInfo,
+  projectId,
 }: {
   bom: BomItem[];
   materials: Material[];
@@ -1583,6 +1585,8 @@ export default function BomPanel({
   projectName?: string;
   /** Address-derived building context for subsidy eligibility defaults */
   buildingInfo?: BuildingInfo | null;
+  /** Project ID used by API-backed cost add-ons such as waste estimates */
+  projectId?: string;
 }) {
   const [compareMaterial, setCompareMaterial] = useState<{ id: string; name: string } | null>(null);
   const [materialSearch, setMaterialSearch] = useState("");
@@ -1907,6 +1911,9 @@ export default function BomPanel({
         )}
         {bom.length > 0 && total > 0 && (
           <SubsidyCalculator totalCost={total} buildingInfo={buildingInfo} />
+        )}
+        {bom.length > 0 && projectId && (
+          <WasteEstimatePanel projectId={projectId} bomCount={bom.length} buildingInfo={buildingInfo} />
         )}
         {bom.length > 0 && (
           <button

--- a/web/src/components/WasteEstimatePanel.tsx
+++ b/web/src/components/WasteEstimatePanel.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { api } from "@/lib/api";
+import type { BuildingInfo, WasteCategoryEstimate, WasteEstimateResponse, WasteSortingGuideEntry } from "@/types";
+
+function formatNumber(value: number, locale: string, digits = 1): string {
+  return value.toLocaleString(locale, { maximumFractionDigits: digits });
+}
+
+function categoryColor(type: string): string {
+  switch (type) {
+    case "puujate":
+      return "#8B6F47";
+    case "metallijate":
+      return "#718096";
+    case "kivijate":
+      return "#A0AEC0";
+    case "vaarallinen_jate":
+      return "var(--danger)";
+    case "sekajate":
+      return "var(--amber)";
+    default:
+      return "var(--forest)";
+  }
+}
+
+function localizedInstruction(entry: WasteSortingGuideEntry, locale: string): string {
+  return locale === "fi" ? entry.sortingInstruction_fi : entry.sortingInstruction_en;
+}
+
+export default function WasteEstimatePanel({
+  projectId,
+  bomCount,
+  buildingInfo,
+}: {
+  projectId?: string;
+  bomCount: number;
+  buildingInfo?: BuildingInfo | null;
+}) {
+  const { t, locale } = useTranslation();
+  const [estimate, setEstimate] = useState<WasteEstimateResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!projectId || bomCount === 0) {
+      setEstimate(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    api.getWasteEstimate(projectId)
+      .then((data: WasteEstimateResponse) => {
+        if (!cancelled) setEstimate(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, bomCount]);
+
+  const asbestosRisk = typeof buildingInfo?.year_built === "number" && buildingInfo.year_built < 1994;
+  const recyclableWeight = estimate?.categories
+    .filter((category) => category.recyclable)
+    .reduce((sum, category) => sum + category.weightKg, 0) ?? 0;
+  const recyclingPct = estimate && estimate.totalWeightKg > 0
+    ? Math.round((recyclableWeight / estimate.totalWeightKg) * 100)
+    : 0;
+  const topCategories = estimate?.categories.slice(0, 4) ?? [];
+  const topGuide = estimate?.sortingGuide.slice(0, 3) ?? [];
+
+  const summaryBox = (label: string, value: string) => (
+    <div
+      style={{
+        padding: "8px 10px",
+        background: "var(--bg-secondary)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-sm)",
+      }}
+    >
+      <div style={{ color: "var(--text-muted)", fontSize: 10, marginBottom: 3 }}>{label}</div>
+      <div style={{ color: "var(--text-primary)", fontFamily: "var(--font-mono)", fontSize: 12, fontWeight: 600 }}>
+        {value}
+      </div>
+    </div>
+  );
+
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        padding: "14px 16px",
+        background: "var(--bg-tertiary)",
+        borderRadius: "var(--radius-md)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 8 }}>
+        <div>
+          <div className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)" }}>
+            {t("waste.title")}
+          </div>
+          <div style={{ fontSize: 12, color: "var(--text-secondary)", marginTop: 2 }}>
+            {t("waste.subtitle")}
+          </div>
+        </div>
+        {estimate && estimate.totalWeightKg > 0 && (
+          <span
+            style={{
+              padding: "3px 7px",
+              borderRadius: 999,
+              background: recyclingPct >= 70 ? "var(--forest-dim)" : "var(--amber-glow)",
+              border: recyclingPct >= 70 ? "1px solid rgba(74,124,89,0.2)" : "1px solid var(--amber-border)",
+              color: recyclingPct >= 70 ? "var(--forest)" : "var(--amber)",
+              fontSize: 10,
+              fontFamily: "var(--font-mono)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {t("waste.recyclingRate", { pct: recyclingPct })}
+          </span>
+        )}
+      </div>
+
+      {loading && !estimate && (
+        <div style={{ marginTop: 12, color: "var(--text-muted)", fontSize: 12 }}>
+          {t("waste.estimateLoading")}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ marginTop: 12, color: "var(--danger)", fontSize: 12 }}>
+          {t("waste.estimateFailed")}
+        </div>
+      )}
+
+      {!loading && !error && (!estimate || estimate.categories.length === 0) && (
+        <div style={{ marginTop: 12, color: "var(--text-muted)", fontSize: 12, lineHeight: 1.45 }}>
+          {t("waste.noWasteDesc")}
+        </div>
+      )}
+
+      {estimate && estimate.categories.length > 0 && (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 12 }}>
+            {summaryBox(t("waste.totalWeight"), `${formatNumber(estimate.totalWeightKg, locale)} kg`)}
+            {summaryBox(t("waste.totalVolume"), `${formatNumber(estimate.totalVolumeM3, locale, 2)} m\u00b3`)}
+            {summaryBox(t("waste.totalDisposalCost"), `${formatNumber(estimate.totalDisposalCost, locale, 0)} \u20ac`)}
+            {summaryBox(
+              t("waste.containerRecommendation"),
+              `${estimate.containerRecommendation.count} x ${estimate.containerRecommendation.size}`,
+            )}
+          </div>
+
+          <div style={{ marginTop: 12 }}>
+            <div className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 6 }}>
+              {t("waste.categories")}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {topCategories.map((category: WasteCategoryEstimate) => (
+                <div
+                  key={category.type}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "1fr auto",
+                    gap: 8,
+                    alignItems: "center",
+                    fontSize: 11,
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}>
+                    <span
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: categoryColor(category.type),
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span style={{ color: "var(--text-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {t(`waste.${category.type}`)}
+                    </span>
+                    <span style={{ color: category.recyclable ? "var(--forest)" : "var(--text-muted)", fontSize: 10 }}>
+                      {category.recyclable ? t("waste.recyclable") : t("waste.notRecyclable")}
+                    </span>
+                  </div>
+                  <span style={{ fontFamily: "var(--font-mono)", color: "var(--text-primary)" }}>
+                    {formatNumber(category.weightKg, locale)} kg
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div style={{ marginTop: 12 }}>
+            <div className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 6 }}>
+              {t("waste.sortingGuide")}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 7 }}>
+              {topGuide.map((entry) => (
+                <div
+                  key={entry.wasteType}
+                  style={{
+                    padding: "7px 8px",
+                    background: "var(--bg-secondary)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--radius-sm)",
+                    fontSize: 11,
+                    lineHeight: 1.45,
+                  }}
+                >
+                  <div style={{ color: "var(--text-primary)", fontWeight: 600, marginBottom: 2 }}>
+                    {t(`waste.${entry.wasteType}`)}
+                  </div>
+                  <div style={{ color: "var(--text-muted)" }}>{localizedInstruction(entry, locale)}</div>
+                  <div style={{ color: "var(--amber)", marginTop: 3 }}>{entry.acceptedAt}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {asbestosRisk && (
+            <div
+              style={{
+                marginTop: 10,
+                padding: "8px 10px",
+                background: "rgba(239,68,68,0.06)",
+                border: "1px solid rgba(239,68,68,0.2)",
+                borderRadius: "var(--radius-sm)",
+                color: "var(--danger)",
+                fontSize: 11,
+                lineHeight: 1.45,
+              }}
+            >
+              {t("waste.asbestosWarning", { year: buildingInfo?.year_built ?? "" })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -577,6 +577,17 @@ describe("exhaustive i18n key parity", () => {
     "subsidy.heating.districtHeat", "subsidy.heating.airWater",
     "subsidy.heating.groundSource", "subsidy.heating.otherNonFossil",
     "subsidy.heating.fossil",
+    // waste
+    "waste.title", "waste.subtitle", "waste.totalWeight", "waste.totalVolume",
+    "waste.totalDisposalCost", "waste.recyclingRate", "waste.categories",
+    "waste.wasteType", "waste.weight", "waste.volume", "waste.recyclable",
+    "waste.notRecyclable", "waste.disposalCost", "waste.containerRecommendation",
+    "waste.containerSize", "waste.containerCount", "waste.containerCost",
+    "waste.sortingGuide", "waste.sortingInstruction", "waste.acceptedAt",
+    "waste.noWaste", "waste.noWasteDesc", "waste.puujate", "waste.metallijate",
+    "waste.kivijate", "waste.sekajate", "waste.vaarallinen_jate",
+    "waste.muovijate", "waste.lasijate", "waste.eristejate",
+    "waste.estimateLoading", "waste.estimateFailed", "waste.asbestosWarning",
     // viewport
     "viewport.contextMenuLabel",
   ];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -292,6 +292,8 @@ export const api = {
   getStalePrices: () => apiFetch("/pricing/stale"),
   estimateEnergySubsidy: (data: EnergySubsidyRequest) =>
     apiFetch("/subsidies/energy/estimate", { method: "POST", body: JSON.stringify(data) }),
+  getWasteEstimate: (projectId: string) =>
+    apiFetch(`/waste/estimate?projectId=${encodeURIComponent(projectId)}`),
 
   getCategories: () => apiFetch("/categories"),
   getTemplates: () => apiFetch("/templates"),

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -876,6 +876,7 @@ const translations = {
       totalWeight: 'Jätteen kokonaispaino',
       totalVolume: 'Kokonaistilavuus',
       totalDisposalCost: 'Hävityskustannukset yhteensä',
+      recyclingRate: '{{pct}}% kierrätettävissä',
       categories: 'Jätelajit',
       wasteType: 'Jätelajin',
       weight: 'Paino',
@@ -902,6 +903,7 @@ const translations = {
       eristejate: 'Eristejäte',
       estimateLoading: 'Ladataan jätearviota...',
       estimateFailed: 'Jätearvion lataus epäonnistui',
+      asbestosWarning: 'Rakennusvuosi {{year}}: ennen vuotta 1994 rakennetuissa kohteissa voi olla asbestia. Tee asbestikartoitus ennen purkutöitä.',
     },
   },
   en: {
@@ -1766,6 +1768,7 @@ const translations = {
       totalWeight: 'Total waste weight',
       totalVolume: 'Total volume',
       totalDisposalCost: 'Total disposal cost',
+      recyclingRate: '{{pct}}% recyclable',
       categories: 'Waste categories',
       wasteType: 'Waste type',
       weight: 'Weight',
@@ -1792,6 +1795,7 @@ const translations = {
       eristejate: 'Insulation waste',
       estimateLoading: 'Loading waste estimate...',
       estimateFailed: 'Failed to load waste estimate',
+      asbestosWarning: 'Built in {{year}}: pre-1994 Finnish buildings may contain asbestos. Complete an asbestos survey before demolition.',
     },
     stock: {
       title: 'Availability',

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -215,6 +215,34 @@ export interface EnergySubsidyResponse {
   disclaimer: string;
 }
 
+export interface WasteCategoryEstimate {
+  type: string;
+  weightKg: number;
+  volumeM3: number;
+  recyclable: boolean;
+  disposalCostEur: number;
+}
+
+export interface WasteSortingGuideEntry {
+  wasteType: string;
+  sortingInstruction_fi: string;
+  sortingInstruction_en: string;
+  acceptedAt: string;
+}
+
+export interface WasteEstimateResponse {
+  totalWeightKg: number;
+  totalVolumeM3: number;
+  categories: WasteCategoryEstimate[];
+  containerRecommendation: {
+    size: string;
+    count: number;
+    totalCost: number;
+  };
+  sortingGuide: WasteSortingGuideEntry[];
+  totalDisposalCost: number;
+}
+
 export interface Category {
   id: string;
   display_name: string;


### PR DESCRIPTION
Closes #253

## Summary
- add a Waste & Disposal panel to the BOM cost area using the existing /waste/estimate endpoint
- show total waste weight, total volume, disposal cost, skip/container recommendation, recyclable share, top waste categories, and sorting guide snippets
- surface a pre-1994 asbestos warning from project building_info
- return totalVolumeM3 from the waste API so the UI can show the full volume estimate

## Verification
- npm test -- waste.test.ts (api)
- npm test -- src/lib/__tests__/i18n.test.ts (web)
- npm test -- src/components/__tests__/BomPanel.test.ts (web)
- npm test (api)
- npm test (web)
- npm run build (api)
- npm run build (web)

Note: web build still emits the pre-existing Next warning for experimental.viewTransition.