### PR TITLE
style: button depth feedback, card focus states, login gradient

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1290,7 +1290,7 @@ body::before {
   user-select: none;
 }
 
-.btn:active { transform: scale(0.97); }
+.btn:active { transform: scale(0.97) translateY(0.5px); box-shadow: inset 0 1px 3px rgba(0,0,0,0.25); }
 
 .btn:disabled {
   opacity: 0.4;
@@ -1329,8 +1329,8 @@ body::before {
 }
 
 .btn-primary:active:not(:disabled) {
-  transform: translateY(0) scale(0.98);
-  box-shadow: 0 0 8px rgba(229, 160, 75, 0.1);
+  transform: translateY(0.5px) scale(0.98);
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.3), 0 0 6px rgba(229, 160, 75, 0.08);
 }
 
 .btn-ghost {
@@ -1453,6 +1453,13 @@ select:focus {
 .card:hover {
   border-color: rgba(229, 160, 75, 0.3);
   box-shadow: 0 0 20px rgba(229, 160, 75, 0.08), 0 4px 12px rgba(0, 0, 0, 0.3);
+  transform: translateY(-1px);
+}
+
+.card:focus-visible {
+  outline: none;
+  border-color: var(--amber);
+  box-shadow: 0 0 0 2px rgba(229, 160, 75, 0.25);
 }
 
 .badge {
@@ -1559,8 +1566,10 @@ select:focus {
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(ellipse 80% 60% at 20% 80%, rgba(229,160,75,0.06), transparent),
-    radial-gradient(ellipse 60% 40% at 80% 20%, rgba(229,160,75,0.03), transparent);
+    radial-gradient(ellipse 90% 70% at 15% 85%, rgba(229,160,75,0.14), transparent 70%),
+    radial-gradient(ellipse 70% 50% at 80% 15%, rgba(229,160,75,0.08), transparent 65%),
+    radial-gradient(ellipse 50% 40% at 50% 50%, rgba(229,160,75,0.05), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(180,130,60,0.06), transparent 50%);
   pointer-events: none;
 }
 
@@ -2890,8 +2899,20 @@ select:focus {
 }
 
 .card-interactive:active {
-  transform: translateY(0);
+  transform: translateY(0) scale(0.99);
+  box-shadow: inset 0 1px 3px rgba(0,0,0,0.15), 0 0 8px rgba(229, 160, 75, 0.06);
   transition-duration: 0.06s;
+}
+
+.card-interactive:focus-visible {
+  outline: none;
+  border-color: var(--amber);
+  box-shadow: 0 0 0 2px rgba(229, 160, 75, 0.25);
+}
+
+.card-interactive:focus-visible::before {
+  opacity: 1;
+  transform: scaleY(1);
 }
 
 /* Template cards grid */
@@ -3469,13 +3490,16 @@ select:focus {
 /* === Ghost/Danger active states === */
 .btn-ghost:active:not(:disabled) {
   background: var(--bg-tertiary);
-  transform: scale(0.97);
+  border-color: var(--text-muted);
+  transform: scale(0.97) translateY(0.5px);
+  box-shadow: inset 0 1px 3px rgba(0,0,0,0.2);
   transition-duration: 0.06s;
 }
 
 .btn-danger:active:not(:disabled) {
   background: rgba(239, 68, 68, 0.2);
-  transform: scale(0.97);
+  transform: scale(0.97) translateY(0.5px);
+  box-shadow: inset 0 1px 3px rgba(0,0,0,0.2);
   transition-duration: 0.06s;
 }
 


### PR DESCRIPTION
## Summary
- **Button press depth** (#576): Add inset shadow + translateY on active for tactile "pressed into surface" feel across `.btn`, `.btn-primary`, `.btn-ghost`, `.btn-danger`
- **Card focus-visible** (#100): Add amber focus ring and active press scale to `.card` and `.card-interactive` for keyboard navigation
- **Login gradient mesh** (#297): Enrich login brand panel `::before` with 4-point radial gradient mesh for warm depth

## Test plan
- [ ] Click/hold any button — verify press-down visual feedback with inset shadow
- [ ] Tab through project cards — verify amber focus ring appears
- [ ] Click a card — verify subtle scale-down on press
- [ ] Visit login page — verify richer amber gradient glow behind brand panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)