### PR TITLE
feat(chat): persist conversation history per project

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -2243,6 +2243,7 @@ export default function ProjectPage() {
 
           {/* Embedded AI assistant */}
           <ChatPanel
+            projectId={projectId}
             sceneJs={sceneJs}
             onApplyCode={handleApplyCode}
             bom={bom}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -31,6 +31,7 @@ function shouldGroup(current: ChatMessage, prev: ChatMessage | undefined): boole
 }
 
 export default function ChatPanel({
+  projectId,
   sceneJs,
   onApplyCode,
   bom,
@@ -40,6 +41,7 @@ export default function ChatPanel({
   renovationRoiSummary,
   onMessageCountChange,
 }: {
+  projectId?: string;
   sceneJs: string;
   onApplyCode: (code: string) => void;
   bom?: BomItem[];
@@ -50,7 +52,18 @@ export default function ChatPanel({
   onMessageCountChange?: (count: number) => void;
 }) {
   const glow = useCursorGlow();
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const chatStorageKey = projectId ? `helscoop-chat-${projectId}` : null;
+  const [messages, setMessages] = useState<ChatMessage[]>(() => {
+    if (typeof window === "undefined" || !chatStorageKey) return [];
+    try {
+      const stored = localStorage.getItem(chatStorageKey);
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
+  useEffect(() => {
+    if (!chatStorageKey || messages.length === 0) return;
+    try { localStorage.setItem(chatStorageKey, JSON.stringify(messages.slice(-50))); } catch {}
+  }, [messages, chatStorageKey]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
   const [pendingCode, setPendingCode] = useState<string | null>(null);


### PR DESCRIPTION
## Summary
- Chat messages persist to `localStorage` keyed by project ID (`helscoop-chat-{id}`)
- Survives panel toggle, page reload, and navigation
- Capped at 50 messages to bound storage usage
- Auto-scroll to latest message was already implemented

Closes #99

## Test plan
- [ ] Send chat messages, close and reopen chat panel — messages persist
- [ ] Reload page — messages still visible
- [ ] Different projects have independent chat histories
- [ ] History caps at 50 messages (oldest trimmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)