### PR TITLE
feat: add Google and Apple OAuth linking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,15 @@ REDIS_URL=redis://localhost:6379
 # ---- Web ----
 NEXT_PUBLIC_API_URL=http://localhost:3001
 
+# ---- OAuth sign-in ----
+# Google OAuth client ID. Use the same browser client ID in web and API token verification.
+# GOOGLE_CLIENT_ID=
+# NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+# Apple Services ID and redirect URI configured in Apple Developer.
+# APPLE_CLIENT_ID=
+# NEXT_PUBLIC_APPLE_CLIENT_ID=
+# NEXT_PUBLIC_APPLE_REDIRECT_URI=http://localhost:3000
+
 # ---- CORS ----
 # Comma-separated list of allowed origins
 CORS_ORIGIN=http://localhost:3000

--- a/api/src/__tests__/google-auth.test.ts
+++ b/api/src/__tests__/google-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import crypto from "crypto";
 
 // Mock the db module before importing auth
 vi.mock("../db", () => ({
@@ -12,7 +13,7 @@ vi.mock("../email", () => ({
   sendVerificationEmail: vi.fn(),
 }));
 
-import { verifyGoogleToken, googleLogin } from "../auth";
+import { verifyGoogleToken, verifyAppleToken, googleLogin, appleLogin } from "../auth";
 import { query } from "../db";
 
 const mockedQuery = vi.mocked(query);
@@ -112,53 +113,134 @@ describe("googleLogin", () => {
 
   it("returns existing user when google_id matches", async () => {
     const existingUser = { id: "user-1", email: "test@gmail.com", name: "Test User", role: "homeowner" };
-    mockedQuery.mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] });
 
     const result = await googleLogin(payload);
     expect(result).toEqual(existingUser);
-    // Should only query once (by google_id)
-    expect(mockedQuery).toHaveBeenCalledTimes(1);
     expect(mockedQuery).toHaveBeenCalledWith(
-      "SELECT id, email, name, role FROM users WHERE google_id = $1",
-      ["google-uid-789"]
+      expect.stringContaining("FROM user_oauth_providers"),
+      ["google", "google-uid-789"]
     );
   });
 
   it("links Google account to existing email user", async () => {
     const existingUser = { id: "user-2", email: "test@gmail.com", name: "Existing User", role: "homeowner" };
-    // First query (by google_id) returns empty
-    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
-    // Second query (by email) returns existing user
-    mockedQuery.mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] });
-    // Third query (UPDATE to link google_id)
-    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] });
 
     const result = await googleLogin(payload);
     expect(result).toEqual(existingUser);
-    expect(mockedQuery).toHaveBeenCalledTimes(3);
-    // Verify the UPDATE was called to link google_id
     expect(mockedQuery).toHaveBeenCalledWith(
-      "UPDATE users SET google_id = $1, email_verified = true WHERE id = $2",
-      ["google-uid-789", "user-2"]
+      expect.stringContaining("UPDATE users"),
+      ["google-uid-789", true, null, "google", "user-2"]
+    );
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO user_oauth_providers"),
+      ["user-2", "google", "google-uid-789", "test@gmail.com", true, "Test User", null]
     );
   });
 
   it("creates a new user when no match exists", async () => {
     const newUser = { id: "user-new", email: "test@gmail.com", name: "Test User", role: "homeowner" };
-    // First query (by google_id) returns empty
-    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
-    // Second query (by email) returns empty
-    mockedQuery.mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] });
-    // Third query (INSERT) returns new user
-    mockedQuery.mockResolvedValueOnce({ rows: [newUser], command: "", rowCount: 1, oid: 0, fields: [] });
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [newUser], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] });
 
     const result = await googleLogin(payload);
     expect(result).toEqual(newUser);
