### PR TITLE
fix(a11y): accessibility batch — admin, verify-email, forgot-password, ConfirmDialog

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -95,6 +95,7 @@ function MaterialsTab() {
         <input
           className="input"
           placeholder={t('admin.search')}
+          aria-label={t('admin.search')}
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           style={{ flex: 1, padding: "8px 14px", fontSize: 13 }}
@@ -334,7 +335,7 @@ function PricingTab() {
           <tbody>
             {stale.map((s, i) => (
               <tr
-                key={i}
+                key={`${s.material_name}-${s.supplier_name}`}
                 style={{ animation: `fadeIn 0.2s ease-out ${i * 0.04}s both` }}
               >
                 <td style={{ ...tdStyle, fontWeight: 500 }}>{s.material_name}</td>
@@ -430,10 +431,12 @@ export default function AdminPage() {
         </div>
       </div>
 
-      <div style={{ display: "flex", gap: 4, marginBottom: 24 }}>
+      <div role="tablist" style={{ display: "flex", gap: 4, marginBottom: 24 }}>
         {tabs.map((tabItem) => (
           <button
             key={tabItem.key}
+            role="tab"
+            aria-selected={tab === tabItem.key}
             className="btn"
             onClick={() => setTab(tabItem.key)}
             style={{

--- a/web/src/app/forgot-password/page.tsx
+++ b/web/src/app/forgot-password/page.tsx
@@ -108,7 +108,7 @@ export default function ForgotPasswordPage() {
               </div>
 
               {error && (
-                <div style={{
+                <div role="alert" style={{
                   padding: "10px 14px",
                   borderRadius: "var(--radius-md)",
                   background: "var(--danger-dim)",

--- a/web/src/app/verify-email/page.tsx
+++ b/web/src/app/verify-email/page.tsx
@@ -54,7 +54,12 @@ function VerifyEmailContent() {
 
         {status === "success" && (
           <>
-            <div style={{ fontSize: 48, marginBottom: 16 }}>&#10003;</div>
+            <div style={{ marginBottom: 16 }} aria-hidden="true">
+              <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--success, #4ade80)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+            </div>
             <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
               Sahkoposti vahvistettu!
             </h1>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -321,8 +321,7 @@ export default function ChatPanel({
         cancelText={t('editor.cancel') || "Cancel"}
         onConfirm={handleConfirmApply}
         onCancel={() => setPendingCode(null)}
-      />
-      {pendingCode !== null && (
+      >
         <div className="chat-skip-confirm">
           <input
             type="checkbox"
@@ -335,7 +334,7 @@ export default function ChatPanel({
             {t('editor.dontAskAgain') || "Don't ask again this session"}
           </label>
         </div>
-      )}
+      </ConfirmDialog>
     </div>
   );
 }

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -12,6 +12,7 @@ export interface ConfirmDialogProps {
   variant?: "default" | "danger";
   onConfirm: () => void;
   onCancel: () => void;
+  children?: React.ReactNode;
 }
 
 export default function ConfirmDialog({
@@ -23,6 +24,7 @@ export default function ConfirmDialog({
   variant = "default",
   onConfirm,
   onCancel,
+  children,
 }: ConfirmDialogProps) {
   const { t } = useTranslation();
   const resolvedConfirmText = confirmText ?? t("dialog.confirm");
@@ -52,9 +54,13 @@ export default function ConfirmDialog({
       }
 
       if (e.key === "Tab") {
-        const focusable = [cancelBtnRef.current, confirmBtnRef.current].filter(
-          Boolean
-        ) as HTMLElement[];
+        const container = dialogRef.current;
+        if (!container) return;
+        const focusable = Array.from(
+          container.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          )
+        );
         if (focusable.length === 0) return;
 
         const first = focusable[0];
@@ -171,6 +177,8 @@ export default function ConfirmDialog({
         >
           {message}
         </p>
+
+        {children}
 
         <div
           style={{


### PR DESCRIPTION
## Summary
- Add `aria-label` to admin materials search input (#772)
- Replace HTML entity `&#10003;` with accessible SVG checkmark on verify-email page (#769)
- Add `role="alert"` to forgot-password error div (#778)
- Add `role="tablist"`, `role="tab"`, `aria-selected` to admin tab buttons (#770)
- Use composite key instead of array index for stale price table rows (#781)
- Move "Don't ask again" checkbox inside ConfirmDialog via new `children` prop (#663)
- Update ConfirmDialog focus trap to include all focusable children elements

Closes #772, #769, #778, #770, #781, #663

## Test plan
- [ ] Verify admin page materials search has proper aria-label
- [ ] Verify verify-email success shows SVG checkmark (not HTML entity)
- [ ] Verify forgot-password error div announces via screen reader
- [ ] Verify admin tabs have proper ARIA roles and selected state
- [ ] Verify stale price table rows have stable keys (no React warnings)
- [ ] Verify "Don't ask again" checkbox renders inside ConfirmDialog modal
- [ ] Verify Tab key cycles through checkbox + buttons in ConfirmDialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)