### PR TITLE
fix(ui): quick batch 6 — a11y, perf, and i18n fixes

### DIFF
--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -64,7 +64,7 @@ export default function NotFound() {
             textAnchor="middle"
             fontSize="22"
             fontWeight="700"
-            fontFamily="var(--font-display)"
+            fontFamily="var(--font-display), sans-serif"
             fill="var(--amber)"
           >
             ?

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -312,7 +312,7 @@ export default function SettingsPage() {
               <button
                 className="btn btn-primary"
                 type="submit"
-                disabled={savingProfile}
+                disabled={savingProfile || (name === (user?.name || "") && email === (user?.email || ""))}
                 style={{ padding: "11px 24px" }}
               >
                 {savingProfile ? <span className="btn-spinner" /> : t("settings.saveProfile")}

--- a/web/src/components/SceneApiReference.tsx
+++ b/web/src/components/SceneApiReference.tsx
@@ -243,6 +243,7 @@ function FunctionCard({
           className="api-ref-copy-btn"
           onClick={() => onCopy(fn.example)}
           title="Copy to clipboard"
+          aria-label="Copy to clipboard"
         >
           <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
@@ -390,6 +391,7 @@ export default function SceneApiReference({
                         className="api-ref-copy-btn"
                         onClick={() => copyToClipboard(entry.code)}
                         title="Copy to editor"
+                    aria-label="Copy to editor"
                       >
                         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                           <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
@@ -487,6 +489,7 @@ export default function SceneApiReference({
                     className="api-ref-copy-btn"
                     onClick={() => copyToClipboard(entry.code)}
                     title="Copy to editor"
+                    aria-label="Copy to editor"
                   >
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                       <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />

--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -279,27 +279,13 @@ export default function SceneEditor({
     textareaRef.current?.focus();
   }, []);
 
-  /* ── Listen for cursor changes via interval while focused ───── */
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, []);
-
   const startCursorTracking = useCallback(() => {
     setIsFocused(true);
-    if (intervalRef.current) return;
-    intervalRef.current = setInterval(updateCursorLine, 50);
+    updateCursorLine();
   }, [updateCursorLine]);
 
   const stopCursorTracking = useCallback(() => {
     setIsFocused(false);
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
   }, []);
 
   /* ── Error line (0-based index, or -1 if no error line) ──────── */

--- a/web/src/components/UpgradeGate.tsx
+++ b/web/src/components/UpgradeGate.tsx
@@ -24,7 +24,7 @@ export interface PlanFeatures {
 
 export interface PlanConfig {
   tier: PlanTier;
-  name: string;
+  nameKey: string;
   monthlyPrice: number;
   features: PlanFeatures;
 }
@@ -36,7 +36,7 @@ export interface PlanConfig {
 const PLANS: PlanConfig[] = [
   {
     tier: "free",
-    name: "Ilmainen / Free",
+    nameKey: "upgrade.free",
     monthlyPrice: 0,
     features: {
       maxProjects: 3,
@@ -48,7 +48,7 @@ const PLANS: PlanConfig[] = [
   },
   {
     tier: "pro",
-    name: "Pro",
+    nameKey: "upgrade.pro",
     monthlyPrice: 19,
     features: {
       maxProjects: 20,
@@ -60,7 +60,7 @@ const PLANS: PlanConfig[] = [
   },
   {
     tier: "enterprise",
-    name: "Yritys / Enterprise",
+    nameKey: "upgrade.enterprise",
     monthlyPrice: 49,
     features: {
       maxProjects: -1,
@@ -227,7 +227,7 @@ export default function UpgradeGate({
               textAlign: "center",
               color: p.tier === currentPlan ? "var(--amber, #c4915c)" : "inherit",
             }}>
-              {p.tier === "free" ? t("upgrade.free") : p.tier === "pro" ? t("upgrade.pro") : t("upgrade.enterprise")}
+              {t(p.nameKey)}
             </span>
           ))}
         </div>

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -238,6 +238,7 @@ function CameraToolbar({
             data-active={i === activePreset}
             onClick={() => handlePreset(preset, i)}
             data-tooltip={t(preset.key)}
+            aria-label={t(preset.key)}
           >
             {t(preset.key)}
           </button>


### PR DESCRIPTION
## Summary
- **UpgradeGate**: use i18n `nameKey` for plan names instead of hardcoded ternary chain (#717)
- **SceneEditor**: replace 50ms `setInterval` cursor tracking with event-driven updates — eliminates unnecessary CPU usage (#736)
- **SceneApiReference**: add `aria-label` to all copy buttons for screen readers (#751)
- **Viewport3D**: add `aria-label` to camera preset buttons (#749)
- **NotFound**: add `sans-serif` fallback for SVG `font-family` in case `--font-display` isn't loaded (#715)
- **SettingsPage**: disable save button when profile form hasn't changed (#745)

Fixes #717, #736, #751, #749, #715, #745

## Test plan
- [ ] Verify UpgradeGate plan comparison table shows correct translated plan names
- [ ] Verify SceneEditor cursor line highlight still tracks correctly on click/key events
- [ ] Verify copy buttons in API reference are announced by screen readers
- [ ] Verify camera preset buttons are announced by screen readers
- [ ] Verify 404 page renders question mark correctly even without custom font
- [ ] Verify settings save button is disabled when no changes are made, enables on edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)