-    expect(mockedQuery).toHaveBeenCalledTimes(3);
-    // Verify the INSERT was called with correct values
     expect(mockedQuery).toHaveBeenCalledWith(
       expect.stringContaining("INSERT INTO users"),
-      ["test@gmail.com", "Test User", "google-uid-789"]
+      ["test@gmail.com", "Test User", "google", null, "google-uid-789"]
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Apple Sign In
+// ---------------------------------------------------------------------------
+
+function b64url(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+describe("verifyAppleToken", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null for malformed identity tokens", async () => {
+    const result = await verifyAppleToken("not-a-jwt");
+    expect(result).toBeNull();
+  });
+
+  it("verifies a signed Apple identity token with JWKS", async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const jwk = publicKey.export({ format: "jwk" }) as Record<string, unknown>;
+    const header = { alg: "RS256", kid: "apple-test-key" };
+    const payload = {
+      iss: "https://appleid.apple.com",
+      aud: "fi.helscoop.web",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      sub: "apple-user-123",
+      email: "user@privaterelay.appleid.com",
+      email_verified: "true",
+    };
+    const signingInput = `${b64url(header)}.${b64url(payload)}`;
+    const signature = crypto.sign("RSA-SHA256", Buffer.from(signingInput), privateKey).toString("base64url");
+    const token = `${signingInput}.${signature}`;
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ keys: [{ ...jwk, kid: "apple-test-key", alg: "RS256", use: "sig" }] }),
+    }));
+
+    const result = await verifyAppleToken(token, { name: "Apple User" });
+    expect(result).toEqual({
+      sub: "apple-user-123",
+      email: "user@privaterelay.appleid.com",
+      email_verified: true,
+      name: "Apple User",
+    });
+  });
+});
+
+describe("appleLogin", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockedQuery.mockReset();
+  });
+
+  it("links Apple account to an existing user with the same verified email", async () => {
+    const existingUser = { id: "user-apple", email: "test@example.com", name: "Existing User", role: "homeowner" };
+    mockedQuery
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [existingUser], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] })
+      .mockResolvedValueOnce({ rows: [], command: "", rowCount: 1, oid: 0, fields: [] });
+
+    const result = await appleLogin({
+      sub: "apple-sub-1",
+      email: "test@example.com",
+      email_verified: true,
+      name: "Apple User",
+    });
+
+    expect(result).toEqual(existingUser);
+    expect(mockedQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO user_oauth_providers"),
+      ["user-apple", "apple", "apple-sub-1", "test@example.com", true, "Apple User", null],
     );
   });
 });

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -98,6 +98,7 @@ export async function login(email: string, password: string) {
   );
   if (result.rows.length === 0) return null;
   const user = result.rows[0];
+  if (!user.password_hash) return null;
   const valid = await bcrypt.compare(password, user.password_hash);
   if (!valid) return null;
   return { id: user.id, email: user.email, name: user.name, role: user.role };
