### PR TITLE
fix(ui): share button loading state and locale-aware dates

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1000,6 +1000,7 @@ export default function ProjectPage() {
             className="btn btn-ghost"
             data-tooltip={t('editor.share')}
             aria-label={t('editor.share')}
+            disabled={shareLoading}
             onClick={async () => {
               if (!shareToken) {
                 setShareLoading(true);
@@ -1015,7 +1016,7 @@ export default function ProjectPage() {
               }
               setShowShareDialog(true);
             }}
-            style={{ padding: "5px 7px", display: "flex", alignItems: "center", gap: 4 }}
+            style={{ padding: "5px 7px", display: "flex", alignItems: "center", gap: 4, opacity: shareLoading ? 0.5 : 1 }}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="18" cy="5" r="3" />

--- a/web/src/components/ConfidenceBadge.tsx
+++ b/web/src/components/ConfidenceBadge.tsx
@@ -138,7 +138,7 @@ export interface ConfidenceBadgeProps {
 }
 
 export default function ConfidenceBadge({ provenance, compact = false }: ConfidenceBadgeProps) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
   const cfg = LEVEL_CONFIG[provenance.confidence];
 
   const label = t(cfg.labelKey);
@@ -152,7 +152,7 @@ export default function ConfidenceBadge({ provenance, compact = false }: Confide
       {provenance.fetchedAt && (
         <span>
           {t("confidence.fetchedAt")}:{" "}
-          {new Date(provenance.fetchedAt).toLocaleDateString()}
+          {new Date(provenance.fetchedAt).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}
         </span>
       )}
     </span>
@@ -162,7 +162,7 @@ export default function ConfidenceBadge({ provenance, compact = false }: Confide
     <Tooltip content={tooltipContent}>
       <span
         tabIndex={0}
-        aria-label={`${t("confidence.dataQuality")}: ${label}${provenance.fetchedAt ? `, ${t("confidence.fetchedAt")} ${new Date(provenance.fetchedAt).toLocaleDateString()}` : ""}`}
+        aria-label={`${t("confidence.dataQuality")}: ${label}${provenance.fetchedAt ? `, ${t("confidence.fetchedAt")} ${new Date(provenance.fetchedAt).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")}` : ""}`}
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -190,14 +190,14 @@ export default function ConfidenceBadge({ provenance, compact = false }: Confide
 
 /* ── StalePrice badge ────────────────────────────────────────────── */
 export function StalePriceBadge({ lastUpdated }: { lastUpdated: string | null | undefined }) {
-  const { t } = useTranslation();
+  const { t, locale } = useTranslation();
 
   const tooltipContent = (
     <span>
       {t("confidence.stalePriceDetail")}
       {lastUpdated && (
         <>
-          {" "}({t("confidence.fetchedAt")}: {new Date(lastUpdated).toLocaleDateString()})
+          {" "}({t("confidence.fetchedAt")}: {new Date(lastUpdated).toLocaleDateString(locale === "fi" ? "fi-FI" : "en-GB")})
         </>
       )}
     </span>


### PR DESCRIPTION
## Summary
- **Share button** (#658): now disables and dims while generating share token — prevents double-click
- **ConfidenceBadge/StalePriceBadge**: bare `toLocaleDateString()` → locale-aware (uses `fi-FI` or `en-GB` based on active locale)

Fixes #658

## Test plan
- [ ] Click share button → verify it dims and is not clickable during token generation
- [ ] Check confidence badge dates render correctly in both fi/en locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)