### PR TITLE
Improve mobile editor panel gestures

### DIFF
--- a/web/src/__tests__/MobileEditorTabs.test.tsx
+++ b/web/src/__tests__/MobileEditorTabs.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import MobileEditorTabs from "@/components/MobileEditorTabs";
+
+function renderTabs(onSwipe = vi.fn()) {
+  render(
+    <MobileEditorTabs
+      active="viewport"
+      ariaLabel="Editor mobile panels"
+      onChange={vi.fn()}
+      onSwipe={onSwipe}
+      tabs={[
+        { id: "viewport", label: "Scene" },
+        { id: "chat", label: "Chat", badge: 2 },
+        { id: "bom", label: "Materials" },
+      ]}
+    />
+  );
+  return screen.getByRole("tablist", { name: "Editor mobile panels" });
+}
+
+describe("MobileEditorTabs swipe gestures", () => {
+  it("reports horizontal swipes", () => {
+    const onSwipe = vi.fn();
+    const tablist = renderTabs(onSwipe);
+
+    fireEvent.touchStart(tablist, { touches: [{ clientX: 180, clientY: 40 }] });
+    fireEvent.touchEnd(tablist, { changedTouches: [{ clientX: 80, clientY: 45 }] });
+
+    expect(onSwipe).toHaveBeenCalledWith("left");
+  });
+
+  it("reports vertical swipes", () => {
+    const onSwipe = vi.fn();
+    const tablist = renderTabs(onSwipe);
+
+    fireEvent.touchStart(tablist, { touches: [{ clientX: 80, clientY: 160 }] });
+    fireEvent.touchEnd(tablist, { changedTouches: [{ clientX: 84, clientY: 80 }] });
+
+    expect(onSwipe).toHaveBeenCalledWith("up");
+  });
+
+  it("ignores small accidental touch movement", () => {
+    const onSwipe = vi.fn();
+    const tablist = renderTabs(onSwipe);
+
+    fireEvent.touchStart(tablist, { touches: [{ clientX: 80, clientY: 80 }] });
+    fireEvent.touchEnd(tablist, { changedTouches: [{ clientX: 95, clientY: 90 }] });
+
+    expect(onSwipe).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4064,6 +4064,8 @@ select:focus {
   }
 
   .editor-page {
+    --mobile-tabs-height: 61px;
+    --mobile-active-panel-height: 0px;
     width: 100vw;
     max-width: 100vw;
     height: 100vh;
@@ -4081,6 +4083,7 @@ select:focus {
   }
 
   .editor-viewport-area {
+    position: relative;
     flex: 1 1 auto;
     min-width: 0;
     min-height: 0;
@@ -4093,9 +4096,20 @@ select:focus {
   }
 
   .viewport-toolbar {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: calc(var(--mobile-tabs-height) + var(--mobile-active-panel-height) + 8px);
+    z-index: 25;
+    max-width: calc(100vw - 16px);
     gap: 6px;
     padding: 6px 8px;
     overflow-x: auto;
+    border-radius: 999px;
+    border: 1px solid var(--border-strong);
+    background: color-mix(in srgb, var(--bg-elevated) 86%, transparent);
+    box-shadow: var(--shadow-md);
+    backdrop-filter: blur(18px) saturate(1.25);
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
   }
@@ -4126,6 +4140,7 @@ select:focus {
     background: color-mix(in srgb, var(--bg-secondary) 82%, transparent);
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
+    touch-action: pan-x pan-y;
   }
 
   .mobile-editor-tabs::-webkit-scrollbar {
@@ -4192,7 +4207,7 @@ select:focus {
   .editor-page[data-mobile-panel="code"] .editor-code-panel {
     display: flex;
     flex-direction: column;
-    height: min(42dvh, 360px) !important;
+    height: var(--mobile-active-panel-height) !important;
     flex-shrink: 0;
     padding: 8px;
     border-top: 1px solid var(--border);
@@ -4213,7 +4228,7 @@ select:focus {
   .editor-page[data-mobile-panel="bom"] .editor-bom-panel {
     display: flex;
     width: 100% !important;
-    height: min(46dvh, 420px);
+    height: var(--mobile-active-panel-height);
     max-height: none;
     min-height: 240px;
     border-left: none;
@@ -4225,7 +4240,7 @@ select:focus {
   .editor-page[data-mobile-panel="docs"] .scene-docs-panel {
     display: flex;
     width: 100% !important;
-    height: min(42dvh, 380px) !important;
+    height: var(--mobile-active-panel-height) !important;
     max-height: none;
     border-left: none;
     border-top: 1px solid var(--border);
@@ -4234,6 +4249,33 @@ select:focus {
 
   .editor-page[data-mobile-panel="docs"] .api-ref-panel {
     height: 100%;
+  }
+
+  .editor-page[data-mobile-panel="chat"],
+  .editor-page[data-mobile-panel="code"],
+  .editor-page[data-mobile-panel="params"],
+  .editor-page[data-mobile-panel="docs"] {
+    --mobile-active-panel-height: min(42dvh, 360px);
+  }
+
+  .editor-page[data-mobile-panel="bom"] {
+    --mobile-active-panel-height: min(46dvh, 420px);
+  }
+
+  .editor-page[data-mobile-panel-size="expanded"] {
+    --mobile-active-panel-height: min(70dvh, calc(100dvh - 150px));
+  }
+
+  .editor-page[data-mobile-panel-size="minimized"] {
+    --mobile-active-panel-height: 0px;
+  }
+
+  .editor-page[data-mobile-panel-size="minimized"] .chat-embedded,
+  .editor-page[data-mobile-panel-size="minimized"] .editor-code-panel,
+  .editor-page[data-mobile-panel-size="minimized"] .editor-bom-panel,
+  .editor-page[data-mobile-panel-size="minimized"] .scene-params-panel,
+  .editor-page[data-mobile-panel-size="minimized"] .scene-docs-panel {
+    display: none !important;
   }
 
   .chat-embedded {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -11,7 +11,7 @@ import SceneEditor from "@/components/SceneEditor";
 import BomPanel from "@/components/BomPanel";
 import type { BomPriceOverride } from "@/components/BomSavingsPanel";
 import ChatPanel from "@/components/ChatPanel";
-import MobileEditorTabs from "@/components/MobileEditorTabs";
+import MobileEditorTabs, { type MobileEditorSwipeDirection } from "@/components/MobileEditorTabs";
 import SceneParamsPanel from "@/components/SceneParamsPanel";
 import SceneApiReference from "@/components/SceneApiReference";
 import SharePresentationPanel from "@/components/SharePresentationPanel";
@@ -113,6 +113,7 @@ const HISTORY_LIMIT = 50;
 const MOBILE_EDITOR_QUERY = "(max-width: 768px)";
 
 type MobileEditorPanel = "viewport" | "chat" | "bom" | "code" | "params" | "docs";
+type MobilePanelSize = "normal" | "expanded" | "minimized";
 
 function getBomWidthBounds(): { min: number; max: number } {
   if (typeof window === "undefined") return { min: 260, max: 600 };
@@ -164,6 +165,7 @@ export default function ProjectPage() {
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showHeaderMenu, setShowHeaderMenu] = useState(false);
   const [activeMobilePanel, setActiveMobilePanel] = useState<MobileEditorPanel>("viewport");
+  const [mobilePanelSize, setMobilePanelSize] = useState<MobilePanelSize>("normal");
   const [exportingFormat, setExportingFormat] = useState<"pdf" | "csv" | "json" | "ara" | "ifc" | null>(null);
   const [showShareDialog, setShowShareDialog] = useState(false);
   const [showAraChecklist, setShowAraChecklist] = useState(false);
@@ -539,6 +541,7 @@ export default function ProjectPage() {
   const handleMobilePanelChange = useCallback(
     (panel: MobileEditorPanel) => {
       setActiveMobilePanel(panel);
+      setMobilePanelSize(panel === "viewport" ? "minimized" : "normal");
       if (panel === "chat") markChat();
       if (panel === "bom") setShowBom(true);
       if (panel === "code") {
@@ -550,6 +553,37 @@ export default function ProjectPage() {
     },
     [markChat, markCodeEditor, showCode]
   );
+
+  const mobilePanelOrder = useMemo<MobileEditorPanel[]>(() => [
+    "viewport",
+    "chat",
+    "bom",
+    "code",
+    ...(sceneParams.length > 0 ? (["params"] as MobileEditorPanel[]) : []),
+    ...(showDocs ? (["docs"] as MobileEditorPanel[]) : []),
+  ], [sceneParams.length, showDocs]);
+
+  const handleMobilePanelSwipe = useCallback((direction: MobileEditorSwipeDirection) => {
+    if (direction === "up") {
+      if (activeMobilePanel === "viewport") handleMobilePanelChange("chat");
+      setMobilePanelSize("expanded");
+      return;
+    }
+
+    if (direction === "down") {
+      setMobilePanelSize((size) => (size === "expanded" ? "normal" : "minimized"));
+      return;
+    }
+
+    const currentIndex = mobilePanelOrder.indexOf(activeMobilePanel);
+    if (currentIndex === -1) return;
+    const delta = direction === "left" ? 1 : -1;
+    const nextIndex = Math.max(0, Math.min(mobilePanelOrder.length - 1, currentIndex + delta));
+    const nextPanel = mobilePanelOrder[nextIndex];
+    if (nextPanel && nextPanel !== activeMobilePanel) {
+      handleMobilePanelChange(nextPanel);
+    }
+  }, [activeMobilePanel, handleMobilePanelChange, mobilePanelOrder]);
 
   const toggleCodePanel = useCallback(() => {
     if (!showCode) markCodeEditor();
@@ -593,6 +627,7 @@ export default function ProjectPage() {
   useEffect(() => {
     if (!isMobileEditor) {
       setBomWidth((width) => clampBomWidth(width));
+      setMobilePanelSize("normal");
       return;
     }
     if ((activeMobilePanel === "code" && !showCode) ||
@@ -1251,7 +1286,11 @@ export default function ProjectPage() {
   }
 
   return (
-    <div className="editor-page" data-mobile-panel={isMobileEditor ? activeMobilePanel : undefined}>
+    <div
+      className="editor-page"
+      data-mobile-panel={isMobileEditor ? activeMobilePanel : undefined}
+      data-mobile-panel-size={isMobileEditor ? mobilePanelSize : undefined}
+    >
 
       {/* Header */}
       <div className="editor-header">
@@ -2053,27 +2092,23 @@ export default function ProjectPage() {
             <MobileEditorTabs<MobileEditorPanel>
               active={activeMobilePanel}
               onChange={handleMobilePanelChange}
+              onSwipe={handleMobilePanelSwipe}
               ariaLabel={locale === "fi" ? "Editorin mobiilipaneelit" : "Editor mobile panels"}
-              tabs={[
-                { id: "viewport", label: t("editor.scene") },
-                {
-                  id: "chat",
-                  label: t("editor.assistant"),
-                  badge: chatMessageCount || undefined,
-                },
-                {
-                  id: "bom",
-                  label: t("editor.materialList"),
-                  badge: bom.length || undefined,
-                },
-                { id: "code", label: locale === "fi" ? "Koodi" : "Code" },
-                ...(sceneParams.length > 0
-                  ? [{ id: "params" as const, label: t("editor.params"), badge: sceneParams.length }]
-                  : []),
-                ...(showDocs
-                  ? [{ id: "docs" as const, label: t("editor.docs") || "Docs" }]
-                  : []),
-              ]}
+              tabs={mobilePanelOrder.map((id) => ({
+                id,
+                label:
+                  id === "viewport" ? t("editor.scene") :
+                  id === "chat" ? t("editor.assistant") :
+                  id === "bom" ? t("editor.materialList") :
+                  id === "code" ? (locale === "fi" ? "Koodi" : "Code") :
+                  id === "params" ? t("editor.params") :
+                  t("editor.docs") || "Docs",
+                badge:
+                  id === "chat" ? chatMessageCount || undefined :
+                  id === "bom" ? bom.length || undefined :
+                  id === "params" ? sceneParams.length :
+                  undefined,
+              }))}
             />
           )}
 

--- a/web/src/components/MobileEditorTabs.tsx
+++ b/web/src/components/MobileEditorTabs.tsx
@@ -1,15 +1,20 @@
 "use client";
 
+import { useRef, type TouchEvent } from "react";
+
 export interface MobileEditorTab<T extends string> {
   id: T;
   label: string;
   badge?: string | number;
 }
 
+export type MobileEditorSwipeDirection = "left" | "right" | "up" | "down";
+
 interface MobileEditorTabsProps<T extends string> {
   active: T;
   tabs: MobileEditorTab<T>[];
   onChange: (tab: T) => void;
+  onSwipe?: (direction: MobileEditorSwipeDirection) => void;
   ariaLabel: string;
 }
 
@@ -17,10 +22,49 @@ export default function MobileEditorTabs<T extends string>({
   active,
   tabs,
   onChange,
+  onSwipe,
   ariaLabel,
 }: MobileEditorTabsProps<T>) {
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    if (event.touches.length !== 1) return;
+    touchStartRef.current = {
+      x: event.touches[0].clientX,
+      y: event.touches[0].clientY,
+    };
+  };
+
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    const start = touchStartRef.current;
+    touchStartRef.current = null;
+    if (!start || !onSwipe) return;
+
+    const touch = event.changedTouches[0];
+    if (!touch) return;
+
+    const dx = touch.clientX - start.x;
+    const dy = touch.clientY - start.y;
+    const absX = Math.abs(dx);
+    const absY = Math.abs(dy);
+    const threshold = 40;
+
+    if (Math.max(absX, absY) < threshold) return;
+    if (absX > absY) {
+      onSwipe(dx < 0 ? "left" : "right");
+    } else {
+      onSwipe(dy < 0 ? "up" : "down");
+    }
+  };
+
   return (
-    <div className="mobile-editor-tabs" role="tablist" aria-label={ariaLabel}>
+    <div
+      className="mobile-editor-tabs"
+      role="tablist"
+      aria-label={ariaLabel}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
       {tabs.map((tab) => (
         <button
           key={tab.id}


### PR DESCRIPTION
Closes #416

## Summary
- adds swipe detection to the mobile editor tab bar for left/right panel changes and up/down panel expansion/minimization
- adds mobile panel sizing state so Chat/BOM/Code/Params/Docs can expand to 70dvh or minimize back to tab-bar-only
- makes the viewport toolbar float as a touch-sized mobile pill above the active bottom panel
- keeps the implementation CSS-driven via editor data attributes and mobile media queries

## Verification
- web: npm test -- --run src/__tests__/MobileEditorTabs.test.tsx src/__tests__/BomResizeTouch.test.ts
- web: npm run build
- git diff --check
- web: npm test