### PR TITLE
feat: landing page scroll progress bar

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4672,6 +4672,35 @@ select:focus {
   opacity: 1;
 }
 
+/* === Scroll progress bar (landing page) === */
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  z-index: 9999;
+  background: transparent;
+  pointer-events: none;
+}
+
+@supports (animation-timeline: scroll()) {
+  .scroll-progress::after {
+    content: '';
+    display: block;
+    height: 100%;
+    background: linear-gradient(90deg, var(--amber-dim), var(--amber), var(--amber-light));
+    transform-origin: left;
+    transform: scaleX(0);
+    animation: scrollFill linear both;
+    animation-timeline: scroll(root);
+  }
+}
+
+@keyframes scrollFill {
+  to { transform: scaleX(1); }
+}
+
 /* === ConnectionBanner === */
 .connection-banner {
   position: fixed;

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -68,6 +68,7 @@ export default function Home() {
   if (!loggedIn) {
     return (
       <>
+        <div className="scroll-progress" aria-hidden="true" />
         <LoginForm
           onLogin={handleLogin}
           pendingBuilding={pendingBuilding}


### PR DESCRIPTION
## Summary
- Add amber gradient scroll progress indicator at top of landing page — Fixes #368
- Uses native CSS `animation-timeline: scroll()` for zero-JS, GPU-composited performance
- Wrapped in `@supports` for graceful degradation in unsupported browsers
- `aria-hidden="true"` for screen reader accessibility

## Test plan
- [ ] Scroll landing page — amber line fills from left to right at top of viewport
- [ ] Verify no JS required (pure CSS animation)
- [ ] Test in Safari (unsupported) — bar should be invisible, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)