### PR TITLE
feat(validation): scene validation warnings for geometry and materials

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -68,6 +68,9 @@ function formatWarning(raw: string, t: (key: string, params?: Record<string, str
   if (key === "validation.invalidDimension") {
     return t(key, { geometry: rest });
   }
+  if (key === "validation.highTriCount" || key === "validation.unmaterialized" || key === "validation.highObjectCount") {
+    return t(key, { count: rest });
+  }
   return t(key);
 }
 

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -632,6 +632,9 @@ const translations = {
       tooManyObjects: 'Kohtauksessa on {{count}} objektia — yli 200 voi hidastaa suorituskykyä',
       farFromOrigin: 'Objekti on {{distance}} yksikön päässä origosta — tarkista sijainti',
       invalidDimension: '{{geometry}}-objektilla on nolla- tai negatiivinen mitta',
+      highTriCount: 'Kohtauksessa on {{count}} kolmiota — voi hidastaa renderöintiä',
+      unmaterialized: '{{count}} objektilla ei ole materiaalia',
+      highObjectCount: 'Kohtauksessa on {{count}} objektia — harkitse yksinkertaistamista',
       warningsTitle: 'Varoitukset',
     },
     saveStatus: {
@@ -1735,6 +1738,9 @@ const translations = {
       tooManyObjects: 'Scene has {{count}} objects — more than 200 may cause performance issues',
       farFromOrigin: 'Object is {{distance}} units from origin — check position',
       invalidDimension: '{{geometry}} has zero or negative dimensions',
+      highTriCount: 'Scene has {{count}} triangles — may slow rendering',
+      unmaterialized: '{{count}} objects have no material assigned',
+      highObjectCount: 'Scene has {{count}} objects — consider simplifying',
       warningsTitle: 'Warnings',
     },
     saveStatus: {

--- a/web/src/lib/manifold-engine.ts
+++ b/web/src/lib/manifold-engine.ts
@@ -596,6 +596,25 @@ if (typeof displayScale !== "undefined") { __result__.displayScale = displayScal
       warnings.push("validation.emptyScene");
     }
 
+    // Scene validation warnings
+    let totalTris = 0;
+    let unmaterializedCount = 0;
+    for (const s of sorted) {
+      totalTris += s.tris;
+      if (!s.cm.material) {
+        unmaterializedCount++;
+      }
+    }
+    if (totalTris > 500000) {
+      warnings.push(`validation.highTriCount:${totalTris}`);
+    }
+    if (unmaterializedCount > 0) {
+      warnings.push(`validation.unmaterialized:${unmaterializedCount}`);
+    }
+    if (coloredManifolds.length > 100) {
+      warnings.push(`validation.highObjectCount:${coloredManifolds.length}`);
+    }
+
     const result: ManifoldSceneResult = {
       meshes,
       error: null,


### PR DESCRIPTION
## Summary
- Populate the existing empty `warnings[]` array in `manifold-engine.ts` with 3 validation checks:
  - **High triangle count** (>500K): warns about potential rendering slowdown
  - **Unmaterialized objects**: objects without `withMaterial()` get flagged
  - **High object count** (>100): suggests simplifying the scene
- Added Finnish and English i18n keys for all new warnings
- Wired `formatWarning()` in editor page to handle the new warning key formats

## Test plan
- [ ] Create a scene with >100 objects — should show high object count warning
- [ ] Create objects without `withMaterial()` — should show unmaterialized warning
- [ ] Verify warnings render in amber pills below viewport toolbar
- [ ] Test both Finnish and English warning text
- [ ] Existing warnings (typo detection, bracket matching) still work

Fixes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)