### PR TITLE
Fix mobile editor layout

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2463,6 +2463,36 @@ select:focus {
   gap: 4px;
 }
 
+.editor-mobile-actions {
+  display: none;
+  position: relative;
+}
+
+.editor-mobile-actions-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 190px;
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  z-index: 120;
+}
+
+.editor-mobile-actions-menu .btn {
+  width: 100%;
+  justify-content: flex-start;
+  padding: 10px 12px;
+  border: none;
+  font-size: 13px;
+}
+
+.mobile-editor-tabs {
+  display: none;
+}
+
 /* ── Save status pill ────────────────────────────────────── */
 
 .save-status-pill {
@@ -3146,50 +3176,254 @@ select:focus {
   }
 
   .editor-page {
-    height: auto;
+    width: 100vw;
+    max-width: 100vw;
+    height: 100vh;
+    height: 100dvh;
     min-height: 100vh;
     min-height: 100dvh;
+    overflow: hidden;
   }
 
   .editor-main {
     flex-direction: column;
-    overflow: visible;
-  }
-
-  .editor-bom-panel {
-    width: 100%;
-    border-left: none;
-    border-top: 1px solid var(--border);
-    max-height: 50vh;
-  }
-
-  .chat-embedded {
-    padding: 0 6px 6px 6px;
-  }
-  .chat-messages-area {
-    max-height: 160px;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
   }
 
   .editor-viewport-area {
-    min-height: 300px;
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .editor-viewport-shell {
+    min-height: 280px;
+    touch-action: none;
+  }
+
+  .viewport-toolbar {
+    gap: 6px;
+    padding: 6px 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .viewport-toolbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .viewport-toolbar-btn {
+    flex: 0 0 auto;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px 10px;
+  }
+
+  .viewport-status {
+    display: none;
+  }
+
+  .mobile-editor-tabs {
+    display: flex;
+    flex-shrink: 0;
+    gap: 6px;
+    padding: 8px;
+    overflow-x: auto;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .mobile-editor-tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .mobile-editor-tab {
+    min-width: 72px;
+    min-height: 44px;
+    padding: 8px 10px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    white-space: nowrap;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .mobile-editor-tab[data-active="true"] {
+    color: var(--amber);
+    background: var(--amber-glow);
+    border-color: var(--amber-border);
+  }
+
+  .mobile-editor-tab-badge {
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 99px;
+    background: var(--bg-hover);
+    color: var(--text-muted);
+    font-size: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .mobile-editor-tab[data-active="true"] .mobile-editor-tab-badge {
+    background: rgba(229, 160, 75, 0.2);
+    color: var(--amber);
+  }
+
+  .resize-handle-v {
+    display: none;
+  }
+
+  .editor-page[data-mobile-panel]:not([data-mobile-panel="chat"]) .chat-embedded,
+  .editor-page[data-mobile-panel]:not([data-mobile-panel="code"]) .editor-code-panel,
+  .editor-page[data-mobile-panel]:not([data-mobile-panel="bom"]) .editor-bom-panel,
+  .editor-page[data-mobile-panel]:not([data-mobile-panel="params"]) .scene-params-panel,
+  .editor-page[data-mobile-panel]:not([data-mobile-panel="docs"]) .scene-docs-panel {
+    display: none;
+  }
+
+  .editor-page[data-mobile-panel="chat"] .chat-embedded,
+  .editor-page[data-mobile-panel="code"] .editor-code-panel {
+    display: flex;
+    flex-direction: column;
+    height: min(42dvh, 360px) !important;
+    flex-shrink: 0;
+    padding: 8px;
+    border-top: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface-raised) 72%, transparent);
+  }
+
+  .editor-page[data-mobile-panel="chat"] .chat-messages-area {
+    max-height: none;
+    flex: 1;
+    min-height: 0;
+  }
+
+  .editor-page[data-mobile-panel="chat"] .chat-messages-scroll {
+    max-height: none;
+    flex: 1;
+  }
+
+  .editor-page[data-mobile-panel="bom"] .editor-bom-panel {
+    display: flex;
+    width: 100% !important;
+    height: min(46dvh, 420px);
+    max-height: none;
+    min-height: 240px;
+    border-left: none;
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .editor-page[data-mobile-panel="params"] .scene-params-panel,
+  .editor-page[data-mobile-panel="docs"] .scene-docs-panel {
+    display: flex;
+    width: 100% !important;
+    height: min(42dvh, 380px) !important;
+    max-height: none;
+    border-left: none;
+    border-top: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+
+  .editor-page[data-mobile-panel="docs"] .api-ref-panel {
+    height: 100%;
+  }
+
+  .chat-embedded {
+    padding: 8px;
+  }
+
+  .chat-input-bar textarea,
+  .chat-input-bar button,
+  .bom-item-qty-input,
+  .editor-bom-panel button,
+  .editor-bom-panel input,
+  .scene-params-panel button,
+  .scene-params-panel input {
+    min-height: 44px;
   }
 
   .editor-header {
-    flex-wrap: wrap;
-    gap: 4px;
-    padding: 6px 10px;
+    flex-wrap: nowrap;
+    gap: 6px;
+    padding: 6px 8px;
+    min-height: 56px;
+    overflow: visible;
   }
 
   .editor-header-desc {
     display: none;
   }
 
+  .editor-header-name-wrapper {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .editor-header-name {
+    max-width: none;
+    padding: 8px 6px;
+    font-size: 14px;
+  }
+
+  .save-status-pill {
+    min-width: 44px;
+    min-height: 44px;
+    justify-content: center;
+    padding: 8px !important;
+  }
+
+  .save-status-label {
+    display: none;
+  }
+
   .editor-header-actions {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 4px;
-    width: 100%;
+    width: auto;
+    flex-shrink: 0;
     justify-content: flex-end;
+  }
+
+  .editor-action-secondary,
+  .editor-action-divider,
+  .editor-header-divider {
+    display: none !important;
+  }
+
+  .editor-mobile-actions {
+    display: block;
+  }
+
+  .editor-header-actions > .btn,
+  .editor-mobile-actions-btn {
+    min-width: 44px;
+    min-height: 44px;
+    padding: 8px !important;
+  }
+
+  .editor-mobile-actions-menu {
+    width: min(220px, calc(100vw - 24px));
   }
 
   .project-card-grid {
@@ -3253,6 +3487,20 @@ select:focus {
     border-left: none !important;
     border-top: 1px solid var(--border);
     max-height: 50vh;
+  }
+}
+
+@media (pointer: coarse) {
+  .btn,
+  .viewport-toolbar-btn,
+  .mobile-editor-tab,
+  .category-chip {
+    min-height: 44px;
+  }
+
+  .editor-header-actions > .btn,
+  .editor-mobile-actions-btn {
+    min-width: 44px;
   }
 }
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { ToastProvider } from "@/components/ToastProvider";
 import { LocaleProvider } from "@/components/LocaleProvider";
@@ -51,6 +51,12 @@ export const metadata: Metadata = {
     description:
       "3D-mallinna talosi, suunnittele remontti ja saa materiaalihinnat reaaliajassa.",
   },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
 };
 
 const jsonLd = {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "@/components/LocaleProvider";
 import SceneEditor from "@/components/SceneEditor";
 import BomPanel from "@/components/BomPanel";
 import ChatPanel from "@/components/ChatPanel";
+import MobileEditorTabs from "@/components/MobileEditorTabs";
 import SceneParamsPanel from "@/components/SceneParamsPanel";
 import SceneApiReference from "@/components/SceneApiReference";
 import { parseSceneParams, applyParamToScript } from "@/lib/scene-interpreter";
@@ -26,6 +27,7 @@ import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { useAnalytics, useEditorSession } from "@/hooks/useAnalytics";
 import { useDraftRecovery } from "@/hooks/useDraftRecovery";
 import { useAutoSave } from "@/hooks/useAutoSave";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import type { SaveableFields } from "@/hooks/useAutoSave";
 import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
 import SaveStatusIndicator from "@/components/SaveStatusIndicator";
@@ -100,6 +102,24 @@ scene.add(wall4, { material: "lumber", color: [0.85, 0.75, 0.55] });
 `;
 
 const HISTORY_LIMIT = 50;
+const MOBILE_EDITOR_QUERY = "(max-width: 768px)";
+
+type MobileEditorPanel = "viewport" | "chat" | "bom" | "code" | "params" | "docs";
+
+function getBomWidthBounds(): { min: number; max: number } {
+  if (typeof window === "undefined") return { min: 260, max: 600 };
+  const isTabletOrNarrow = window.innerWidth <= 1024;
+  const min = isTabletOrNarrow ? 220 : 260;
+  const max = isTabletOrNarrow
+    ? Math.max(min, Math.min(430, Math.floor(window.innerWidth * 0.42)))
+    : 600;
+  return { min, max };
+}
+
+function clampBomWidth(width: number): number {
+  const { min, max } = getBomWidthBounds();
+  return Math.max(min, Math.min(max, width));
+}
 
 export default function ProjectPage() {
   const params = useParams();
@@ -110,6 +130,7 @@ export default function ProjectPage() {
   const { toggle: toggleTheme, resolved: resolvedTheme } = useTheme();
   const { track } = useAnalytics();
   const { markCodeEditor, markChat } = useEditorSession();
+  const isMobileEditor = useMediaQuery(MOBILE_EDITOR_QUERY);
 
   const [project, setProject] = useState<Project | null>(null);
   const [materials, setMaterials] = useState<Material[]>([]);
@@ -132,6 +153,8 @@ export default function ProjectPage() {
   const [showParams, setShowParams] = useState(true);
   const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [showHeaderMenu, setShowHeaderMenu] = useState(false);
+  const [activeMobilePanel, setActiveMobilePanel] = useState<MobileEditorPanel>("viewport");
   const [exportingFormat, setExportingFormat] = useState<"pdf" | "csv" | "json" | "ara" | "ifc" | null>(null);
   const [showShareDialog, setShowShareDialog] = useState(false);
   const [showAraChecklist, setShowAraChecklist] = useState(false);
@@ -143,7 +166,7 @@ export default function ProjectPage() {
   const [bomWidth, setBomWidth] = useState(() => {
     if (typeof window !== "undefined") {
       const saved = localStorage.getItem("helscoop_bom_width");
-      if (saved) return Math.max(260, Math.min(600, parseInt(saved, 10)));
+      if (saved) return clampBomWidth(parseInt(saved, 10));
     }
     return 340;
   });
@@ -377,6 +400,23 @@ export default function ProjectPage() {
     };
   }, [showExportMenu]);
 
+  useEffect(() => {
+    if (!showHeaderMenu) return;
+    const close = (e: MouseEvent) => {
+      if ((e.target as HTMLElement).closest("[data-editor-mobile-actions]")) return;
+      setShowHeaderMenu(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setShowHeaderMenu(false);
+    };
+    document.addEventListener("click", close);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("click", close);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [showHeaderMenu]);
+
   const startResize = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     resizingRef.current = true;
@@ -384,7 +424,7 @@ export default function ProjectPage() {
     const startWidth = bomWidth;
     const onMove = (ev: MouseEvent) => {
       const delta = startX - ev.clientX;
-      const next = Math.max(260, Math.min(600, startWidth + delta));
+      const next = clampBomWidth(startWidth + delta);
       setBomWidth(next);
     };
     const onUp = () => {
@@ -413,7 +453,7 @@ export default function ProjectPage() {
     const onMove = (ev: TouchEvent) => {
       if (ev.touches.length !== 1) return;
       const delta = startX - ev.touches[0].clientX;
-      const next = Math.max(260, Math.min(600, startWidth + delta));
+      const next = clampBomWidth(startWidth + delta);
       setBomWidth(next);
     };
     const onEnd = () => {
@@ -483,13 +523,81 @@ export default function ProjectPage() {
     [pushHistory, markChat]
   );
 
+  const handleMobilePanelChange = useCallback(
+    (panel: MobileEditorPanel) => {
+      setActiveMobilePanel(panel);
+      if (panel === "chat") markChat();
+      if (panel === "bom") setShowBom(true);
+      if (panel === "code") {
+        if (!showCode) markCodeEditor();
+        setShowCode(true);
+      }
+      if (panel === "params") setShowParams(true);
+      if (panel === "docs") setShowDocs(true);
+    },
+    [markChat, markCodeEditor, showCode]
+  );
+
+  const toggleCodePanel = useCallback(() => {
+    if (!showCode) markCodeEditor();
+    setShowCode((visible) => {
+      const next = !visible;
+      if (isMobileEditor) setActiveMobilePanel(next ? "code" : "viewport");
+      return next;
+    });
+  }, [isMobileEditor, markCodeEditor, showCode]);
+
+  const toggleDocsPanel = useCallback(() => {
+    setShowDocs((visible) => {
+      const next = !visible;
+      if (isMobileEditor) setActiveMobilePanel(next ? "docs" : "viewport");
+      return next;
+    });
+  }, [isMobileEditor]);
+
+  const toggleParamsPanel = useCallback(() => {
+    setShowParams((visible) => {
+      const next = !visible;
+      if (isMobileEditor) setActiveMobilePanel(next ? "params" : "viewport");
+      return next;
+    });
+  }, [isMobileEditor]);
+
+  const duplicateProject = useCallback(async () => {
+    setShowHeaderMenu(false);
+    setDuplicating(true);
+    try {
+      const dup = await api.duplicateProject(projectId);
+      toast(t('toast.projectDuplicated'), "success");
+      router.push(`/project/${dup.id}`);
+    } catch (err) {
+      toast(err instanceof Error ? err.message : t('toast.duplicateFailed'), "error");
+    } finally {
+      setDuplicating(false);
+    }
+  }, [projectId, router, t, toast]);
+
+  useEffect(() => {
+    if (!isMobileEditor) {
+      setBomWidth((width) => clampBomWidth(width));
+      return;
+    }
+    if ((activeMobilePanel === "code" && !showCode) ||
+      (activeMobilePanel === "params" && !showParams) ||
+      (activeMobilePanel === "docs" && !showDocs)) {
+      setActiveMobilePanel("viewport");
+    }
+  }, [activeMobilePanel, isMobileEditor, showCode, showDocs, showParams]);
+
   /* ── Keyboard shortcuts ──────────────────────────────────────── */
   const closeAllPanels = useCallback(() => {
     setShowCode(false);
     setShowShortcutsHelp(false);
     setShowExportMenu(false);
+    setShowHeaderMenu(false);
     setShowDocs(false);
-  }, []);
+    if (isMobileEditor) setActiveMobilePanel("viewport");
+  }, [isMobileEditor]);
 
   const shortcuts = useMemo<KeyboardShortcut[]>(() => [
     {
@@ -660,7 +768,7 @@ export default function ProjectPage() {
             <polyline points="8 6 2 12 8 18" />
           </svg>
         ),
-        action: () => { if (!showCode) markCodeEditor(); setShowCode((v) => !v); },
+        action: toggleCodePanel,
         isActive: showCode,
       },
       {
@@ -868,7 +976,7 @@ export default function ProjectPage() {
         isActive: showDocs,
       },
     ];
-  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, markCodeEditor, wireframe, showBom, showDocs, resolvedTheme, exportIfcPermitModel]);
+  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, toggleCodePanel, wireframe, showBom, showDocs, resolvedTheme, exportIfcPermitModel]);
 
   const handleViewportReset = useCallback(() => {
     setSceneJs(DEFAULT_SCENE);
@@ -977,7 +1085,7 @@ export default function ProjectPage() {
   }
 
   return (
-    <div className="editor-page">
+    <div className="editor-page" data-mobile-panel={isMobileEditor ? activeMobilePanel : undefined}>
 
       {/* Header */}
       <div className="editor-header">
@@ -986,7 +1094,7 @@ export default function ProjectPage() {
             <polyline points="15 18 9 12 15 6" />
           </svg>
         </button>
-        <div style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
+        <div className="editor-header-divider" style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
         <div className="editor-header-name-wrapper">
           <input
             className="editor-header-name"
@@ -1015,7 +1123,7 @@ export default function ProjectPage() {
         <SaveStatusIndicator status={saveStatus} lastSaved={lastSaved} />
         <div className="editor-header-actions">
           <button
-            className="btn btn-ghost"
+            className="btn btn-ghost editor-action-secondary"
             onClick={undo}
             disabled={!canUndo}
             data-tooltip={`${t('editor.undo')} (${shortcutLabel('Cmd+Z')})`}
@@ -1028,7 +1136,7 @@ export default function ProjectPage() {
             </svg>
           </button>
           <button
-            className="btn btn-ghost"
+            className="btn btn-ghost editor-action-secondary"
             onClick={redo}
             disabled={!canRedo}
             data-tooltip={`${t('editor.redo')} (${shortcutLabel('Cmd+Shift+Z')})`}
@@ -1041,22 +1149,11 @@ export default function ProjectPage() {
             </svg>
           </button>
           <button
-            className="btn btn-ghost"
+            className="btn btn-ghost editor-action-secondary"
             data-tooltip={t('project.copy')}
             aria-label={t('editor.duplicateProject')}
             disabled={duplicating}
-            onClick={async () => {
-              setDuplicating(true);
-              try {
-                const dup = await api.duplicateProject(projectId);
-                toast(t('toast.projectDuplicated'), "success");
-                router.push(`/project/${dup.id}`);
-              } catch (err) {
-                toast(err instanceof Error ? err.message : t('toast.duplicateFailed'), "error");
-              } finally {
-                setDuplicating(false);
-              }
-            }}
+            onClick={duplicateProject}
             style={{ padding: "5px 7px" }}
           >
             {duplicating ? (
@@ -1070,7 +1167,57 @@ export default function ProjectPage() {
               </svg>
             )}
           </button>
-          <div style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
+          <div className="editor-action-divider" style={{ width: 1, height: 18, background: "var(--border)", flexShrink: 0 }} />
+          <div className="editor-mobile-actions" data-editor-mobile-actions>
+            <button
+              className="btn btn-ghost editor-mobile-actions-btn"
+              type="button"
+              aria-label={t("toast.overflowMore", { count: 3 })}
+              aria-haspopup="menu"
+              aria-expanded={showHeaderMenu}
+              onClick={() => setShowHeaderMenu((v) => !v)}
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="1" />
+                <circle cx="19" cy="12" r="1" />
+                <circle cx="5" cy="12" r="1" />
+              </svg>
+            </button>
+            {showHeaderMenu && (
+              <div className="editor-mobile-actions-menu dropdown-menu" role="menu">
+                <button
+                  role="menuitem"
+                  className="btn btn-ghost"
+                  disabled={!canUndo}
+                  onClick={() => {
+                    setShowHeaderMenu(false);
+                    undo();
+                  }}
+                >
+                  {t("editor.undo")}
+                </button>
+                <button
+                  role="menuitem"
+                  className="btn btn-ghost"
+                  disabled={!canRedo}
+                  onClick={() => {
+                    setShowHeaderMenu(false);
+                    redo();
+                  }}
+                >
+                  {t("editor.redo")}
+                </button>
+                <button
+                  role="menuitem"
+                  className="btn btn-ghost"
+                  disabled={duplicating}
+                  onClick={duplicateProject}
+                >
+                  {t("editor.duplicateProject")}
+                </button>
+              </div>
+            )}
+          </div>
           <button
             className="btn btn-ghost"
             data-tooltip={t('editor.share')}
@@ -1491,7 +1638,7 @@ export default function ProjectPage() {
             <button
               className="viewport-toolbar-btn"
               data-active={showCode}
-              onClick={() => { if (!showCode) markCodeEditor(); setShowCode(!showCode); }}
+              onClick={toggleCodePanel}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="16 18 22 12 16 6" />
@@ -1530,7 +1677,7 @@ export default function ProjectPage() {
             <button
               className="viewport-toolbar-btn"
               data-active={showDocs}
-              onClick={() => setShowDocs(!showDocs)}
+              onClick={toggleDocsPanel}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="10" />
@@ -1543,7 +1690,7 @@ export default function ProjectPage() {
               <button
                 className="viewport-toolbar-btn"
                 data-active={showParams}
-                onClick={() => setShowParams(!showParams)}
+                onClick={toggleParamsPanel}
               >
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <line x1="4" y1="21" x2="4" y2="14" />
@@ -1576,6 +1723,7 @@ export default function ProjectPage() {
           {/* 3D Viewport */}
           <div
             ref={viewportRef}
+            className="editor-viewport-shell"
             data-tour="viewport"
             style={{
               flex: 1,
@@ -1734,9 +1882,38 @@ export default function ProjectPage() {
             </div>
           )}
 
+          {isMobileEditor && (
+            <MobileEditorTabs<MobileEditorPanel>
+              active={activeMobilePanel}
+              onChange={handleMobilePanelChange}
+              ariaLabel={locale === "fi" ? "Editorin mobiilipaneelit" : "Editor mobile panels"}
+              tabs={[
+                { id: "viewport", label: t("editor.scene") },
+                {
+                  id: "chat",
+                  label: t("editor.assistant"),
+                  badge: chatMessageCount || undefined,
+                },
+                {
+                  id: "bom",
+                  label: t("editor.materialList"),
+                  badge: bom.length || undefined,
+                },
+                { id: "code", label: locale === "fi" ? "Koodi" : "Code" },
+                ...(sceneParams.length > 0
+                  ? [{ id: "params" as const, label: t("editor.params"), badge: sceneParams.length }]
+                  : []),
+                ...(showDocs
+                  ? [{ id: "docs" as const, label: t("editor.docs") || "Docs" }]
+                  : []),
+              ]}
+            />
+          )}
+
           {/* Collapsible Code Editor */}
           {showCode && (
             <div
+              className="editor-code-panel"
               style={{
                 height: 260,
                 flexShrink: 0,
@@ -1777,14 +1954,16 @@ export default function ProjectPage() {
         {/* Resize handle + BOM panel */}
         {showBom && (
           <>
-            <div
-              className="resize-handle-v"
-              role="separator"
-              aria-label="Resize BOM panel"
-              aria-orientation="vertical"
-              onMouseDown={startResize}
-              onTouchStart={startTouchResize}
-            />
+            {!isMobileEditor && (
+              <div
+                className="resize-handle-v"
+                role="separator"
+                aria-label="Resize BOM panel"
+                aria-orientation="vertical"
+                onMouseDown={startResize}
+                onTouchStart={startTouchResize}
+              />
+            )}
             <BomPanel
               bom={bom}
               materials={materials}
@@ -1792,7 +1971,7 @@ export default function ProjectPage() {
               onAddImported={addImportedBomItem}
               onRemove={removeBomItem}
               onUpdateQty={updateBomQty}
-              style={{ width: bomWidth }}
+              style={isMobileEditor ? undefined : { width: bomWidth }}
               sceneJs={sceneJs}
               projectName={projectName}
               buildingInfo={project?.building_info ?? null}
@@ -1803,12 +1982,13 @@ export default function ProjectPage() {
 
         {/* Scene API Reference panel */}
         {showDocs && (
-          <div style={{ width: 320, flexShrink: 0, height: "100%", overflow: "hidden" }}>
+          <div className="scene-docs-panel" style={{ width: 320, flexShrink: 0, height: "100%", overflow: "hidden" }}>
             <SceneApiReference
               onInsertCode={(code) => {
                 setSceneJs((prev) => prev + "\n" + code);
                 pushHistory(sceneJs + "\n" + code);
                 setShowCode(true);
+                if (isMobileEditor) setActiveMobilePanel("code");
               }}
             />
           </div>

--- a/web/src/components/MobileEditorTabs.tsx
+++ b/web/src/components/MobileEditorTabs.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+export interface MobileEditorTab<T extends string> {
+  id: T;
+  label: string;
+  badge?: string | number;
+}
+
+interface MobileEditorTabsProps<T extends string> {
+  active: T;
+  tabs: MobileEditorTab<T>[];
+  onChange: (tab: T) => void;
+  ariaLabel: string;
+}
+
+export default function MobileEditorTabs<T extends string>({
+  active,
+  tabs,
+  onChange,
+  ariaLabel,
+}: MobileEditorTabsProps<T>) {
+  return (
+    <div className="mobile-editor-tabs" role="tablist" aria-label={ariaLabel}>
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          type="button"
+          role="tab"
+          aria-selected={active === tab.id}
+          className="mobile-editor-tab"
+          data-active={active === tab.id}
+          onClick={() => onChange(tab.id)}
+        >
+          <span>{tab.label}</span>
+          {tab.badge !== undefined && tab.badge !== 0 && (
+            <span className="mobile-editor-tab-badge">{tab.badge}</span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/OnboardingTour.tsx
+++ b/web/src/components/OnboardingTour.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import { getToken } from "@/lib/api";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 const STORAGE_KEY = "helscoop_onboarding_completed";
 
@@ -270,6 +271,7 @@ export function WelcomeModal({
 /** Step-by-step tooltip tour overlay */
 export function TourOverlay({ onComplete }: { onComplete: () => void }) {
   const { t } = useTranslation();
+  const isMobileTour = useMediaQuery("(max-width: 768px)");
   const [currentStep, setCurrentStep] = useState(0);
   const [displayStep, setDisplayStep] = useState(0);
   const [contentFade, setContentFade] = useState(true);
@@ -290,7 +292,9 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
 
   // Find visible steps (elements that exist in the DOM)
   const visibleSteps = TOUR_STEPS.filter(
-    (step) => document.querySelector(step.target) !== null
+    (step) =>
+      !(isMobileTour && step.target === "[data-tour='viewport']") &&
+      document.querySelector(step.target) !== null
   );
 
   const step = visibleSteps[currentStep];
@@ -300,6 +304,15 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
     const rect = getElementRect(step.target);
     setTargetRect(rect);
   }, [step]);
+
+  useEffect(() => {
+    if (visibleSteps.length > 0 && currentStep >= visibleSteps.length) {
+      setCurrentStep(visibleSteps.length - 1);
+    }
+    if (visibleSteps.length > 0 && displayStep >= visibleSteps.length) {
+      setDisplayStep(visibleSteps.length - 1);
+    }
+  }, [currentStep, displayStep, visibleSteps.length]);
 
   useEffect(() => {
     updateRect();
@@ -342,14 +355,19 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
       }
     : {};
 
+  const tooltipWidth =
+    typeof window === "undefined"
+      ? 320
+      : Math.min(320, Math.max(240, window.innerWidth - 24));
+
   const tooltipPos = targetRect
     ? computeTooltipPosition(
         targetRect,
         step.placement,
-        tooltipSize.width,
+        Math.min(tooltipSize.width, tooltipWidth),
         tooltipSize.height
       )
-    : { top: window.innerHeight / 2 - 75, left: window.innerWidth / 2 - 160 };
+    : { top: window.innerHeight / 2 - 75, left: window.innerWidth / 2 - tooltipWidth / 2 };
 
   const handlePrev = useCallback(() => {
     if (currentStep > 0) {
@@ -397,7 +415,6 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
   }, [currentStep]);
 
   const isLast = currentStep === visibleSteps.length - 1;
-
   return (
     <>
       {/* Backdrop overlay for click-blocking */}
@@ -423,7 +440,7 @@ export function TourOverlay({ onComplete }: { onComplete: () => void }) {
           zIndex: 1202,
           top: tooltipPos.top,
           left: tooltipPos.left,
-          width: 320,
+          width: tooltipWidth,
           background: "var(--surface-float)",
           border: "1px solid var(--surface-border-float)",
           borderRadius: "var(--radius-md)",

--- a/web/src/hooks/useMediaQuery.ts
+++ b/web/src/hooks/useMediaQuery.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+
+    const media = window.matchMedia(query);
+    const update = () => setMatches(media.matches);
+
+    update();
+    if (media.addEventListener) {
+      media.addEventListener("change", update);
+      return () => media.removeEventListener("change", update);
+    }
+
+    media.addListener(update);
+    return () => media.removeListener(update);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- Add mobile editor panel tabs for viewport, chat, materials, code, params, and docs.
- Convert the mobile editor from the desktop side-by-side layout into bounded stacked panels with 44px touch targets.
- Clamp persisted BOM widths for tablet/narrow layouts and hide the desktop resize handle on mobile.
- Add viewport metadata and make onboarding tooltips mobile-safe.

Closes #644.
Relates #416.

## Verification
- npm test -- src/lib/__tests__/i18n.test.ts
- npm test -- src/__tests__/OnboardingTour.test.tsx
- npm test
- npm run build
- git diff --check