### PR TITLE
fix(ui): hardcoded colors, locales, and deprecated APIs across 10 components

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -205,7 +205,7 @@ function SuppliersTab() {
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   useEffect(() => {
     api.getSuppliers()
@@ -262,7 +262,7 @@ function SuppliersTab() {
                   <span className="badge badge-amber">{s.product_count}</span>
                 </td>
                 <td style={{ ...tdStyle, color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: 12 }}>
-                  {s.oldest_price ? new Date(s.oldest_price).toLocaleDateString() : "-"}
+                  {s.oldest_price ? new Date(s.oldest_price).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB") : "-"}
                 </td>
               </tr>
             ))
@@ -277,7 +277,7 @@ function PricingTab() {
   const [stale, setStale] = useState<StalePrice[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   useEffect(() => {
     api.getStalePrices()
@@ -343,7 +343,7 @@ function PricingTab() {
                   {s.unit_price.toFixed(2)} EUR
                 </td>
                 <td style={{ ...tdStyle, color: "var(--text-muted)", fontFamily: "var(--font-mono)", fontSize: 12 }}>
-                  {new Date(s.last_scraped_at).toLocaleDateString()}
+                  {new Date(s.last_scraped_at).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}
                 </td>
                 <td style={tdStyle}>
                   <span className={`badge ${s.days_stale > 60 ? "badge-danger" : "badge-warning"}`}>

--- a/web/src/app/shared/[token]/SharedProjectContent.tsx
+++ b/web/src/app/shared/[token]/SharedProjectContent.tsx
@@ -22,7 +22,7 @@ const Viewport3D = dynamic(() => import("@/components/Viewport3D"), {
 });
 
 export default function SharedProjectContent({ token }: { token: string }) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   const [project, setProject] = useState<Project | null>(null);
   const [bom, setBom] = useState<BomItem[]>([]);
@@ -238,7 +238,7 @@ export default function SharedProjectContent({ token }: { token: string }) {
                 {t('share.total')}
               </span>
               <span style={{ fontSize: 15, fontWeight: 700, color: "var(--accent)", fontVariantNumeric: "tabular-nums" }}>
-                {grandTotal.toLocaleString("fi-FI", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} EUR
+                {grandTotal.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} EUR
               </span>
             </div>
           </div>

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -73,13 +73,14 @@ function stockTooltip(
     link?: string | null;
   },
   t: (key: string) => string,
+  locale: string = "fi",
 ): string {
   const meta = stockMeta(normalizeStockLevel(item.stock_level), t);
   const checkedAt = item.stock_last_checked_at ?? item.last_checked_at;
   const parts = [meta.label];
   if (item.store_location) parts.push(item.store_location);
   if (checkedAt) {
-    parts.push(`${t("bom.lastChecked")}: ${new Date(checkedAt).toLocaleDateString()}`);
+    parts.push(`${t("bom.lastChecked")}: ${new Date(checkedAt).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}`);
   }
   if (item.link) parts.push(item.link);
   return parts.join(" · ");
@@ -647,7 +648,7 @@ function PriceComparisonPopup({
   const [priceHistory, setPriceHistory] = useState<PriceHistoryRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [showChart, setShowChart] = useState(false);
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const popupRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const triggerRef = useRef<Element | null>(null);
@@ -829,7 +830,7 @@ function PriceComparisonPopup({
                 const sparkColor = supplierColors.get(price.supplier_id) || "var(--text-muted)";
                 const priceStockLevel = normalizeStockLevel(price.stock_level);
                 const priceStock = stockMeta(priceStockLevel, t);
-                const priceStockTooltip = stockTooltip(price, t);
+                const priceStockTooltip = stockTooltip(price, t, locale);
                 return (
                   <div
                     key={price.id}
@@ -920,7 +921,7 @@ function PriceComparisonPopup({
                         <span>{localizeUnit(price.unit, t)} {t('pricing.perUnit')}</span>
                         {price.sku && <span>SKU: {price.sku}</span>}
                         {price.last_scraped_at && (
-                          <span>{t('pricing.lastChecked')}: {new Date(price.last_scraped_at).toLocaleDateString()}</span>
+                          <span>{t('pricing.lastChecked')}: {new Date(price.last_scraped_at).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}</span>
                         )}
                       </div>
                       {price.link && (
@@ -1322,7 +1323,7 @@ function BomItemCard({
     mat.design_unit !== mat.purchasable_unit;
   const stockLevel = normalizeStockLevel(item.stock_level);
   const stock = stockMeta(stockLevel, t);
-  const stockTooltipText = stockTooltip(item, t);
+  const stockTooltipText = stockTooltip(item, t, locale);
 
   return (
     <div
@@ -2165,7 +2166,7 @@ export default function BomPanel({
               const displayName = getLocalizedMaterialName(m, locale);
               const priceStockLevel = normalizeStockLevel(price?.stock_level);
               const priceStock = stockMeta(priceStockLevel, t);
-              const priceStockTooltip = price ? stockTooltip(price, t) : "";
+              const priceStockTooltip = price ? stockTooltip(price, t, locale) : "";
               return (
                 <div
                   key={m.id}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -315,7 +315,7 @@ export default function ChatPanel({
             "This will replace your current scene script with the AI-generated code.") +
           "\n\n" +
           (t('editor.confirmApplyUndo') || "You can undo with") +
-          ` ${navigator.platform?.includes("Mac") ? "Cmd" : "Ctrl"}+Z`
+          ` ${/Mac|iPhone|iPad|iPod/.test(navigator.userAgent) ? "Cmd" : "Ctrl"}+Z`
         }
         confirmText={t('editor.applyToScene') || "Apply to scene"}
         cancelText={t('editor.cancel') || "Cancel"}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -69,7 +69,7 @@ const CATEGORY_LABELS_FALLBACK: Record<CommandCategory, string> = {
  */
 function isMacPlatform(): boolean {
   if (typeof navigator === "undefined") return false;
-  return /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
+  return /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
 }
 
 function formatShortcutDisplay(shortcut: string): string {

--- a/web/src/components/ConfidenceBadge.tsx
+++ b/web/src/components/ConfidenceBadge.tsx
@@ -138,7 +138,7 @@ export interface ConfidenceBadgeProps {
 }
 
 export default function ConfidenceBadge({ provenance, compact = false }: ConfidenceBadgeProps) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const cfg = LEVEL_CONFIG[provenance.confidence];
 
   const label = t(cfg.labelKey);
@@ -152,7 +152,7 @@ export default function ConfidenceBadge({ provenance, compact = false }: Confide
       {provenance.fetchedAt && (
         <span>
           {t("confidence.fetchedAt")}:{" "}
-          {new Date(provenance.fetchedAt).toLocaleDateString()}
+          {new Date(provenance.fetchedAt).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}
         </span>
       )}
     </span>
@@ -162,7 +162,7 @@ export default function ConfidenceBadge({ provenance, compact = false }: Confide
     <Tooltip content={tooltipContent}>
       <span
         tabIndex={0}
-        aria-label={`${t("confidence.dataQuality")}: ${label}${provenance.fetchedAt ? `, ${t("confidence.fetchedAt")} ${new Date(provenance.fetchedAt).toLocaleDateString()}` : ""}`}
+        aria-label={`${t("confidence.dataQuality")}: ${label}${provenance.fetchedAt ? `, ${t("confidence.fetchedAt")} ${new Date(provenance.fetchedAt).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}` : ""}`}
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -190,14 +190,14 @@ export default function ConfidenceBadge({ provenance, compact = false }: Confide
 
 /* ── StalePrice badge ────────────────────────────────────────────── */
 export function StalePriceBadge({ lastUpdated }: { lastUpdated: string | null | undefined }) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   const tooltipContent = (
     <span>
       {t("confidence.stalePriceDetail")}
       {lastUpdated && (
         <>
-          {" "}({t("confidence.fetchedAt")}: {new Date(lastUpdated).toLocaleDateString()})
+          {" "}({t("confidence.fetchedAt")}: {new Date(lastUpdated).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")})
         </>
       )}
     </span>

--- a/web/src/components/KeyboardShortcutsHelp.tsx
+++ b/web/src/components/KeyboardShortcutsHelp.tsx
@@ -9,7 +9,7 @@ import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
  */
 function isMacPlatform(): boolean {
   if (typeof navigator === "undefined") return false;
-  return /Mac|iPod|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
+  return /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
 }
 
 function formatShortcut(shortcut: KeyboardShortcut): string {

--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -600,7 +600,7 @@ export default function SceneEditor({
               style={{
                 height: "22.1px",
                 ...(i === errorLineIdx
-                  ? { color: "#e05555", fontWeight: 600 }
+                  ? { color: "var(--error, #e05555)", fontWeight: 600 }
                   : i === cursorLine
                     ? { color: "var(--text-secondary)" }
                     : {}),
@@ -763,7 +763,7 @@ export default function SceneEditor({
                   borderRadius: "var(--radius-sm)",
                   fontSize: 11,
                   fontFamily: "var(--font-mono)",
-                  color: "#e05555",
+                  color: "var(--error, #e05555)",
                   lineHeight: 1.4,
                   maxWidth: "100%",
                   overflow: "hidden",
@@ -808,7 +808,7 @@ export default function SceneEditor({
             borderRadius: "var(--radius-sm)",
             fontSize: 12,
             fontFamily: "var(--font-mono)",
-            color: "#e05555",
+            color: "var(--error, #e05555)",
             lineHeight: 1.4,
           }}
         >

--- a/web/src/components/TemplateGrid.tsx
+++ b/web/src/components/TemplateGrid.tsx
@@ -23,7 +23,7 @@ export default function TemplateGrid({
   creating: boolean;
   onCreateFromTemplate: (tmpl: Template) => void;
 }) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   return (
     <div style={{ marginTop: 28 }}>
@@ -105,7 +105,7 @@ export default function TemplateGrid({
                     {tmpl.name}
                   </div>
                   <span className="badge badge-amber">
-                    ~{Number(tmpl.estimated_cost).toLocaleString("fi-FI")} &euro;
+                    ~{Number(tmpl.estimated_cost).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} &euro;
                   </span>
                 </div>
               </div>

--- a/web/src/components/UpgradeGate.tsx
+++ b/web/src/components/UpgradeGate.tsx
@@ -268,7 +268,7 @@ export default function UpgradeGate({
           style={{
             flex: 1,
             background: "var(--amber, #c4915c)",
-            color: "#fff",
+            color: "var(--on-amber, #fff)",
             border: "none",
             borderRadius: "var(--radius-sm, 6px)",
             padding: "10px 20px",


### PR DESCRIPTION
## Summary
- **UpgradeGate**: CTA button `color: "#fff"` → `var(--on-amber, #fff)` for theme compatibility (#725)
- **SceneEditor**: error color `#e05555` → `var(--error, #e05555)` in 3 locations (#723)
- **ChatPanel/CommandPalette/KeyboardShortcutsHelp**: deprecated `navigator.platform` → `navigator.userAgent` (#743, #780)
- **TemplateGrid/SharedProjectContent**: hardcoded `"fi-FI"` locale → locale-aware number formatting (#775)
- **AdminPage**: bare `toLocaleDateString()` → locale-aware in SuppliersTab and PricingTab (#782)
- **ConfidenceBadge/BomPanel**: bare `toLocaleDateString()` → locale-aware formatting

Fixes #725, #723, #743, #780, #775, #782

## Test plan
- [ ] Verify UpgradeGate CTA text visible on both light/dark themes
- [ ] Verify SceneEditor error messages use theme error color
- [ ] Verify Cmd/Ctrl detection works correctly on Mac and non-Mac
- [ ] Switch locale to English and verify number/date formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)