### PR TITLE
fix: URL crash, OnboardingTour render rules, button opacity, shared heading

### DIFF
--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -576,7 +576,7 @@ function SuppliersTab() {
                       rel="noopener noreferrer"
                       style={{ color: "var(--accent)", textDecoration: "none" }}
                     >
-                      {new URL(s.website).hostname}
+                      {(() => { try { return new URL(s.website).hostname; } catch { return s.website; } })()}
                     </a>
                   ) : (
                     <span style={{ color: "var(--text-muted)" }}>-</span>

--- a/web/src/app/shared/[token]/SharedProjectContent.tsx
+++ b/web/src/app/shared/[token]/SharedProjectContent.tsx
@@ -67,7 +67,7 @@ export default function SharedProjectContent({ token }: { token: string }) {
         color: "var(--text-muted)",
         fontSize: 14,
       }} role="status" aria-live="polite" aria-busy="true">
-        {t('editor.loadingProject')}
+        <h1 style={{ fontSize: 14, fontWeight: 400, margin: 0 }}>{t('editor.loadingProject')}</h1>
       </div>
     );
   }

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -323,7 +323,7 @@ export default function AddressSearch({
                   }
                 }}
                 disabled={creating}
-                style={{ width: "100%", padding: "11px 14px", fontSize: 13, fontWeight: 600 }}
+                style={{ width: "100%", padding: "11px 14px", fontSize: 13, fontWeight: 600, opacity: creating ? 0.7 : 1 }}
               >
                 {creating ? t('search.creatingProject') : t('search.createFromBuilding')}
               </button>

--- a/web/src/components/OnboardingTour.tsx
+++ b/web/src/components/OnboardingTour.tsx
@@ -290,14 +290,17 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
     }
   }, [currentStep, displayStep]);
 
-  // Find visible steps (elements that exist in the DOM)
-  const visibleSteps = TOUR_STEPS.filter(
-    (step) =>
-      !(isMobileTour && step.target === "[data-tour='viewport']") &&
-      document.querySelector(step.target) !== null
-  );
+  const [visibleSteps, setVisibleSteps] = useState<TourStep[] | null>(null);
 
-  const step = visibleSteps[currentStep];
+  useEffect(() => {
+    setVisibleSteps(TOUR_STEPS.filter(
+      (s) =>
+        !(isMobileTour && s.target === "[data-tour='viewport']") &&
+        document.querySelector(s.target) !== null
+    ));
+  }, [isMobileTour]);
+
+  const step = visibleSteps?.[currentStep];
 
   const updateRect = useCallback(() => {
     if (!step) return;
@@ -306,13 +309,14 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
   }, [step]);
 
   useEffect(() => {
+    if (!visibleSteps) return;
     if (visibleSteps.length > 0 && currentStep >= visibleSteps.length) {
       setCurrentStep(visibleSteps.length - 1);
     }
     if (visibleSteps.length > 0 && displayStep >= visibleSteps.length) {
       setDisplayStep(visibleSteps.length - 1);
     }
-  }, [currentStep, displayStep, visibleSteps.length]);
+  }, [currentStep, displayStep, visibleSteps]);
 
   useEffect(() => {
     updateRect();
@@ -338,12 +342,13 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
   }, [currentStep]);
 
   const handleNext = useCallback(() => {
+    if (!visibleSteps) return;
     if (currentStep < visibleSteps.length - 1) {
       setCurrentStep(currentStep + 1);
     } else {
       onComplete();
     }
-  }, [currentStep, visibleSteps.length, onComplete]);
+  }, [currentStep, visibleSteps, onComplete]);
 
   const handleSkip = useCallback(() => {
     onComplete();
@@ -374,8 +379,15 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
     }
   }, [currentStep]);
 
-  if (visibleSteps.length === 0 || !step) {
-    onComplete();
+  const shouldComplete = visibleSteps !== null && (visibleSteps.length === 0 || !step);
+
+  useEffect(() => {
+    if (shouldComplete) {
+      onComplete();
+    }
+  }, [shouldComplete, onComplete]);
+
+  if (!visibleSteps || visibleSteps.length === 0 || !step) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Wrap `new URL(s.website)` in try/catch so malformed supplier URLs don't crash admin page (#773)
- Move `onComplete()` from render body to `useEffect` in TourOverlay — fixes React rule violation (#776)
- Compute `visibleSteps` via `useState`/`useEffect` instead of on every render (#777)
- Add `opacity: 0.7` to compact-mode "Create project" button when disabled (#713)
- Add `<h1>` to SharedProjectContent loading state for SEO/accessibility (#783)

Closes #773, #776, #777, #713, #783

## Test plan
- [ ] Admin suppliers tab renders gracefully with malformed website URLs
- [ ] OnboardingTour completes without React console warnings
- [ ] Tour tooltip shows correct step count and content
- [ ] AddressSearch compact mode shows dimmed button while creating
- [ ] Shared project loading state has heading element in DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)