### PR TITLE
fix(ui): batch 11 — skeleton loading, focus restore, responsive sidebar

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3236,6 +3236,17 @@ select:focus {
   .bom-item-qty-input {
     padding: 10px 8px;
   }
+
+  .shared-project-layout {
+    flex-direction: column;
+  }
+
+  .shared-project-sidebar {
+    width: 100% !important;
+    border-left: none !important;
+    border-top: 1px solid var(--border);
+    max-height: 50vh;
+  }
 }
 
 /* ========= SMALL MOBILE (480px) ========= */

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { api, setToken, getToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
@@ -39,6 +39,7 @@ export default function SettingsPage() {
   // Delete account
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deletingAccount, setDeletingAccount] = useState(false);
+  const deleteBtnRef = useRef<HTMLButtonElement>(null);
 
   const { toast } = useToast();
   const { t } = useTranslation();
@@ -593,6 +594,7 @@ export default function SettingsPage() {
           </div>
 
           <button
+            ref={deleteBtnRef}
             className="btn btn-danger"
             onClick={() => setShowDeleteConfirm(true)}
             style={{ padding: "11px 24px" }}
@@ -613,7 +615,10 @@ export default function SettingsPage() {
           setShowDeleteConfirm(false);
           handleDeleteAccount();
         }}
-        onCancel={() => setShowDeleteConfirm(false)}
+        onCancel={() => {
+          setShowDeleteConfirm(false);
+          deleteBtnRef.current?.focus();
+        }}
       />
     </div>
   );

--- a/web/src/app/shared/[token]/SharedProjectContent.tsx
+++ b/web/src/app/shared/[token]/SharedProjectContent.tsx
@@ -139,7 +139,7 @@ export default function SharedProjectContent({ token }: { token: string }) {
       </div>
 
       {/* Main content */}
-      <div style={{
+      <div className="shared-project-layout" style={{
         flex: 1,
         display: "flex",
         minHeight: 0,
@@ -170,7 +170,7 @@ export default function SharedProjectContent({ token }: { token: string }) {
 
         {/* BOM sidebar */}
         {bom.length > 0 && (
-          <div style={{
+          <div className="shared-project-sidebar" style={{
             width: 320,
             flexShrink: 0,
             borderLeft: "1px solid var(--border)",

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { api, setToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
-import { SkeletonProjectCard } from "@/components/Skeleton";
+import { SkeletonProjectCard, SkeletonBlock } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
@@ -551,8 +551,10 @@ export default function ProjectList({
         {showTrash && (
           <div>
             {trashLoading ? (
-              <div style={{ color: "var(--text-muted)", fontSize: 14, padding: "20px 0" }}>
-                {t('project.loadingProjects')}
+              <div style={{ display: "flex", flexDirection: "column", gap: 12, padding: "12px 0" }}>
+                {[0, 1].map((i) => (
+                  <SkeletonBlock key={i} width="100%" height={72} radius="var(--radius-md)" />
+                ))}
               </div>
             ) : trashProjects.length === 0 ? (
               <div style={{ padding: "24px 0", textAlign: "center" }}>


### PR DESCRIPTION
## Summary
- **#661** Settings: restore focus to delete-account button after dismissing the confirm dialog (skeleton loading state was already implemented)
- **#629** ProjectList: replace plain-text trash loading indicator with proper `SkeletonBlock` placeholders matching the rest of the app
- **#774** SharedProjectContent: BOM sidebar stacks below viewport on mobile (<768px) instead of squeezing the 3D view
- **#623** Already fixed — main project grid already uses `SkeletonProjectCard` during loading

## Test plan
- [ ] Settings: open delete dialog, cancel — focus should return to delete button
- [ ] ProjectList: expand trash section while loading — should show skeleton blocks, not text
- [ ] Shared project page: resize to <768px — sidebar should stack below viewport
- [ ] Verify no regressions in desktop layout

Closes #661, #629, #774, #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)