### PR TITLE
feat(design): typography optical sizing + Finnish design language

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
   /* ── Tonal elevation scale (~4% luminance per step) ─────────────── */
@@ -77,6 +77,17 @@
   --font-display: 'Inter', -apple-system, system-ui, sans-serif;
   --font-sans: 'Inter', -apple-system, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  /* ── Modular type scale (minor third 1.2) ─────────────────────── */
+  --text-xs: 10px;
+  --text-sm: 11px;
+  --text-base: 13px;
+  --text-md: 15px;
+  --text-lg: 18px;
+  --text-xl: 22px;
+  --text-2xl: 26px;
+  --text-3xl: 32px;
+  --text-display: 44px;
 
   --accent: var(--amber);
   --success: var(--forest);
@@ -446,8 +457,9 @@ body {
   background: var(--bg-primary);
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 13px;
+  font-size: var(--text-base);
   line-height: 1.5;
+  font-optical-sizing: auto;
 }
 
 /* Subtle noise texture overlay for dark backgrounds — adds depth */
@@ -519,7 +531,7 @@ body::before {
   backdrop-filter: var(--glass-ground-blur);
   -webkit-backdrop-filter: var(--glass-ground-blur);
   border-left: 1px solid var(--glass-ground-border);
-  box-shadow: var(--shadow-depth-1);
+  box-shadow: var(--shadow-depth-1), inset 0 1px 2px rgba(255,255,255,0.02);
   overflow: hidden;
   transition: background var(--transition-normal);
 }
@@ -2129,10 +2141,11 @@ select:focus {
 
 /* Heading — clean sans-serif, tight tracking */
 .heading-display {
-  font-family: var(--font-body);
-  font-weight: 600;
+  font-family: var(--font-display);
+  font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.15;
+  font-optical-sizing: auto;
 }
 
 /* Mono label */
@@ -2158,7 +2171,8 @@ select:focus {
 }
 
 .brand-title {
-  font-size: 48px;
+  font-size: var(--text-display);
+  font-weight: 700;
   line-height: 1.05;
   margin-bottom: 16px;
   color: var(--text-primary);
@@ -2638,7 +2652,7 @@ select:focus {
   background: var(--glass-mid);
   backdrop-filter: var(--glass-mid-blur);
   -webkit-backdrop-filter: var(--glass-mid-blur);
-  box-shadow: var(--shadow-depth-2);
+  box-shadow: var(--shadow-depth-2), inset 0 1px 2px rgba(255,255,255,0.02);
   flex-shrink: 0;
   transition: background var(--transition-normal);
 }
@@ -2661,9 +2675,10 @@ select:focus {
   background: var(--glass-float);
   backdrop-filter: var(--glass-float-blur);
   -webkit-backdrop-filter: var(--glass-float-blur);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-float-border);
   border-radius: var(--radius-md) var(--radius-md) 0 0;
   border-bottom: none;
+  box-shadow: inset 0 1px 2px rgba(255,255,255,0.03);
   animation: chatMsgIn var(--transition-normal)-out both;
 }
 


### PR DESCRIPTION
## Summary
- **Typography upgrade** (#239): Updated Inter font import to use optical sizing axis (`opsz 14..32`) for sharper rendering at display sizes. Added modular type scale tokens (`--text-xs` through `--text-display`). Bumped heading weight to 700 with `font-optical-sizing: auto`.
- **Finnish design language** (#578): Added Iittala-inspired inner-shadow accents (`inset 0 1px 2px rgba(255,255,255,0.02-0.03)`) to glassmorphism panels for layered transparency depth. Used `--glass-float-border` token on chat area for consistent elevation hierarchy.

## Test plan
- [ ] Verify headings render with slightly sharper/crisper typography at large sizes
- [ ] Check panel surfaces show subtle inner highlight (most visible on chat panel)
- [ ] Ensure light theme overrides still work correctly
- [ ] No layout shifts from font weight change (700 vs 600)

Fixes #239, #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)