### PR TITLE
fix(ui): quick batch 9 — i18n, focus trap, editor constants

### DIFF
--- a/web/src/app/verify-email/page.tsx
+++ b/web/src/app/verify-email/page.tsx
@@ -4,17 +4,19 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { api } from "@/lib/api";
+import { useTranslation } from "@/components/LocaleProvider";
 
 function VerifyEmailContent() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token");
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
   const [errorMsg, setErrorMsg] = useState("");
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!token) {
       setStatus("error");
-      setErrorMsg("Vahvistustunniste puuttuu / Missing verification token");
+      setErrorMsg(t("verifyEmail.missingToken"));
       return;
     }
 
@@ -22,9 +24,9 @@ function VerifyEmailContent() {
       .then(() => setStatus("success"))
       .catch((err) => {
         setStatus("error");
-        setErrorMsg(err instanceof Error ? err.message : "Vahvistus epaonnistui / Verification failed");
+        setErrorMsg(err instanceof Error ? err.message : t("verifyEmail.failed"));
       });
-  }, [token]);
+  }, [token, t]);
 
   return (
     <div style={{
@@ -44,10 +46,10 @@ function VerifyEmailContent() {
         {status === "loading" && (
           <>
             <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
-              Vahvistetaan...
+              {t("verifyEmail.verifying")}
             </h1>
             <p style={{ color: "var(--text-muted)", fontSize: 14 }}>
-              Odota hetki / Please wait...
+              {t("verifyEmail.pleaseWait")}
             </p>
           </>
         )}
@@ -61,19 +63,17 @@ function VerifyEmailContent() {
               </svg>
             </div>
             <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
-              Sahkoposti vahvistettu!
+              {t("verifyEmail.successTitle")}
             </h1>
             <p style={{ color: "var(--text-muted)", fontSize: 14, marginBottom: 24, lineHeight: 1.6 }}>
-              Sahkopostiosoitteesi on nyt vahvistettu. Voit jatkaa Helscoopiin.
-              <br />
-              Your email has been verified. You can continue to Helscoop.
+              {t("verifyEmail.successMessage")}
             </p>
             <a
               href="/"
               className="btn btn-primary"
               style={{ textDecoration: "none", padding: "13px 32px", fontSize: 14 }}
             >
-              Jatka / Continue
+              {t("verifyEmail.continue")}
             </a>
           </>
         )}
@@ -81,7 +81,7 @@ function VerifyEmailContent() {
         {status === "error" && (
           <>
             <h1 className="heading-display" style={{ fontSize: 28, marginBottom: 16 }}>
-              Vahvistus epaonnistui
+              {t("verifyEmail.failedTitle")}
             </h1>
             <div style={{
               padding: "10px 14px",
@@ -99,7 +99,7 @@ function VerifyEmailContent() {
               className="btn btn-ghost"
               style={{ fontSize: 13, textDecoration: "none" }}
             >
-              Takaisin etusivulle / Back to home
+              {t("verifyEmail.backHome")}
             </a>
           </>
         )}
@@ -109,6 +109,8 @@ function VerifyEmailContent() {
 }
 
 export default function VerifyEmailPage() {
+  const { t } = useTranslation();
+
   return (
     <Suspense fallback={
       <div style={{
@@ -119,7 +121,7 @@ export default function VerifyEmailPage() {
         background: "var(--bg-primary)",
         color: "var(--text-muted)",
       }}>
-        Ladataan... / Loading...
+        {t("verifyEmail.loading")}
       </div>
     }>
       <VerifyEmailContent />

--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -103,6 +103,10 @@ function escapeHtml(s: string): string {
     .replace(/>/g, "&gt;");
 }
 
+const EDITOR_FONT_SIZE = 13;
+const EDITOR_LINE_HEIGHT = Math.round(EDITOR_FONT_SIZE * 1.7 * 10) / 10;
+const EDITOR_PADDING_TOP = 20;
+
 /* ── Component ───────────────────────────────────────────────────── */
 export default function SceneEditor({
   sceneJs,
@@ -210,7 +214,7 @@ export default function SceneEditor({
     if (!ta) return;
     // Compute line number of the match
     const linesBefore = sceneJs.slice(0, match.start).split("\n").length - 1;
-    const targetScrollTop = linesBefore * 22.1 - ta.clientHeight / 2 + 22.1;
+    const targetScrollTop = linesBefore * EDITOR_LINE_HEIGHT - ta.clientHeight / 2 + EDITOR_LINE_HEIGHT;
     ta.scrollTop = Math.max(0, targetScrollTop);
     syncScroll();
   }, [currentMatchIdx, findMatches, sceneJs, syncScroll]);
@@ -262,8 +266,8 @@ export default function SceneEditor({
   /* ── Shared text style (keep textarea + overlay pixel-identical) */
   const sharedStyle: React.CSSProperties = {
     fontFamily: "var(--font-mono)",
-    fontSize: 13,
-    lineHeight: "22.1px",  // 13 * 1.7
+    fontSize: EDITOR_FONT_SIZE,
+    lineHeight: `${EDITOR_LINE_HEIGHT}px`,
     padding: "20px 20px 20px 0",
     margin: 0,
     border: "none",
@@ -299,7 +303,7 @@ export default function SceneEditor({
     const ta = textareaRef.current;
     if (!ta) return;
     // Scroll so the error line is roughly centred in the visible area
-    const lineHeight = 22.1;
+    const lineHeight = EDITOR_LINE_HEIGHT;
     const paddingTop = 20;
     const targetScrollTop = paddingTop + errorLineIdx * lineHeight - ta.clientHeight / 2 + lineHeight;
     ta.scrollTop = Math.max(0, targetScrollTop);
@@ -591,7 +595,7 @@ export default function SceneEditor({
             <div
               key={i}
               style={{
-                height: "22.1px",
+                height: `${EDITOR_LINE_HEIGHT}px`,
                 ...(i === errorLineIdx
                   ? { color: "var(--error, #e05555)", fontWeight: 600 }
                   : i === cursorLine
@@ -610,10 +614,10 @@ export default function SceneEditor({
           <div
             style={{
               position: "absolute",
-              top: 20 + cursorLine * 22.1,
+              top: EDITOR_PADDING_TOP + cursorLine * EDITOR_LINE_HEIGHT,
               left: 0,
               right: 0,
-              height: 22.1,
+              height: EDITOR_LINE_HEIGHT,
               background: "rgba(255, 255, 255, 0.03)",
               pointerEvents: "none",
               zIndex: 0,
@@ -625,10 +629,10 @@ export default function SceneEditor({
             <div
               style={{
                 position: "absolute",
-                top: 20 + errorLineIdx * 22.1,
+                top: EDITOR_PADDING_TOP + errorLineIdx * EDITOR_LINE_HEIGHT,
                 left: 0,
                 right: 0,
-                height: 22.1,
+                height: EDITOR_LINE_HEIGHT,
                 background: "rgba(224, 85, 85, 0.1)",
                 borderBottom: "2px solid rgba(224, 85, 85, 0.5)",
                 pointerEvents: "none",
@@ -738,7 +742,7 @@ export default function SceneEditor({
               aria-live="polite"
               style={{
                 position: "absolute",
-                top: 20 + (errorLineIdx + 1) * 22.1,
+                top: EDITOR_PADDING_TOP + (errorLineIdx + 1) * EDITOR_LINE_HEIGHT,
                 left: 20,
                 right: 8,
                 zIndex: 4,

--- a/web/src/components/UpgradeGate.tsx
+++ b/web/src/components/UpgradeGate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 
 // ---------------------------------------------------------------------------
@@ -103,13 +103,44 @@ export default function UpgradeGate({
 }: UpgradeGateProps) {
   const { t } = useTranslation();
   const [dismissed, setDismissed] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
-  if (dismissed) return null;
-
-  function handleDismiss() {
+  const handleDismiss = useCallback(() => {
     setDismissed(true);
     onDismiss?.();
-  }
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (inline || dismissed) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        handleDismiss();
+        return;
+      }
+      if (e.key === "Tab" && dialogRef.current) {
+        const focusable = Array.from(
+          dialogRef.current.querySelectorAll<HTMLElement>(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          )
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    dialogRef.current?.querySelector<HTMLElement>("button")?.focus();
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [inline, dismissed, handleDismiss]);
+
+  if (dismissed) return null;
 
   // Determine headline / description
   const isAiQuota = feature === "aiMessages";
@@ -174,7 +205,7 @@ export default function UpgradeGate({
   ];
 
   const content = (
-    <div style={inline ? {} : card}>
+    <div ref={dialogRef} role={inline ? undefined : "dialog"} aria-modal={inline ? undefined : true} aria-label={headline} style={inline ? {} : card}>
       {/* Header */}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 6 }}>
         <div>

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -730,6 +730,18 @@ const translations = {
       avatarAriaLabel: 'Käyttäjävalikko: {{name}}',
       menuAriaLabel: '{{name}} — valikko',
     },
+    verifyEmail: {
+      verifying: 'Vahvistetaan...',
+      pleaseWait: 'Odota hetki',
+      successTitle: 'S\u00e4hk\u00f6posti vahvistettu!',
+      successMessage: 'S\u00e4hk\u00f6postiosoitteesi on nyt vahvistettu. Voit jatkaa Helscoopiin.',
+      continue: 'Jatka',
+      failedTitle: 'Vahvistus ep\u00e4onnistui',
+      failed: 'Vahvistus ep\u00e4onnistui',
+      missingToken: 'Vahvistustunniste puuttuu',
+      backHome: 'Takaisin etusivulle',
+      loading: 'Ladataan...',
+    },
     bom: {
       donutChartAriaLabel: 'Kustannuserittelyn kaavio: {{categories}}',
       exportCsv: 'Lataa CSV',
@@ -1697,6 +1709,18 @@ const translations = {
     userMenu: {
       avatarAriaLabel: 'User menu for {{name}}',
       menuAriaLabel: '{{name}} menu',
+    },
+    verifyEmail: {
+      verifying: 'Verifying...',
+      pleaseWait: 'Please wait',
+      successTitle: 'Email verified!',
+      successMessage: 'Your email has been verified. You can continue to Helscoop.',
+      continue: 'Continue',
+      failedTitle: 'Verification failed',
+      failed: 'Verification failed',
+      missingToken: 'Missing verification token',
+      backHome: 'Back to home',
+      loading: 'Loading...',
     },
     bom: {
       donutChartAriaLabel: 'Cost breakdown chart: {{categories}}',


### PR DESCRIPTION
## Summary
- **VerifyEmail**: replace all hardcoded Finnish/English dual strings with proper `t()` i18n calls (#768)
- **UpgradeGate**: add focus trap, Escape-to-close, and `role="dialog"` / `aria-modal` for modal overlay (#682)
- **SceneEditor**: extract magic number `22.1px` line height into `EDITOR_LINE_HEIGHT` / `EDITOR_FONT_SIZE` / `EDITOR_PADDING_TOP` constants (#734)
- Add `verifyEmail.*` i18n key set for fi and en

Fixes #768, #682, #734

## Test plan
- [ ] Verify email verification page shows correct translated text in both fi and en
- [ ] Verify UpgradeGate modal traps focus (Tab cycles within dialog)
- [ ] Verify pressing Escape closes the UpgradeGate modal
- [ ] Verify SceneEditor cursor highlight, error highlight, and gutter still align correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)