### PR TITLE
test: 161 tests for maintenance schedules, waste factors, animated number, credit balance

### DIFF
--- a/api/src/__tests__/maintenance-schedules.test.ts
+++ b/api/src/__tests__/maintenance-schedules.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  maintenanceSchedules,
+  defaultSchedule,
+  getScheduleForCategory,
+  type MaintenanceSchedule,
+} from "../maintenance-schedules";
+
+describe("maintenanceSchedules data", () => {
+  const categories = Object.keys(maintenanceSchedules);
+
+  it("has at least 10 material categories", () => {
+    expect(categories.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it.each(categories)("%s has positive inspection interval", (cat) => {
+    expect(maintenanceSchedules[cat].inspectionIntervalMonths).toBeGreaterThan(0);
+  });
+
+  it.each(categories)("%s has positive expected life", (cat) => {
+    expect(maintenanceSchedules[cat].expectedLifeYears).toBeGreaterThan(0);
+  });
+
+  it.each(categories)("%s has non-empty Finnish notes", (cat) => {
+    expect(maintenanceSchedules[cat].maintenanceNotes_fi.length).toBeGreaterThan(0);
+  });
+
+  it.each(categories)("%s has non-empty English notes", (cat) => {
+    expect(maintenanceSchedules[cat].maintenanceNotes_en.length).toBeGreaterThan(0);
+  });
+
+  it("foundation has the longest expected life", () => {
+    const lifetimes = categories.map((c) => maintenanceSchedules[c].expectedLifeYears);
+    const maxLife = Math.max(...lifetimes);
+    expect(maintenanceSchedules["foundation"].expectedLifeYears).toBe(maxLife);
+  });
+
+  it("paint has the shortest expected life", () => {
+    const lifetimes = categories.map((c) => maintenanceSchedules[c].expectedLifeYears);
+    const minLife = Math.min(...lifetimes);
+    expect(maintenanceSchedules["paint"].expectedLifeYears).toBe(minLife);
+  });
+
+  it("inspection intervals are multiples of 12", () => {
+    for (const cat of categories) {
+      expect(maintenanceSchedules[cat].inspectionIntervalMonths % 12).toBe(0);
+    }
+  });
+});
+
+describe("defaultSchedule", () => {
+  it("has 24-month inspection interval", () => {
+    expect(defaultSchedule.inspectionIntervalMonths).toBe(24);
+  });
+
+  it("has 30-year expected life", () => {
+    expect(defaultSchedule.expectedLifeYears).toBe(30);
+  });
+
+  it("has bilingual notes", () => {
+    expect(defaultSchedule.maintenanceNotes_fi.length).toBeGreaterThan(0);
+    expect(defaultSchedule.maintenanceNotes_en.length).toBeGreaterThan(0);
+  });
+});
+
+describe("getScheduleForCategory", () => {
+  it("returns the correct schedule for a known category", () => {
+    const result = getScheduleForCategory("lumber");
+    expect(result).toBe(maintenanceSchedules["lumber"]);
+    expect(result.inspectionIntervalMonths).toBe(12);
+  });
+
+  it("returns the correct schedule for roofing", () => {
+    const result = getScheduleForCategory("roofing");
+    expect(result.expectedLifeYears).toBe(40);
+  });
+
+  it("returns default schedule for unknown category", () => {
+    const result = getScheduleForCategory("unknown_material");
+    expect(result).toBe(defaultSchedule);
+  });
+
+  it("returns default schedule for empty string", () => {
+    expect(getScheduleForCategory("")).toBe(defaultSchedule);
+  });
+
+  it("is case-sensitive", () => {
+    expect(getScheduleForCategory("Lumber")).toBe(defaultSchedule);
+  });
+});

--- a/api/src/__tests__/waste-factors.test.ts
+++ b/api/src/__tests__/waste-factors.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  WASTE_FACTORS,
+  DEFAULT_WASTE_FACTOR,
+  CONTAINER_SIZES,
+  SORTING_GUIDE,
+  recommendContainer,
+  type WasteType,
+} from "../waste-factors";
+
+describe("WASTE_FACTORS data", () => {
+  const categories = Object.keys(WASTE_FACTORS);
+
+  it("has at least 8 material categories", () => {
+    expect(categories.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it.each(categories)("%s has positive kgPerUnit", (cat) => {
+    expect(WASTE_FACTORS[cat].kgPerUnit).toBeGreaterThan(0);
+  });
+
+  it.each(categories)("%s has recycling rate between 0 and 1", (cat) => {
+    const rate = WASTE_FACTORS[cat].recyclingRate;
+    expect(rate).toBeGreaterThanOrEqual(0);
+    expect(rate).toBeLessThanOrEqual(1);
+  });
+
+  it.each(categories)("%s has non-negative disposal cost", (cat) => {
+    expect(WASTE_FACTORS[cat].disposalCostPerTonne).toBeGreaterThanOrEqual(0);
+  });
+
+  it.each(categories)("%s has positive volumePerKg", (cat) => {
+    expect(WASTE_FACTORS[cat].volumePerKg).toBeGreaterThan(0);
+  });
+
+  it("paint is classified as hazardous waste", () => {
+    expect(WASTE_FACTORS["paint"].wasteType).toBe("vaarallinen_jate");
+    expect(WASTE_FACTORS["paint"].recyclingRate).toBe(0);
+  });
+
+  it("metal roofing has highest recycling rate", () => {
+    expect(WASTE_FACTORS["roofing"].recyclingRate).toBe(0.95);
+  });
+
+  it("fasteners have highest recycling rate", () => {
+    expect(WASTE_FACTORS["fasteners"].recyclingRate).toBe(0.98);
+  });
+
+  it("clean wood and metal have zero disposal cost", () => {
+    expect(WASTE_FACTORS["lumber"].disposalCostPerTonne).toBe(0);
+    expect(WASTE_FACTORS["roofing"].disposalCostPerTonne).toBe(0);
+    expect(WASTE_FACTORS["fasteners"].disposalCostPerTonne).toBe(0);
+  });
+
+  it("plumbing has secondary waste type", () => {
+    expect(WASTE_FACTORS["plumbing"].secondaryWasteType).toBe("muovijate");
+  });
+
+  it("electrical has secondary hazardous waste type", () => {
+    expect(WASTE_FACTORS["electrical"].secondaryWasteType).toBe("vaarallinen_jate");
+  });
+});
+
+describe("DEFAULT_WASTE_FACTOR", () => {
+  it("is classified as mixed waste", () => {
+    expect(DEFAULT_WASTE_FACTOR.wasteType).toBe("sekajate");
+  });
+
+  it("has conservative 30% recycling rate", () => {
+    expect(DEFAULT_WASTE_FACTOR.recyclingRate).toBe(0.3);
+  });
+
+  it("has 150 EUR/tonne disposal cost", () => {
+    expect(DEFAULT_WASTE_FACTOR.disposalCostPerTonne).toBe(150);
+  });
+});
+
+describe("CONTAINER_SIZES", () => {
+  it("has 3 sizes in ascending order", () => {
+    expect(CONTAINER_SIZES).toHaveLength(3);
+    for (let i = 1; i < CONTAINER_SIZES.length; i++) {
+      expect(CONTAINER_SIZES[i].sizeM3).toBeGreaterThan(CONTAINER_SIZES[i - 1].sizeM3);
+    }
+  });
+
+  it("costs increase with size", () => {
+    for (let i = 1; i < CONTAINER_SIZES.length; i++) {
+      expect(CONTAINER_SIZES[i].costEur).toBeGreaterThan(CONTAINER_SIZES[i - 1].costEur);
+    }
+  });
+
+  it("max load increases with size", () => {
+    for (let i = 1; i < CONTAINER_SIZES.length; i++) {
+      expect(CONTAINER_SIZES[i].maxLoadKg).toBeGreaterThan(CONTAINER_SIZES[i - 1].maxLoadKg);
+    }
+  });
+
+  it("all sizes have bilingual labels", () => {
+    for (const size of CONTAINER_SIZES) {
+      expect(size.label.length).toBeGreaterThan(0);
+      expect(size.labelFi.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("recommendContainer", () => {
+  it("recommends smallest container for small jobs", () => {
+    const result = recommendContainer(2, 1000);
+    expect(result.size.sizeM3).toBe(4);
+    expect(result.count).toBe(1);
+  });
+
+  it("recommends 2x4m3 for medium volume that fits in <= 2 small skips", () => {
+    const result = recommendContainer(5, 2000);
+    expect(result.size.sizeM3).toBe(4);
+    expect(result.count).toBe(2);
+  });
+
+  it("recommends 2x6m3 for 9m3 volume (fits in <= 2 containers)", () => {
+    const result = recommendContainer(9, 5000);
+    expect(result.size.sizeM3).toBe(6);
+    expect(result.count).toBe(2);
+  });
+
+  it("uses multiple containers when volume exceeds single", () => {
+    const result = recommendContainer(7, 2000);
+    expect(result.size.sizeM3).toBe(4);
+    expect(result.count).toBe(2);
+    expect(result.totalCost).toBe(500);
+  });
+
+  it("considers weight limit for heavy materials", () => {
+    const result = recommendContainer(3, 7000);
+    expect(result.size.sizeM3).toBe(6);
+    expect(result.count).toBe(2);
+  });
+
+  it("falls back to largest for very large jobs", () => {
+    const result = recommendContainer(50, 20000);
+    expect(result.size.sizeM3).toBe(10);
+    expect(result.count).toBeGreaterThan(2);
+    expect(result.totalCost).toBe(result.count * 500);
+  });
+
+  it("returns at least 1 container", () => {
+    const result = recommendContainer(0.1, 1);
+    expect(result.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("weight-limited result uses correct count", () => {
+    const result = recommendContainer(1, 9000);
+    expect(result.size.sizeM3).toBe(6);
+    expect(result.count).toBe(2);
+  });
+});
+
+describe("SORTING_GUIDE", () => {
+  const allWasteTypes: WasteType[] = [
+    "puujate", "metallijate", "kivijate", "sekajate",
+    "vaarallinen_jate", "muovijate", "lasijate", "eristejate",
+  ];
+
+  it("covers all 8 waste types", () => {
+    const coveredTypes = SORTING_GUIDE.map((e) => e.wasteType);
+    for (const wt of allWasteTypes) {
+      expect(coveredTypes).toContain(wt);
+    }
+  });
+
+  it("has bilingual instructions for each entry", () => {
+    for (const entry of SORTING_GUIDE) {
+      expect(entry.sortingInstruction_fi.length).toBeGreaterThan(0);
+      expect(entry.sortingInstruction_en.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has acceptedAt location for each entry", () => {
+    for (const entry of SORTING_GUIDE) {
+      expect(entry.acceptedAt.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("hazardous waste mentions separate collection", () => {
+    const hazardous = SORTING_GUIDE.find((e) => e.wasteType === "vaarallinen_jate")!;
+    expect(hazardous.sortingInstruction_en.toLowerCase()).toContain("separate");
+  });
+});

--- a/web/src/__tests__/animated-number.test.tsx
+++ b/web/src/__tests__/animated-number.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
+
+let rafCallbacks: ((ts: number) => void)[] = [];
+let rafId = 0;
+
+beforeEach(() => {
+  rafCallbacks = [];
+  rafId = 0;
+  vi.stubGlobal("requestAnimationFrame", (cb: (ts: number) => void) => {
+    rafCallbacks.push(cb);
+    return ++rafId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    // no-op for tests
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function flushRaf(timestamp: number) {
+  const cbs = [...rafCallbacks];
+  rafCallbacks = [];
+  cbs.forEach((cb) => cb(timestamp));
+}
+
+describe("useAnimatedNumber", () => {
+  it("returns the initial target immediately", () => {
+    const { result } = renderHook(() => useAnimatedNumber(100));
+    expect(result.current).toBe(100);
+  });
+
+  it("starts animating when target changes", () => {
+    const { result, rerender } = renderHook(
+      ({ target }) => useAnimatedNumber(target, 400),
+      { initialProps: { target: 0 } },
+    );
+    expect(result.current).toBe(0);
+
+    rerender({ target: 100 });
+    expect(rafCallbacks.length).toBeGreaterThan(0);
+  });
+
+  it("reaches exact target at end of animation", () => {
+    const { result, rerender } = renderHook(
+      ({ target }) => useAnimatedNumber(target, 400),
+      { initialProps: { target: 0 } },
+    );
+
+    rerender({ target: 200 });
+
+    // Simulate first frame at t=0
+    act(() => flushRaf(0));
+    // Simulate final frame at t=400 (duration)
+    act(() => flushRaf(400));
+
+    expect(result.current).toBe(200);
+  });
+
+  it("interpolates intermediate values with ease-out", () => {
+    const { result, rerender } = renderHook(
+      ({ target }) => useAnimatedNumber(target, 1000),
+      { initialProps: { target: 0 } },
+    );
+
+    rerender({ target: 100 });
+
+    // t=0
+    act(() => flushRaf(0));
+    // t=500 (50% through)
+    act(() => flushRaf(500));
+
+    // Ease-out: 1 - (1-0.5)^3 = 1 - 0.125 = 0.875
+    // So at 50% time, we should be at ~87.5% of the way
+    expect(result.current).toBeCloseTo(87.5, 0);
+  });
+
+  it("does not animate when target stays the same", () => {
+    const { result, rerender } = renderHook(
+      ({ target }) => useAnimatedNumber(target, 400),
+      { initialProps: { target: 50 } },
+    );
+
+    rerender({ target: 50 });
+    expect(rafCallbacks.length).toBe(0);
+    expect(result.current).toBe(50);
+  });
+
+  it("cancels previous animation when target changes mid-flight", () => {
+    const cancelSpy = vi.fn();
+    vi.stubGlobal("cancelAnimationFrame", cancelSpy);
+
+    const { rerender } = renderHook(
+      ({ target }) => useAnimatedNumber(target, 400),
+      { initialProps: { target: 0 } },
+    );
+
+    rerender({ target: 100 });
+    act(() => flushRaf(0));
+
+    rerender({ target: 200 });
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  it("animates downward", () => {
+    const { result, rerender } = renderHook(
+      ({ target }) => useAnimatedNumber(target, 400),
+      { initialProps: { target: 100 } },
+    );
+
+    rerender({ target: 0 });
+
+    act(() => flushRaf(0));
+    act(() => flushRaf(400));
+
+    expect(result.current).toBe(0);
+  });
+
+  it("uses custom duration", () => {
+    const { result, rerender } = renderHook(
+      ({ target, duration }) => useAnimatedNumber(target, duration),
+      { initialProps: { target: 0, duration: 200 } },
+    );
+
+    rerender({ target: 100, duration: 200 });
+
+    act(() => flushRaf(0));
+    // At 100ms (50% of 200ms duration), ease-out: 1 - (0.5)^3 = 0.875
+    act(() => flushRaf(100));
+    expect(result.current).toBeCloseTo(87.5, 0);
+
+    act(() => flushRaf(200));
+    expect(result.current).toBe(100);
+  });
+});

--- a/web/src/__tests__/credit-balance.test.tsx
+++ b/web/src/__tests__/credit-balance.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockGetEntitlements = vi.fn();
+const mockCreateCreditCheckout = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getEntitlements: (...args: unknown[]) => mockGetEntitlements(...args),
+    createCreditCheckout: (...args: unknown[]) => mockCreateCreditCheckout(...args),
+  },
+  ApiError: class extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/hooks/useFocusTrap", () => ({
+  useFocusTrap: vi.fn(),
+}));
+
+import CreditBalancePill from "@/components/CreditBalancePill";
+import type { CreditState } from "@/lib/api";
+
+const baseCreditState: CreditState = {
+  balance: 42,
+  lowCredit: false,
+  monthlyGrant: 50,
+  lowCreditThreshold: 10,
+  costs: { chat: 1 },
+  packs: [
+    { id: "pack-10", credits: 10, priceEur: 4.99, unitPriceEur: 0.499 },
+    { id: "pack-50", credits: 50, priceEur: 19.99, unitPriceEur: 0.3998, savingsPercent: 20 },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetEntitlements.mockResolvedValue({ credits: baseCreditState });
+});
+
+describe("CreditBalancePill", () => {
+  it("shows loading state initially", () => {
+    mockGetEntitlements.mockReturnValue(new Promise(() => {}));
+    render(<CreditBalancePill />);
+    expect(screen.getByText("...")).toBeInTheDocument();
+  });
+
+  it("shows balance after loading", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => {
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+  });
+
+  it("shows short label in non-compact mode", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => {
+      expect(screen.getByText("credits.shortLabel")).toBeInTheDocument();
+    });
+  });
+
+  it("hides short label in compact mode", async () => {
+    render(<CreditBalancePill compact />);
+    await waitFor(() => {
+      expect(screen.getByText("42")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("credits.shortLabel")).not.toBeInTheDocument();
+  });
+
+  it("opens dialog on click", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    fireEvent.click(screen.getByText("42"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("credits.title")).toBeInTheDocument();
+  });
+
+  it("shows current balance in dialog", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    fireEvent.click(screen.getByText("42"));
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveTextContent("42");
+  });
+
+  it("renders credit packs in dialog", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    fireEvent.click(screen.getByText("42"));
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.getByText("4.99 EUR")).toBeInTheDocument();
+    expect(screen.getByText("19.99 EUR")).toBeInTheDocument();
+  });
+
+  it("shows savings badge on discounted pack", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    fireEvent.click(screen.getByText("42"));
+    expect(screen.getByText(/credits\.savings/)).toBeInTheDocument();
+  });
+
+  it("closes dialog via close button", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    fireEvent.click(screen.getByText("42"));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("dialog.close"));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes dialog on backdrop click", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    fireEvent.click(screen.getByText("42"));
+    const backdrop = screen.getByRole("presentation");
+    fireEvent.mouseDown(backdrop);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows low credit warning styling", async () => {
+    mockGetEntitlements.mockResolvedValue({
+      credits: { ...baseCreditState, balance: 5, lowCredit: true },
+    });
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("5"));
+    const button = screen.getByLabelText(/credits\.balanceAria/);
+    expect(button.style.borderColor).toBe("var(--warning-border)");
+  });
+
+  it("shows low badge in dialog when low credit", async () => {
+    mockGetEntitlements.mockResolvedValue({
+      credits: { ...baseCreditState, balance: 5, lowCredit: true },
+    });
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("5"));
+    fireEvent.click(screen.getByText("5"));
+    expect(screen.getByText("credits.lowBadge")).toBeInTheDocument();
+  });
+
+  it("does not show low credit toast when lowCredit is false", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("handles API error gracefully", async () => {
+    mockGetEntitlements.mockRejectedValue(new Error("network"));
+    render(<CreditBalancePill />);
+    await waitFor(() => {
+      expect(screen.getByText("...")).toBeInTheDocument();
+    });
+  });
+
+  it("has correct aria-label with balance", async () => {
+    render(<CreditBalancePill />);
+    await waitFor(() => screen.getByText("42"));
+    const button = screen.getByLabelText(/credits\.balanceAria/);
+    expect(button).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- 72 tests for `maintenance-schedules.ts` — data integrity for all 15 material categories, bilingual notes, category lookup with fallback
- 66 tests for `waste-factors.ts` — waste classification, recycling rates, disposal costs, container recommendation algorithm, sorting guide coverage
- 8 tests for `useAnimatedNumber` hook — ease-out interpolation, cancel mid-animation, direction change, custom duration
- 15 tests for `CreditBalancePill` — loading state, dialog open/close, pack rendering, savings badge, low credit styling, error handling

## Test plan
- [x] All 161 tests pass locally
- [x] No mocking of external services required (pure data + hook tests)
- [x] CreditBalancePill tests mock API and providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)