### PR TITLE
feat: component tests + dashboard analytics summary

### DIFF
--- a/web/src/__tests__/components.test.tsx
+++ b/web/src/__tests__/components.test.tsx
@@ -1,0 +1,252 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// jsdom doesn't implement scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
+// Mock LocaleProvider
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock useCursorGlow
+vi.mock("@/hooks/useCursorGlow", () => ({
+  useCursorGlow: () => ({
+    ref: { current: null },
+    onMouseMove: vi.fn(),
+    onMouseLeave: vi.fn(),
+  }),
+}));
+
+import SceneParamsPanel from "@/components/SceneParamsPanel";
+import { ToastContainer, type ToastItem } from "@/components/Toast";
+import CommandPalette, { type Command } from "@/components/CommandPalette";
+
+// ---------------------------------------------------------------------------
+// SceneParamsPanel
+// ---------------------------------------------------------------------------
+describe("SceneParamsPanel", () => {
+  const mockParams = [
+    { name: "width", section: "Dimensions", label: "Width", min: 1, max: 10, value: 5, step: 1 },
+    { name: "height", section: "Dimensions", label: "Height", min: 0, max: 20, value: 10, step: 1 },
+    { name: "color", section: "Appearance", label: "Color", min: 0, max: 1, value: 0.5, step: 0.1 },
+  ];
+
+  it("returns null when params array is empty", () => {
+    const { container } = render(
+      <SceneParamsPanel params={[]} onParamChange={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders sections grouped by param.section", () => {
+    render(<SceneParamsPanel params={mockParams} onParamChange={vi.fn()} />);
+    expect(screen.getByText("Dimensions")).toBeInTheDocument();
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+  });
+
+  it("renders all param labels", () => {
+    render(<SceneParamsPanel params={mockParams} onParamChange={vi.fn()} />);
+    expect(screen.getByText("Width")).toBeInTheDocument();
+    expect(screen.getByText("Height")).toBeInTheDocument();
+    expect(screen.getByText("Color")).toBeInTheDocument();
+  });
+
+  it("collapse/expand toggles section visibility", () => {
+    render(<SceneParamsPanel params={mockParams} onParamChange={vi.fn()} />);
+    const toggleBtn = screen.getAllByRole("button").find(
+      (b) => b.getAttribute("aria-expanded") === "true",
+    );
+    expect(toggleBtn).toBeDefined();
+    fireEvent.click(toggleBtn!);
+    expect(toggleBtn!.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("calls onParamChange when slider value changes", async () => {
+    vi.useFakeTimers();
+    const onChange = vi.fn();
+    render(<SceneParamsPanel params={mockParams} onParamChange={onChange} />);
+    const sliders = screen.getAllByRole("slider");
+    fireEvent.change(sliders[0], { target: { value: "7" } });
+    act(() => { vi.advanceTimersByTime(20); });
+    expect(onChange).toHaveBeenCalledWith("width", 7);
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Toast
+// ---------------------------------------------------------------------------
+describe("ToastContainer", () => {
+  const baseToast: ToastItem = {
+    id: 1,
+    message: "Test toast",
+    type: "info",
+    createdAt: Date.now(),
+  };
+
+  it("renders a toast message", () => {
+    render(<ToastContainer toasts={[baseToast]} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Test toast")).toBeInTheDocument();
+  });
+
+  it("renders error toast with alert role", () => {
+    const errorToast = { ...baseToast, type: "error" as const, message: "Error!" };
+    render(<ToastContainer toasts={[errorToast]} onDismiss={vi.fn()} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders info toast with status role", () => {
+    render(<ToastContainer toasts={[baseToast]} onDismiss={vi.fn()} />);
+    const statusElements = screen.getAllByRole("status");
+    expect(statusElements.length).toBeGreaterThan(0);
+  });
+
+  it("renders progress toast with progressbar", () => {
+    const progressToast: ToastItem = {
+      ...baseToast,
+      type: "progress",
+      progress: 42,
+      duration: 0,
+    };
+    render(<ToastContainer toasts={[progressToast]} onDismiss={vi.fn()} />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toBeInTheDocument();
+    expect(bar.getAttribute("aria-valuenow")).toBe("42");
+  });
+
+  it("shows overflow indicator when more than 5 toasts", () => {
+    const toasts = Array.from({ length: 7 }, (_, i) => ({
+      ...baseToast,
+      id: i,
+      message: `Toast ${i}`,
+      createdAt: Date.now() + i,
+    }));
+    render(<ToastContainer toasts={toasts} onDismiss={vi.fn()} />);
+    expect(screen.getByText("toast.overflowMore")).toBeInTheDocument();
+  });
+
+  it("renders action button when action is provided", () => {
+    const actionToast: ToastItem = {
+      ...baseToast,
+      action: { label: "Undo", onClick: vi.fn() },
+    };
+    render(<ToastContainer toasts={[actionToast]} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Undo")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses after duration", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    const toast: ToastItem = { ...baseToast, duration: 1000 };
+    render(<ToastContainer toasts={[toast]} onDismiss={onDismiss} />);
+    act(() => { vi.advanceTimersByTime(1300); });
+    expect(onDismiss).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it("groups toasts with same group key", () => {
+    const toasts: ToastItem[] = [
+      { ...baseToast, id: 1, group: "save", message: "Saved 1", createdAt: 1 },
+      { ...baseToast, id: 2, group: "save", message: "Saved 2", createdAt: 2 },
+      { ...baseToast, id: 3, group: "save", message: "Saved 3", createdAt: 3 },
+    ];
+    render(<ToastContainer toasts={toasts} onDismiss={vi.fn()} />);
+    // Only the latest grouped toast message should be visible
+    expect(screen.getByText("Saved 3")).toBeInTheDocument();
+    expect(screen.queryByText("Saved 1")).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CommandPalette
+// ---------------------------------------------------------------------------
+describe("CommandPalette", () => {
+  const commands: Command[] = [
+    { id: "cmd-save", labelKey: "cmd.save", action: vi.fn(), category: "project" },
+    { id: "cmd-undo", labelKey: "cmd.undo", action: vi.fn(), category: "scene" },
+    { id: "cmd-theme", labelKey: "cmd.theme", action: vi.fn(), category: "preferences", isActive: true },
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when open is false", () => {
+    const { container } = render(
+      <CommandPalette open={false} onClose={vi.fn()} commands={commands} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders command labels when open", () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} commands={commands} />);
+    expect(screen.getByText("cmd.save")).toBeInTheDocument();
+    expect(screen.getByText("cmd.undo")).toBeInTheDocument();
+    expect(screen.getByText("cmd.theme")).toBeInTheDocument();
+  });
+
+  it("filters commands by search query", () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} commands={commands} />);
+    const input = screen.getByRole("textbox") || screen.getByRole("searchbox")
+      || document.querySelector("input");
+    fireEvent.change(input!, { target: { value: "save" } });
+    expect(screen.getByText("cmd.save")).toBeInTheDocument();
+    expect(screen.queryByText("cmd.undo")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} commands={commands} />);
+    fireEvent.keyDown(document.querySelector("[role='dialog']") || document.body, {
+      key: "Escape",
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("executes command on Enter after arrow navigation", () => {
+    vi.useFakeTimers();
+    const action = vi.fn();
+    const cmds: Command[] = [
+      { id: "a", labelKey: "Alpha", action, category: "scene" },
+      { id: "b", labelKey: "Beta", action: vi.fn(), category: "scene" },
+    ];
+    render(<CommandPalette open={true} onClose={vi.fn()} commands={cmds} />);
+    const dialog = document.querySelector("[role='dialog']") || document.body;
+    fireEvent.keyDown(dialog, { key: "ArrowDown" });
+    fireEvent.keyDown(dialog, { key: "Enter" });
+    act(() => {
+      vi.advanceTimersByTime(50);
+      // rAF callback
+      vi.advanceTimersByTime(50);
+    });
+    vi.useRealTimers();
+  });
+
+  it("shows toggle indicator for commands with isActive", () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} commands={commands} />);
+    expect(screen.getByText("cmd.theme")).toBeInTheDocument();
+  });
+
+  it("saves recent commands to localStorage on execution", () => {
+    vi.useFakeTimers();
+    const action = vi.fn();
+    const cmds: Command[] = [
+      { id: "test-cmd", labelKey: "Test", action, category: "scene" },
+    ];
+    render(<CommandPalette open={true} onClose={vi.fn()} commands={cmds} />);
+    const dialog = document.querySelector("[role='dialog']") || document.body;
+    // Select first item
+    fireEvent.keyDown(dialog, { key: "ArrowDown" });
+    fireEvent.keyDown(dialog, { key: "Enter" });
+    act(() => { vi.advanceTimersByTime(50); });
+    const stored = localStorage.getItem("helscoop_recent_commands");
+    expect(stored).toContain("test-cmd");
+    vi.useRealTimers();
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3840,6 +3840,39 @@ select:focus {
   margin-bottom: 18px;
 }
 
+.dash-summary-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+@media (max-width: 600px) {
+  .dash-summary-strip { grid-template-columns: 1fr 1fr; }
+}
+.dash-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.dash-stat-value {
+  font-size: 20px;
+  font-weight: 600;
+  font-family: var(--font-display);
+  color: var(--text-primary);
+  letter-spacing: -0.02em;
+}
+.dash-stat-label {
+  font-size: 11px;
+  font-family: var(--font-body);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
 .dash-project-grid {
   display: grid;
   gap: 10px;

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -271,6 +271,27 @@ export default function ProjectList({
     return sorted;
   }, [projects, searchQuery, sortKey, locale]);
 
+  const dashboardStats = useMemo(() => {
+    if (projects.length === 0) return null;
+    const totalCost = projects.reduce((sum, p) => sum + (Number(p.estimated_cost) || 0), 0);
+    const activeCount = projects.length;
+    const latest = projects.reduce((max, p) => {
+      const t = new Date(p.updated_at).getTime();
+      return t > max ? t : max;
+    }, 0);
+    const now = Date.now();
+    const diffMs = now - latest;
+    const diffMin = Math.floor(diffMs / 60000);
+    const diffH = Math.floor(diffMin / 60);
+    const diffD = Math.floor(diffH / 24);
+    let lastActivity: string;
+    if (diffMin < 1) lastActivity = t("dashboard.justNow");
+    else if (diffMin < 60) lastActivity = `${diffMin} min`;
+    else if (diffH < 24) lastActivity = `${diffH}h`;
+    else lastActivity = `${diffD}d`;
+    return { totalCost, activeCount, lastActivity };
+  }, [projects, t]);
+
   return (
     <div style={{ minHeight: "100vh" }}>
       {/* Top bar */}
@@ -493,6 +514,25 @@ export default function ProjectList({
                 <option value="cost">{t('project.sortByCost')}</option>
               </select>
             </div>
+
+            {dashboardStats && (
+              <div className="anim-up delay-1 dash-summary-strip">
+                <div className="dash-stat-card">
+                  <span className="dash-stat-value">
+                    {dashboardStats.totalCost.toLocaleString(locale === "fi" ? "fi-FI" : "en-US", { maximumFractionDigits: 0 })} €
+                  </span>
+                  <span className="dash-stat-label">{t("dashboard.totalCost")}</span>
+                </div>
+                <div className="dash-stat-card">
+                  <span className="dash-stat-value">{dashboardStats.activeCount}</span>
+                  <span className="dash-stat-label">{t("dashboard.activeProjects")}</span>
+                </div>
+                <div className="dash-stat-card">
+                  <span className="dash-stat-value">{dashboardStats.lastActivity}</span>
+                  <span className="dash-stat-label">{t("dashboard.lastActivity")}</span>
+                </div>
+              </div>
+            )}
 
             {filteredProjects.length === 0 ? (
               <div className="anim-up dash-no-results">

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -137,6 +137,12 @@ const translations = {
       copyAriaLabel: 'Kopioi projekti {{name}}',
       deleteAriaLabel: 'Poista projekti {{name}}',
     },
+    dashboard: {
+      totalCost: 'Arvioitu kokonaishinta',
+      activeProjects: 'Aktiiviset projektit',
+      lastActivity: 'Viimeisin muokkaus',
+      justNow: 'Juuri nyt',
+    },
     toast: {
       projectCreated: 'Projekti luotu',
       projectDeleted: 'Projekti siirretty roskakoriin',
@@ -1375,6 +1381,12 @@ const translations = {
       openAriaLabel: 'Open project {{name}}',
       copyAriaLabel: 'Copy project {{name}}',
       deleteAriaLabel: 'Delete project {{name}}',
+    },
+    dashboard: {
+      totalCost: 'Total estimated cost',
+      activeProjects: 'Active projects',
+      lastActivity: 'Last activity',
+      justNow: 'Just now',
     },
     toast: {
       projectCreated: 'Project created',


### PR DESCRIPTION
## Summary
- **#326**: 20 component tests for SceneParamsPanel, Toast/ToastContainer, CommandPalette (render, interaction, keyboard nav, auto-dismiss, grouping, filtering, recent commands)
- **#331**: Dashboard analytics summary strip showing total estimated cost, active project count, and last activity timestamp with locale-aware formatting
- **#300**: Closed as already implemented (email module now has all 4 exports)

Closes #326, closes #331

## Test plan
- [ ] All 688 tests pass (`npx vitest run`)
- [ ] Dashboard summary strip renders above project grid with correct stats
- [ ] Summary strip shows locale-formatted costs (fi: `1 234 €`, en: `1,234 €`)
- [ ] Summary hides when no projects exist
- [ ] Responsive: 2-column on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)