### PR TITLE
fix(ui): batch 10 — a11y and semantics fixes

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2851,6 +2851,13 @@ select:focus {
   opacity: 1;
 }
 
+.project-card-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
 /* Interactive card — hover lift + amber glow */
 .card-interactive {
   cursor: pointer;

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1475,7 +1475,11 @@ export default function ProjectPage() {
               </button>
             )}
             <div style={{ flex: 1 }} />
-            <span className="viewport-status" data-error={!!sceneError}>
+            <span
+              className="viewport-status"
+              data-error={!!sceneError}
+              title={sceneError && sceneError.length > 40 ? sceneError : undefined}
+            >
               {sceneError
                 ? `${t('editor.sceneErrorPrefix')}: ${sceneError.substring(0, 40)}${sceneError.length > 40 ? "..." : ""}`
                 : t('editor.objectCount', { count: objectCount })}

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -364,7 +364,7 @@ function CostBreakdownChart({
 
         {/* Legend */}
         <div style={{ display: "flex", flexDirection: "column", gap: 5, width: "100%" }}>
-          {slices.map((s) => (
+          {slices.map((s, si) => (
             <div
               key={s.name}
               style={{
@@ -378,9 +378,10 @@ function CostBreakdownChart({
                 style={{
                   width: 8,
                   height: 8,
-                  borderRadius: "50%",
+                  borderRadius: si % 4 === 0 ? "50%" : si % 4 === 1 ? "1px" : si % 4 === 2 ? "50% 0" : "0 50%",
                   background: s.color,
                   flexShrink: 0,
+                  transform: si % 4 === 3 ? "rotate(45deg)" : undefined,
                 }}
               />
               <span

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useTranslation } from "@/components/LocaleProvider";
 import type { Project } from "@/types";
 
@@ -15,27 +15,17 @@ export default function ProjectCard({
   onDuplicate: (id: string) => void;
   onDelete: (id: string) => void;
 }) {
-  const router = useRouter();
   const { t, locale } = useTranslation();
 
   return (
     <div
       className="card card-interactive anim-up project-card-grid"
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          router.push(`/project/${project.id}`);
-        }
-      }}
       style={{
         animationDelay: `${index * 0.04}s`,
         padding: 0,
-        cursor: "pointer",
         overflow: "hidden",
+        position: "relative",
       }}
-      onClick={() => (router.push(`/project/${project.id}`))}
     >
       {/* Thumbnail or placeholder */}
       <div className="project-card-thumb" style={{
@@ -62,7 +52,18 @@ export default function ProjectCard({
       <div style={{ padding: "14px 22px 18px" }}>
         <div style={{ minWidth: 0 }}>
           <div style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 6, minWidth: 0 }}>
-            <h3 className="heading-display" style={{ fontSize: 18, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>{project.name}</h3>
+            <h3 className="heading-display" style={{ fontSize: 18, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>
+              <Link
+                href={`/project/${project.id}`}
+                style={{
+                  color: "inherit",
+                  textDecoration: "none",
+                }}
+                className="project-card-link"
+              >
+                {project.name}
+              </Link>
+            </h3>
             {project.estimated_cost > 0 && (
               <span className="badge badge-amber">
                 {Number(project.estimated_cost).toFixed(0)} &euro;
@@ -77,15 +78,7 @@ export default function ProjectCard({
             </span>
           </div>
         </div>
-        <div className="project-card-actions" onClick={(e) => e.stopPropagation()} style={{ marginTop: 10 }}>
-          <button className="btn btn-ghost" style={{ minWidth: 44, minHeight: 44, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "6px 12px", fontSize: 11, gap: 4 }} aria-label={t('project.openAriaLabel', { name: project.name })} onClick={() => (router.push(`/project/${project.id}`))}>
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-              <polyline points="15 3 21 3 21 9" />
-              <line x1="10" y1="14" x2="21" y2="3" />
-            </svg>
-            {t('project.open')}
-          </button>
+        <div className="project-card-actions" style={{ marginTop: 10, position: "relative", zIndex: 1 }}>
           <button className="btn btn-ghost" style={{ minWidth: 44, minHeight: 44, display: "inline-flex", alignItems: "center", justifyContent: "center", padding: "6px 12px", fontSize: 11, gap: 4 }} aria-label={t('project.copyAriaLabel', { name: project.name })} onClick={() => onDuplicate(project.id)}>
             <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />


### PR DESCRIPTION
## Summary
- **#747** ProjectCard: replaced invalid `role="button"` wrapper containing nested buttons with a stretched `<Link>` pattern — valid HTML semantics, proper keyboard navigation
- **#738** BomPanel: category legend dots now use distinct shapes (circle, square, leaf, rotated leaf) so categories are distinguishable without relying on color alone
- **#659** Viewport toolbar: truncated scene error messages (>40 chars) now show full error text via `title` tooltip on hover

## Test plan
- [ ] ProjectCard: verify clicking card area navigates to project, copy/delete buttons work independently
- [ ] ProjectCard: verify keyboard Tab navigates to link then to action buttons
- [ ] BomPanel: verify legend dots have visually distinct shapes
- [ ] Viewport toolbar: trigger a scene error >40 chars, hover to see full message in tooltip

Closes #747, #738, #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)