@@ -190,6 +191,11 @@ export async function resendVerification(userId: string): Promise<boolean> {
 // ---------------------------------------------------------------------------
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || "";
+const APPLE_CLIENT_ID = process.env.APPLE_CLIENT_ID || "";
+const APPLE_ISSUER = "https://appleid.apple.com";
+const APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys";
+
+type OAuthProvider = "google" | "apple";
 
 interface GoogleTokenPayload {
   sub: string;       // Google unique user ID
@@ -197,6 +203,82 @@ interface GoogleTokenPayload {
   email_verified: boolean;
   name?: string;
   picture?: string;
+}
+
+interface AppleTokenPayload {
+  sub: string;
+  email: string;
+  email_verified: boolean;
+  name?: string;
+}
+
+interface OAuthProfile {
+  provider: OAuthProvider;
+  providerUserId: string;
+  email: string;
+  emailVerified: boolean;
+  name?: string;
+  avatarUrl?: string;
+}
+
+interface AppleJwk {
+  kid: string;
+  kty: string;
+  alg?: string;
+  use?: string;
+  n: string;
+  e: string;
+}
+
+function cleanOAuthString(value: unknown, maxLength = 500): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  return cleaned ? cleaned.slice(0, maxLength) : undefined;
+}
+
+function cleanOAuthEmail(value: unknown): string | undefined {
+  const cleaned = cleanOAuthString(value, 320)?.toLowerCase();
+  return cleaned && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(cleaned) ? cleaned : undefined;
+}
+
+function fallbackName(email: string): string {
+  return email.split("@")[0] || "Helscoop user";
+}
+
+function decodeBase64UrlJson(segment: string): Record<string, unknown> | null {
+  try {
+    const decoded = Buffer.from(segment, "base64url").toString("utf8");
+    const parsed = JSON.parse(decoded);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function providerUserColumn(provider: OAuthProvider): "google_id" | "apple_id" {
+  return provider === "google" ? "google_id" : "apple_id";
+}
+
+async function verifyAppleJwtSignature(
+  signingInput: string,
+  signatureSegment: string,
+  kid: string,
+): Promise<boolean> {
+  const res = await fetch(APPLE_JWKS_URL);
+  if (!res.ok) return false;
+  const body = (await res.json()) as { keys?: AppleJwk[] };
+  const jwk = body.keys?.find((key) => key.kid === kid && key.kty === "RSA");
+  if (!jwk) return false;
+
+  const publicKey = crypto.createPublicKey({ key: jwk as any, format: "jwk" });
+  return crypto.verify(
+    "RSA-SHA256",
+    Buffer.from(signingInput),
+    publicKey,
+    Buffer.from(signatureSegment, "base64url"),
+  );
 }
 
 /**
@@ -216,14 +298,16 @@ export async function verifyGoogleToken(idToken: string): Promise<GoogleTokenPay
       return null;
     }
 
-    if (!payload.email || !payload.sub) return null;
+    const email = cleanOAuthEmail(payload.email);
+    const sub = cleanOAuthString(payload.sub, 255);
+    if (!email || !sub) return null;
 
     return {
-      sub: payload.sub as string,
-      email: payload.email as string,
+      sub,
+      email,
       email_verified: payload.email_verified === "true" || payload.email_verified === true,
-      name: (payload.name as string) || (payload.email as string).split("@")[0],
-      picture: payload.picture as string | undefined,
+      name: cleanOAuthString(payload.name, 200) || fallbackName(email),
+      picture: cleanOAuthString(payload.picture, 1000),
     };
   } catch {
     return null;
@@ -231,43 +315,186 @@ export async function verifyGoogleToken(idToken: string): Promise<GoogleTokenPay
 }
 
 /**
- * Find or create a user from a verified Google token payload.
- * - If a user with the same google_id exists, return them.
- * - If a user with the same email exists (local signup), link the Google account.
- * - Otherwise, create a new user.
+ * Verify an Apple Sign In identity token with Apple's JWKS endpoint.
+ * The optional display name is only provided by Apple on the first consent.
  */
-export async function googleLogin(payload: GoogleTokenPayload) {
-  // 1. Check by google_id first (returning Google user)
-  const byGoogleId = await query(
-    "SELECT id, email, name, role FROM users WHERE google_id = $1",
-    [payload.sub]
-  );
-  if (byGoogleId.rows.length > 0) {
-    return byGoogleId.rows[0];
+export async function verifyAppleToken(
+  identityToken: string,
+  profileHint: { name?: unknown; email?: unknown } = {},
+): Promise<AppleTokenPayload | null> {
+  const parts = identityToken.split(".");
+  if (parts.length !== 3) return null;
+
+  const [headerSegment, payloadSegment, signatureSegment] = parts;
+  const header = decodeBase64UrlJson(headerSegment);
+  const payload = decodeBase64UrlJson(payloadSegment);
+  if (!header || !payload) return null;
+  if (header.alg !== "RS256" || typeof header.kid !== "string") return null;
+  if (payload.iss !== APPLE_ISSUER) return null;
+  if (APPLE_CLIENT_ID && payload.aud !== APPLE_CLIENT_ID) return null;
+
+  const exp = typeof payload.exp === "number" ? payload.exp : Number(payload.exp);
+  if (!Number.isFinite(exp) || exp <= Math.floor(Date.now() / 1000)) return null;
+
+  try {
+    const verified = await verifyAppleJwtSignature(
+      `${headerSegment}.${payloadSegment}`,
+      signatureSegment,
+      header.kid,
+    );
+    if (!verified) return null;
+  } catch {
+    return null;
   }
 
-  // 2. Check by email (existing local user signing in with Google for the first time)
+  const sub = cleanOAuthString(payload.sub, 255);
+  const email = cleanOAuthEmail(payload.email) || cleanOAuthEmail(profileHint.email);
+  if (!sub || !email) return null;
+
+  const emailVerified = payload.email_verified === true || payload.email_verified === "true";
+  const name = cleanOAuthString(profileHint.name, 200) || cleanOAuthString(payload.name, 200);
+
+  return {
+    sub,
+    email,
+    email_verified: emailVerified,
+    name: name || fallbackName(email),
+  };
+}
+
+async function linkOAuthProvider(userId: string, profile: OAuthProfile) {
+  const providerColumn = providerUserColumn(profile.provider);
+  await query(
+    `UPDATE users
+     SET ${providerColumn} = COALESCE(${providerColumn}, $1),
+         email_verified = email_verified OR $2,
+         avatar_url = COALESCE(avatar_url, $3),
+         auth_provider = CASE WHEN auth_provider = 'local' THEN $4 ELSE auth_provider END
+     WHERE id = $5`,
+    [profile.providerUserId, profile.emailVerified, profile.avatarUrl ?? null, profile.provider, userId],
+  );
+
+  await query(
+    `INSERT INTO user_oauth_providers (
+       user_id, provider, provider_user_id, email, email_verified, display_name, avatar_url
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (provider, provider_user_id)
+     DO UPDATE SET
+       user_id = EXCLUDED.user_id,
+       email = EXCLUDED.email,
+       email_verified = EXCLUDED.email_verified,
+       display_name = COALESCE(EXCLUDED.display_name, user_oauth_providers.display_name),
+       avatar_url = COALESCE(EXCLUDED.avatar_url, user_oauth_providers.avatar_url),
+       updated_at = now()`,
+    [
+      userId,
+      profile.provider,
+      profile.providerUserId,
+      profile.email,
+      profile.emailVerified,
+      profile.name ?? null,
+      profile.avatarUrl ?? null,
+    ],
+  );
+}
+
+/**
+ * Find or create a user from a verified OAuth provider profile.
+ * - Existing provider identity returns the linked user.
+ * - Existing verified email links Google/Apple to that user.
+ * - Otherwise, a new OAuth-only user is created.
+ */
+export async function oauthLogin(profile: OAuthProfile) {
+  if (!profile.emailVerified) {
+    throw new Error("OAuth provider did not verify the email address");
+  }
+
+  const email = cleanOAuthEmail(profile.email);
+  const providerUserId = cleanOAuthString(profile.providerUserId, 255);
+  if (!email || !providerUserId) {
+    throw new Error("OAuth profile is missing a valid email or provider id");
+  }
+
+  const normalizedProfile: OAuthProfile = {
+    ...profile,
+    email,
+    providerUserId,
+    name: cleanOAuthString(profile.name, 200) || fallbackName(email),
+    avatarUrl: cleanOAuthString(profile.avatarUrl, 1000),
+  };
+
+  const byProvider = await query(
+    `SELECT u.id, u.email, u.name, u.role
+     FROM user_oauth_providers op
+     JOIN users u ON u.id = op.user_id
+     WHERE op.provider = $1 AND op.provider_user_id = $2`,
+    [normalizedProfile.provider, normalizedProfile.providerUserId],
+  );
+  if (byProvider.rows.length > 0) {
+    await linkOAuthProvider(byProvider.rows[0].id, normalizedProfile);
+    return byProvider.rows[0];
+  }
+
+  const providerColumn = providerUserColumn(normalizedProfile.provider);
+  const byLegacyProvider = await query(
+    `SELECT id, email, name, role FROM users WHERE ${providerColumn} = $1`,
+    [normalizedProfile.providerUserId],
+  );
+  if (byLegacyProvider.rows.length > 0) {
+    await linkOAuthProvider(byLegacyProvider.rows[0].id, normalizedProfile);
+    return byLegacyProvider.rows[0];
+  }
+
   const byEmail = await query(
-    "SELECT id, email, name, role FROM users WHERE email = $1",
-    [payload.email]
+    "SELECT id, email, name, role FROM users WHERE lower(email) = lower($1)",
+    [normalizedProfile.email],
   );
   if (byEmail.rows.length > 0) {
-    // Link Google account to existing user
-    await query(
-      "UPDATE users SET google_id = $1, email_verified = true WHERE id = $2",
-      [payload.sub, byEmail.rows[0].id]
-    );
+    await linkOAuthProvider(byEmail.rows[0].id, normalizedProfile);
     return byEmail.rows[0];
   }
 
-  // 3. Create new user
+  const providerColumnValue = normalizedProfile.providerUserId;
   const result = await query(
-    `INSERT INTO users (email, name, google_id, auth_provider, email_verified, accepted_terms_at)
-     VALUES ($1, $2, $3, 'google', true, NOW())
+    `INSERT INTO users (
+       email, name, password_hash, email_verified, accepted_terms_at,
+       auth_provider, avatar_url, ${providerColumn}
+     )
+     VALUES ($1, $2, NULL, true, NOW(), $3, $4, $5)
      RETURNING id, email, name, role`,
-    [payload.email, payload.name || payload.email.split("@")[0], payload.sub]
+    [
+      normalizedProfile.email,
+      normalizedProfile.name || fallbackName(normalizedProfile.email),
+      normalizedProfile.provider,
+      normalizedProfile.avatarUrl ?? null,
+      providerColumnValue,
+    ],
   );
+
+  await linkOAuthProvider(result.rows[0].id, normalizedProfile);
   return result.rows[0];
+}
+
+export async function googleLogin(payload: GoogleTokenPayload) {
+  return oauthLogin({
+    provider: "google",
+    providerUserId: payload.sub,
+    email: payload.email,
+    emailVerified: payload.email_verified,
+    name: payload.name,
+    avatarUrl: payload.picture,
+  });
+}
+
+export async function appleLogin(payload: AppleTokenPayload) {
+  return oauthLogin({
+    provider: "apple",
+    providerUserId: payload.sub,
+    email: payload.email,
+    emailVerified: payload.email_verified,
+    name: payload.name,
+  });
 }
 
 // Validate a reset token and update the user's password. Returns true on success.

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,7 +6,7 @@ import jwt from "jsonwebtoken";
 import rateLimit from "express-rate-limit";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
-import { login, register, signToken, tokenExpiresAt, verifyForRefresh, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, verifyGoogleToken, googleLogin, AuthUser } from "./auth";
+import { login, register, signToken, tokenExpiresAt, verifyForRefresh, requireAuth, forgotPassword, resetPassword, verifyEmail, resendVerification, verifyGoogleToken, googleLogin, verifyAppleToken, appleLogin, AuthUser } from "./auth";
 import { query, pool } from "./db";
 import { kanalaSceneJs } from "./templates/kanala";
 import materialsRouter from "./routes/materials";
@@ -323,6 +323,9 @@ app.post("/auth/google", authLimiter, async (req, res) => {
     if (!payload) {
       return res.status(401).json({ error: "Invalid Google credential" });
     }
+    if (!payload.email_verified) {
+      return res.status(401).json({ error: "Google email is not verified" });
+    }
     const user = await googleLogin(payload);
     res.json({ token: signToken(user), token_expires_at: tokenExpiresAt(), user });
   } catch (e: unknown) {
@@ -333,9 +336,40 @@ app.post("/auth/google", authLimiter, async (req, res) => {
   }
 });
 
+app.post("/auth/apple", authLimiter, async (req, res) => {
+  const { identityToken, user: appleUser } = req.body;
+  if (!identityToken) {
+    return res.status(400).json({ error: "Apple identity token is required" });
+  }
+  try {
+    const nameParts = appleUser?.name;
+    const displayName =
+      typeof appleUser?.name === "string"
+        ? appleUser.name
+        : [nameParts?.firstName, nameParts?.lastName].filter(Boolean).join(" ");
+    const payload = await verifyAppleToken(identityToken, {
+      name: displayName,
+      email: appleUser?.email,
+    });
+    if (!payload) {
+      return res.status(401).json({ error: "Invalid Apple identity token" });
+    }
+    if (!payload.email_verified) {
+      return res.status(401).json({ error: "Apple email is not verified" });
+    }
+    const user = await appleLogin(payload);
+    res.json({ token: signToken(user), token_expires_at: tokenExpiresAt(), user });
+  } catch (e: unknown) {
+    logger.error({ err: e }, "Apple auth error");
+    Sentry.captureException(e);
+    const msg = e instanceof Error ? e.message : "Apple authentication failed";
+    res.status(500).json({ error: msg });
+  }
+});
+
 app.get("/auth/me", authenticatedLimiter, requireAuth, async (req, res) => {
   const result = await query(
-    "SELECT id, email, name, role, email_verified FROM users WHERE id = $1",
+    "SELECT id, email, name, role, email_verified, avatar_url, auth_provider FROM users WHERE id = $1",
     [req.user!.id]
   );
   if (result.rows.length === 0) {

--- a/db/migrations/016_oauth_providers.sql
+++ b/db/migrations/016_oauth_providers.sql
@@ -1,0 +1,42 @@
+-- Migration 016: OAuth provider accounts for Google and Apple sign-in.
+--
+-- Keeps provider identities separate from users so one Helscoop account can
+-- be linked to both Google and Apple by verified email.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS apple_id TEXT UNIQUE;
+
+CREATE TABLE IF NOT EXISTS user_oauth_providers (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL CHECK (provider IN ('google', 'apple')),
+  provider_user_id TEXT NOT NULL,
+  email TEXT NOT NULL,
+  email_verified BOOLEAN NOT NULL DEFAULT false,
+  display_name TEXT,
+  avatar_url TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (provider, provider_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_oauth_providers_user_id
+  ON user_oauth_providers(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_oauth_providers_email
+  ON user_oauth_providers(lower(email));
+
+INSERT INTO user_oauth_providers (
+  user_id,
+  provider,
+  provider_user_id,
+  email,
+  email_verified,
+  display_name,
+  created_at,
+  updated_at
+)
+SELECT id, 'google', google_id, email, email_verified, name, now(), now()
+FROM users
+WHERE google_id IS NOT NULL
+ON CONFLICT (provider, provider_user_id) DO NOTHING;

--- a/web/src/__tests__/LoginForm.test.tsx
+++ b/web/src/__tests__/LoginForm.test.tsx
@@ -42,6 +42,11 @@ vi.mock("@/components/LocaleProvider", () => ({
         "auth.passwordMedium": "Keskitaso",
         "auth.passwordWeak": "Heikko",
         "auth.passwordStrength": "Salasanan vahvuus",
+        "auth.googleSignIn": "Kirjaudu Googlella",
+        "auth.googleSignInError": "Google-kirjautuminen epaonnistui",
+        "auth.appleSignIn": "Kirjaudu Applella",
+        "auth.appleSignInError": "Apple-kirjautuminen epaonnistui",
+        "auth.orContinueWith": "tai jatka",
         "legal.acceptTerms": "Hyvaksyn kayttohehdot ja tietosuojakaytannon",
         "legal.acceptTermsRequired": "Sinun taytyy hyvaksya kayttoehdot",
         "legal.termsOfService": "kayttohehdot",
@@ -73,10 +78,14 @@ vi.mock("@/hooks/useAnalytics", () => ({
 // Mock api module
 const mockLogin = vi.fn();
 const mockRegister = vi.fn();
+const mockGoogleLogin = vi.fn();
+const mockAppleLogin = vi.fn();
 vi.mock("@/lib/api", () => ({
   api: {
     login: (...args: unknown[]) => mockLogin(...args),
     register: (...args: unknown[]) => mockRegister(...args),
+    googleLogin: (...args: unknown[]) => mockGoogleLogin(...args),
+    appleLogin: (...args: unknown[]) => mockAppleLogin(...args),
   },
   setToken: vi.fn(),
 }));
@@ -114,6 +123,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockLogin.mockReset();
   mockRegister.mockReset();
+  mockGoogleLogin.mockReset();
+  mockAppleLogin.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -149,6 +160,12 @@ describe("LoginForm — login mode", () => {
   it("renders switch-to-register link", () => {
     render(<LoginForm {...defaultProps} />);
     expect(screen.getByText("Ei tilia? Rekisteroidy")).toBeDefined();
+  });
+
+  it("renders Google and Apple OAuth buttons prominently", () => {
+    render(<LoginForm {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /Kirjaudu Googlella/ })).toBeDefined();
+    expect(screen.getByRole("button", { name: /Kirjaudu Applella/ })).toBeDefined();
   });
 
   it("shows pending building address in subtitle", () => {
@@ -358,6 +375,33 @@ describe("LoginForm — form submission", () => {
 
     await waitFor(() => {
       expect(mockRegister).toHaveBeenCalledWith("test@test.com", "StrongPass1!", "Test User");
+    });
+  });
+
+  it("uses Apple Sign In popup result to authenticate", async () => {
+    process.env.NEXT_PUBLIC_APPLE_CLIENT_ID = "fi.helscoop.web";
+    mockAppleLogin.mockResolvedValue({ token: "jwt-token", token_expires_at: 9999999999 });
+    Object.defineProperty(window, "AppleID", {
+      configurable: true,
+      value: {
+        auth: {
+          init: vi.fn(),
+          signIn: vi.fn().mockResolvedValue({
+            authorization: { id_token: "apple-id-token" },
+            user: { name: { firstName: "Apple", lastName: "User" }, email: "apple@test.com" },
+          }),
+        },
+      },
+    });
+
+    render(<LoginForm {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: /Kirjaudu Applella/ }));
+
+    await waitFor(() => {
+      expect(mockAppleLogin).toHaveBeenCalledWith(
+        "apple-id-token",
+        { name: { firstName: "Apple", lastName: "User" }, email: "apple@test.com" },
+      );
     });
   });
 });

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -94,6 +94,8 @@ export default function RootLayout({
         />
         {/* Google Identity Services — for Google Sign-In */}
         <script src="https://accounts.google.com/gsi/client" async defer />
+        {/* Apple JS SDK — for Sign in with Apple */}
+        <script src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js" async defer />
         {/* Plausible Analytics — privacy-first, no cookies, GDPR-compliant */}
         <script
           defer

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -11,6 +11,32 @@ import TrustLayer from "@/components/TrustLayer";
 import ScrollReveal from "@/components/ScrollReveal";
 import type { BuildingResult } from "@/types";
 
+type GoogleIdentity = {
+  accounts: {
+    id: {
+      initialize: (config: { client_id: string; callback: (response: { credential: string }) => void }) => void;
+      prompt: () => void;
+    };
+  };
+};
+
+type AppleSignInResponse = {
+  authorization?: { id_token?: string };
+  user?: unknown;
+};
+
+type AppleIdentity = {
+  auth: {
+    init: (config: {
+      clientId: string;
+      scope: string;
+      redirectURI: string;
+      usePopup: boolean;
+    }) => void;
+    signIn: () => Promise<AppleSignInResponse>;
+  };
+};
+
 export default function LoginForm({
   onLogin,
   pendingBuilding,
@@ -27,6 +53,7 @@ export default function LoginForm({
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [appleLoading, setAppleLoading] = useState(false);
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const { t } = useTranslation();
   const { track } = useAnalytics();
@@ -72,17 +99,15 @@ export default function LoginForm({
     setGoogleLoading(true);
     try {
       // Use Google Identity Services popup flow
-      const google = (window as unknown as { google?: { accounts: { id: {
-        initialize: (config: { client_id: string; callback: (response: { credential: string }) => void }) => void;
-        prompt: () => void;
-      } } } }).google;
-      if (!google) {
+      const google = (window as unknown as { google?: GoogleIdentity }).google;
+      const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "";
+      if (!google || !clientId) {
         setError(t("auth.googleSignInError"));
         setGoogleLoading(false);
         return;
       }
       google.accounts.id.initialize({
-        client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID || "",
+        client_id: clientId,
         callback: async (response: { credential: string }) => {
           try {
             const result = await api.googleLogin(response.credential);
@@ -100,6 +125,43 @@ export default function LoginForm({
       setError(t("auth.googleSignInError"));
       setGoogleLoading(false);
     }
+  }
+
+  async function handleAppleSignIn() {
+    setError("");
+    setAppleLoading(true);
+    try {
+      const AppleID = (window as unknown as { AppleID?: AppleIdentity }).AppleID;
+      const clientId = process.env.NEXT_PUBLIC_APPLE_CLIENT_ID || "";
+      if (!AppleID || !clientId) {
+        setError(t("auth.appleSignInError"));
+        setAppleLoading(false);
+        return;
+      }
+
+      AppleID.auth.init({
+        clientId,
+        scope: "name email",
+        redirectURI: process.env.NEXT_PUBLIC_APPLE_REDIRECT_URI || window.location.origin,
+        usePopup: true,
+      });
+
+      const response = await AppleID.auth.signIn();
+      const identityToken = response.authorization?.id_token;
+      if (!identityToken) {
+        setError(t("auth.appleSignInError"));
+        setAppleLoading(false);
+        return;
+      }
+
+      const result = await api.appleLogin(identityToken, response.user);
+      setToken(result.token, result.token_expires_at);
+      track("auth_apple_login", {} as Record<string, never>);
+      onLogin();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("auth.appleSignInError"));
+    }
+    setAppleLoading(false);
   }
 
   const features = [
@@ -376,7 +438,7 @@ export default function LoginForm({
           <button
             type="button"
             onClick={handleGoogleSignIn}
-            disabled={googleLoading}
+            disabled={googleLoading || appleLoading}
             style={{
               width: "100%",
               padding: "12px 16px",
@@ -386,12 +448,12 @@ export default function LoginForm({
               borderRadius: "var(--radius-md)",
               background: "var(--surface)",
               color: "var(--text-primary)",
-              cursor: googleLoading ? "not-allowed" : "pointer",
+              cursor: googleLoading || appleLoading ? "not-allowed" : "pointer",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
               gap: 10,
-              opacity: googleLoading ? 0.7 : 1,
+              opacity: googleLoading || appleLoading ? 0.7 : 1,
               transition: "border-color 0.15s ease, background 0.15s ease",
             }}
           >
@@ -406,6 +468,42 @@ export default function LoginForm({
                   <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
                 </svg>
                 {t("auth.googleSignIn")}
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleAppleSignIn}
+            disabled={googleLoading || appleLoading}
+            style={{
+              width: "100%",
+              padding: "12px 16px",
+              fontSize: 14,
+              fontWeight: 500,
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-md)",
+              background: "var(--text-primary)",
+              color: "var(--bg)",
+              cursor: googleLoading || appleLoading ? "not-allowed" : "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 10,
+              opacity: googleLoading || appleLoading ? 0.7 : 1,
+              transition: "border-color 0.15s ease, background 0.15s ease",
+              marginTop: 10,
+            }}
+          >
+            {appleLoading ? (
+              <span className="btn-spinner" />
+            ) : (
+              <>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M16.36 1.43c0 1.05-.42 2.05-1.12 2.82-.76.84-2.02 1.49-3.08 1.4-.14-1.01.39-2.08 1.05-2.83.75-.85 2.06-1.5 3.15-1.39z" />
+                  <path d="M20.27 17.19c-.54 1.24-.8 1.8-1.5 2.9-.98 1.5-2.37 3.38-4.09 3.39-1.53.02-1.93-.99-4.01-.98-2.08.01-2.52 1-4.05.98-1.72-.02-3.03-1.71-4.02-3.21C-.15 16.05-.43 11.1 1.38 8.45c1.28-1.87 3.3-2.96 5.21-2.96 1.95 0 3.17 1.02 4.78 1.02 1.56 0 2.51-1.03 4.77-1.03 1.71 0 3.53.9 4.8 2.45-4.22 2.22-3.54 8.01-.67 9.26z" />
+                </svg>
+                {t("auth.appleSignIn")}
               </>
             )}
           </button>

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -28,6 +28,7 @@ export type AnalyticsEvent =
   | "auth_register"
   | "auth_login"
   | "auth_google_login"
+  | "auth_apple_login"
   | "page_view";
 
 // ── Property maps per event ────────────────────────────────────────
@@ -46,6 +47,7 @@ export interface AnalyticsEventProps {
   auth_register: Record<string, never>;
   auth_login: Record<string, never>;
   auth_google_login: Record<string, never>;
+  auth_apple_login: Record<string, never>;
   page_view: { path: string };
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -231,6 +231,11 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ credential }),
     }),
+  appleLogin: (identityToken: string, user?: unknown) =>
+    apiFetch("/auth/apple", {
+      method: "POST",
+      body: JSON.stringify({ identityToken, user }),
+    }),
   me: () => apiFetch("/auth/me"),
   updateProfile: (data: { name?: string; email?: string }) =>
     apiFetch("/auth/profile", { method: "PUT", body: JSON.stringify(data) }),

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -47,8 +47,10 @@ const translations = {
       passwordMedium: 'Keskiverto',
       passwordStrong: 'Vahva',
       passwordStrength: 'Salasanan vahvuus',
-      googleSignIn: 'Kirjaudu Google-tilill\u00e4',
+      googleSignIn: 'Jatka Googlella',
       googleSignInError: 'Google-kirjautuminen ep\u00e4onnistui',
+      appleSignIn: 'Jatka Applella',
+      appleSignInError: 'Apple-kirjautuminen ep\u00e4onnistui',
       orContinueWith: 'tai jatka',
     },
     brand: {
@@ -1057,8 +1059,10 @@ const translations = {
       passwordMedium: 'Medium',
       passwordStrong: 'Strong',
       passwordStrength: 'Password strength',
-      googleSignIn: 'Sign in with Google',
+      googleSignIn: 'Continue with Google',
       googleSignInError: 'Google sign-in failed',
+      appleSignIn: 'Continue with Apple',
+      appleSignInError: 'Apple sign-in failed',
       orContinueWith: 'or continue with',
     },
     brand: {


### PR DESCRIPTION
## Summary
- add user_oauth_providers migration for Google/Apple provider identities and account linking by verified email
- generalize OAuth login/upsert logic, verify Apple identity tokens with Apple JWKS, and keep Google token verification
- add Apple and Google sign-in buttons to the login/signup UI with env wiring and tests

Closes #25

## Verification
- api: npm run build
- api: npm test -- src/__tests__/google-auth.test.ts
- api: npm test
- web: npm test -- src/__tests__/LoginForm.test.tsx src/lib/__tests__/i18n.test.ts
- web: npm test
- web: npm run build
- git diff --check

## Deployment notes
- Configure GOOGLE_CLIENT_ID and NEXT_PUBLIC_GOOGLE_CLIENT_ID for Google sign-in.
- Configure APPLE_CLIENT_ID, NEXT_PUBLIC_APPLE_CLIENT_ID, and NEXT_PUBLIC_APPLE_REDIRECT_URI for Apple Sign In.