### PR TITLE
feat(design): floating viewport toolbar pill

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -321,9 +321,10 @@
 }
 
 [data-theme="light"] .viewport-toolbar {
-  background: rgba(255, 255, 255, 0.65);
-  backdrop-filter: blur(16px) saturate(1.2);
-  border-bottom-color: rgba(0, 0, 0, 0.06);
+  background: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(20px) saturate(1.2);
+  border-color: rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
 }
 
 [data-theme="light"] .editor-bom-panel {
@@ -2871,6 +2872,7 @@ select:focus {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  position: relative;
   background:
     radial-gradient(ellipse 60% 40% at 30% 60%, rgba(229,160,75,0.02) 0%, transparent 70%),
     radial-gradient(ellipse 40% 60% at 75% 25%, rgba(229,160,75,0.012) 0%, transparent 60%),
@@ -3610,12 +3612,20 @@ select:focus {
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 2px 12px;
-  background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
-  backdrop-filter: blur(16px) saturate(1.2);
-  -webkit-backdrop-filter: blur(16px) saturate(1.2);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
-  flex-shrink: 0;
+  padding: 4px 14px;
+  background: rgba(14, 14, 17, 0.72);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 99px;
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
+  animation: fadeUp 0.25s ease both;
+  transition: opacity 0.3s ease;
 }
 
 .viewport-toolbar-btn {
@@ -3652,6 +3662,18 @@ select:focus {
   color: var(--amber);
   border-color: var(--amber-border);
   box-shadow: 0 0 8px var(--amber-glow), var(--shadow-subtle);
+}
+
+.viewport-toolbar-sep {
+  width: 1px;
+  height: 20px;
+  background: rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+  margin: 0 4px;
+}
+
+[data-theme="light"] .viewport-toolbar-sep {
+  background: rgba(0, 0, 0, 0.08);
 }
 
 .viewport-status {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1843,93 +1843,6 @@ export default function ProjectPage() {
       <div className="editor-main">
         {/* Left: Viewport + Code */}
         <div className="editor-viewport-area">
-          {/* Toolbar */}
-          <div className="viewport-toolbar">
-            <button
-              className="viewport-toolbar-btn"
-              data-active={showCode}
-              onClick={toggleCodePanel}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="16 18 22 12 16 6" />
-                <polyline points="8 6 2 12 8 18" />
-              </svg>
-              {showCode ? t('editor.hideCode') : t('editor.showCode')}
-            </button>
-            <button
-              className="viewport-toolbar-btn"
-              data-active={wireframe}
-              onClick={() => setWireframe(!wireframe)}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M12 2L2 7l10 5 10-5-10-5z" />
-                <path d="M2 17l10 5 10-5" />
-                <path d="M2 12l10 5 10-5" />
-              </svg>
-              {t('editor.wireframe')}
-            </button>
-            <button
-              className="viewport-toolbar-btn"
-              onClick={() => {
-                const container = viewportRef.current;
-                if (container) {
-                  const el = container.querySelector("div") as HTMLDivElement & { resetCamera?: () => void };
-                  el?.resetCamera?.();
-                }
-              }}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M1 4v6h6" />
-                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
-              </svg>
-              {t('editor.resetCamera')}
-            </button>
-            <button
-              className="viewport-toolbar-btn"
-              data-active={showDocs}
-              onClick={toggleDocsPanel}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-                <line x1="12" y1="17" x2="12.01" y2="17" />
-              </svg>
-              {t('editor.docs') || "Docs"}
-            </button>
-            {sceneParams.length > 0 && (
-              <button
-                className="viewport-toolbar-btn"
-                data-active={showParams}
-                onClick={toggleParamsPanel}
-              >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <line x1="4" y1="21" x2="4" y2="14" />
-                  <line x1="4" y1="10" x2="4" y2="3" />
-                  <line x1="12" y1="21" x2="12" y2="12" />
-                  <line x1="12" y1="8" x2="12" y2="3" />
-                  <line x1="20" y1="21" x2="20" y2="16" />
-                  <line x1="20" y1="12" x2="20" y2="3" />
-                </svg>
-                {t('editor.params') || "Params"}
-              </button>
-            )}
-            <div style={{ flex: 1 }} />
-            <span
-              className="viewport-status"
-              data-error={!!sceneError}
-              title={sceneError && sceneError.length > 40 ? sceneError : undefined}
-            >
-              {sceneError
-                ? `${t('editor.sceneErrorPrefix')}: ${sceneError.substring(0, 40)}${sceneError.length > 40 ? "..." : ""}`
-                : t('editor.objectCount', { count: objectCount })}
-            </span>
-            {sceneJs.length > 100 * 1024 && (
-              <span className="viewport-status" data-error style={{ marginLeft: 8 }} title={t('editor.scriptSizeWarning')}>
-                {Math.round(sceneJs.length / 1024)} KB
-              </span>
-            )}
-          </div>
-
           {/* 3D Viewport */}
           <div
             ref={viewportRef}
@@ -2043,6 +1956,89 @@ export default function ProjectPage() {
                 projectName={projectName}
               />
             </ErrorBoundary>
+          </div>
+
+          {/* Floating viewport toolbar */}
+          <div className="viewport-toolbar">
+            <button
+              className="viewport-toolbar-btn"
+              data-active={wireframe}
+              onClick={() => setWireframe(!wireframe)}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 2L2 7l10 5 10-5-10-5z" />
+                <path d="M2 17l10 5 10-5" />
+                <path d="M2 12l10 5 10-5" />
+              </svg>
+              {t('editor.wireframe')}
+            </button>
+            <button
+              className="viewport-toolbar-btn"
+              onClick={() => {
+                const container = viewportRef.current;
+                if (container) {
+                  const el = container.querySelector("div") as HTMLDivElement & { resetCamera?: () => void };
+                  el?.resetCamera?.();
+                }
+              }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M1 4v6h6" />
+                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+              </svg>
+              {t('editor.resetCamera')}
+            </button>
+            <span className="viewport-toolbar-sep" />
+            <button
+              className="viewport-toolbar-btn"
+              data-active={showCode}
+              onClick={toggleCodePanel}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="16 18 22 12 16 6" />
+                <polyline points="8 6 2 12 8 18" />
+              </svg>
+              {showCode ? t('editor.hideCode') : t('editor.showCode')}
+            </button>
+            <button
+              className="viewport-toolbar-btn"
+              data-active={showDocs}
+              onClick={toggleDocsPanel}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                <line x1="12" y1="17" x2="12.01" y2="17" />
+              </svg>
+              {t('editor.docs') || "Docs"}
+            </button>
+            {sceneParams.length > 0 && (
+              <button
+                className="viewport-toolbar-btn"
+                data-active={showParams}
+                onClick={toggleParamsPanel}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="4" y1="21" x2="4" y2="14" />
+                  <line x1="4" y1="10" x2="4" y2="3" />
+                  <line x1="12" y1="21" x2="12" y2="12" />
+                  <line x1="12" y1="8" x2="12" y2="3" />
+                  <line x1="20" y1="21" x2="20" y2="16" />
+                  <line x1="20" y1="12" x2="20" y2="3" />
+                </svg>
+                {t('editor.params') || "Params"}
+              </button>
+            )}
+            <span className="viewport-toolbar-sep" />
+            <span
+              className="viewport-status"
+              data-error={!!sceneError}
+              title={sceneError && sceneError.length > 40 ? sceneError : undefined}
+            >
+              {sceneError
+                ? `${t('editor.sceneErrorPrefix')}: ${sceneError.substring(0, 40)}${sceneError.length > 40 ? "..." : ""}`
+                : t('editor.objectCount', { count: objectCount })}
+            </span>
           </div>
 
           {/* Scene validation warnings */}


### PR DESCRIPTION
## Summary
- **Floating viewport toolbar** — transforms the docked top bar into a centered floating pill at the bottom of the viewport with glassmorphic backdrop (`blur(20px) saturate(1.4)`), `border-radius: 99px`, and `fadeUp` entry animation — Fixes #500
- Logical section dividers separate view controls (wireframe, reset camera) from code/docs toggles and status badge
- Light theme variant with white glass background

## Test plan
- [ ] Open editor — verify toolbar floats at bottom center of viewport
- [ ] Verify frosted glass effect visible against 3D scene
- [ ] Click each button — verify Code, Wireframe, Reset Camera, Docs, Params all work
- [ ] Switch to light mode — verify toolbar adapts
- [ ] Resize viewport — verify toolbar stays centered
- [ ] Check mobile layout isn't broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)