### PR TITLE
test: 49 tests for Skeleton, ConfidenceBadge, WasteEstimatePanel

### DIFF
--- a/web/src/__tests__/confidence-badge.test.tsx
+++ b/web/src/__tests__/confidence-badge.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+import ConfidenceBadge, { StalePriceBadge } from "@/components/ConfidenceBadge";
+import type { DataProvenance } from "@/lib/confidence";
+
+const verifiedProvenance: DataProvenance = {
+  confidence: "verified",
+  source: "DVV",
+  fetchedAt: "2025-06-01T00:00:00Z",
+};
+
+const estimatedProvenance: DataProvenance = {
+  confidence: "estimated",
+  source: "heuristic",
+};
+
+const demoProvenance: DataProvenance = {
+  confidence: "demo",
+  source: "demo-data",
+};
+
+const manualProvenance: DataProvenance = {
+  confidence: "manual",
+  source: "user",
+};
+
+describe("ConfidenceBadge", () => {
+  it("renders verified badge with label", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    expect(screen.getByText("confidence.verified")).toBeInTheDocument();
+  });
+
+  it("renders estimated badge with label", () => {
+    render(<ConfidenceBadge provenance={estimatedProvenance} />);
+    expect(screen.getByText("confidence.estimated")).toBeInTheDocument();
+  });
+
+  it("renders demo badge with label", () => {
+    render(<ConfidenceBadge provenance={demoProvenance} />);
+    expect(screen.getByText("confidence.demo")).toBeInTheDocument();
+  });
+
+  it("renders manual badge with label", () => {
+    render(<ConfidenceBadge provenance={manualProvenance} />);
+    expect(screen.getByText("confidence.manual")).toBeInTheDocument();
+  });
+
+  it("hides label in compact mode", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} compact />);
+    expect(screen.queryByText("confidence.verified")).not.toBeInTheDocument();
+  });
+
+  it("has aria-label with data quality info", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const badge = screen.getByLabelText(/confidence\.dataQuality/);
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("includes fetch date in aria-label when available", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const badge = screen.getByLabelText(/confidence\.fetchedAt/);
+    expect(badge).toBeInTheDocument();
+  });
+
+  it("shows tooltip on hover", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const badge = screen.getByLabelText(/confidence\.dataQuality/);
+    fireEvent.mouseEnter(badge.parentElement!);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
+  it("tooltip shows source info", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const badge = screen.getByLabelText(/confidence\.dataQuality/);
+    fireEvent.mouseEnter(badge.parentElement!);
+    expect(screen.getByText("DVV")).toBeInTheDocument();
+  });
+
+  it("hides tooltip on mouse leave", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const wrapper = screen.getByLabelText(/confidence\.dataQuality/).parentElement!;
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("is focusable via tabIndex", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const badge = screen.getByLabelText(/confidence\.dataQuality/);
+    expect(badge).toHaveAttribute("tabindex", "0");
+  });
+
+  it("shows tooltip on focus", () => {
+    render(<ConfidenceBadge provenance={verifiedProvenance} />);
+    const badge = screen.getByLabelText(/confidence\.dataQuality/);
+    fireEvent.focus(badge.parentElement!);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+});
+
+describe("StalePriceBadge", () => {
+  it("renders stale price label", () => {
+    render(<StalePriceBadge lastUpdated="2024-01-01" />);
+    expect(screen.getByText("confidence.stalePrice")).toBeInTheDocument();
+  });
+
+  it("has correct aria-label", () => {
+    render(<StalePriceBadge lastUpdated="2024-01-01" />);
+    expect(screen.getByLabelText("confidence.stalePrice")).toBeInTheDocument();
+  });
+
+  it("renders without lastUpdated", () => {
+    render(<StalePriceBadge lastUpdated={null} />);
+    expect(screen.getByText("confidence.stalePrice")).toBeInTheDocument();
+  });
+
+  it("shows tooltip with stale detail on hover", () => {
+    render(<StalePriceBadge lastUpdated="2024-01-15" />);
+    const badge = screen.getByLabelText("confidence.stalePrice");
+    fireEvent.mouseEnter(badge.parentElement!);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
+  it("is focusable", () => {
+    render(<StalePriceBadge lastUpdated="2024-01-01" />);
+    const badge = screen.getByLabelText("confidence.stalePrice");
+    expect(badge).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/web/src/__tests__/skeleton.test.tsx
+++ b/web/src/__tests__/skeleton.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import {
+  SkeletonBlock,
+  Skeleton,
+  SkeletonProjectCard,
+  SkeletonTableRow,
+  SkeletonBomPanel,
+  SkeletonPriceComparison,
+  SkeletonProjectEditor,
+} from "@/components/Skeleton";
+
+describe("SkeletonBlock", () => {
+  it("renders with default dimensions", () => {
+    const { container } = render(<SkeletonBlock />);
+    const el = container.firstChild as HTMLElement;
+    expect(el).toHaveClass("skeleton");
+    expect(el.style.width).toBe("100%");
+    expect(el.style.height).toBe("16px");
+  });
+
+  it("accepts custom width and height", () => {
+    const { container } = render(<SkeletonBlock width={200} height={40} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe("200px");
+    expect(el.style.height).toBe("40px");
+  });
+
+  it("accepts string dimensions", () => {
+    const { container } = render(<SkeletonBlock width="50%" height="2rem" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe("50%");
+    expect(el.style.height).toBe("2rem");
+  });
+
+  it("applies custom border radius", () => {
+    const { container } = render(<SkeletonBlock radius="50%" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.borderRadius).toBe("50%");
+  });
+
+  it("merges extra style props", () => {
+    const { container } = render(<SkeletonBlock style={{ opacity: 0.5 }} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.opacity).toBe("0.5");
+  });
+});
+
+describe("Skeleton variants", () => {
+  it("text variant renders 14px tall by default", () => {
+    const { container } = render(<Skeleton variant="text" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.height).toBe("14px");
+  });
+
+  it("card variant renders 80px tall by default", () => {
+    const { container } = render(<Skeleton variant="card" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.height).toBe("80px");
+  });
+
+  it("circle variant renders 40x40 by default", () => {
+    const { container } = render(<Skeleton variant="circle" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe("40px");
+    expect(el.style.height).toBe("40px");
+    expect(el.style.borderRadius).toBe("50%");
+  });
+
+  it("rect variant renders 48px tall by default", () => {
+    const { container } = render(<Skeleton variant="rect" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.height).toBe("48px");
+  });
+
+  it("default variant is text", () => {
+    const { container } = render(<Skeleton />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.height).toBe("14px");
+  });
+
+  it("overrides default dimensions with props", () => {
+    const { container } = render(<Skeleton variant="circle" width={24} height={24} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe("24px");
+    expect(el.style.height).toBe("24px");
+  });
+});
+
+describe("Composite skeletons", () => {
+  it("SkeletonProjectCard renders without crashing", () => {
+    const { container } = render(<SkeletonProjectCard />);
+    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("SkeletonProjectCard accepts delay", () => {
+    const { container } = render(<SkeletonProjectCard delay={0.1} />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.style.animation).toContain("0.1s");
+  });
+
+  it("SkeletonTableRow renders correct number of columns", () => {
+    const { container } = render(
+      <table><tbody><SkeletonTableRow columns={3} /></tbody></table>,
+    );
+    expect(container.querySelectorAll("td")).toHaveLength(3);
+  });
+
+  it("SkeletonTableRow defaults to 5 columns", () => {
+    const { container } = render(
+      <table><tbody><SkeletonTableRow /></tbody></table>,
+    );
+    expect(container.querySelectorAll("td")).toHaveLength(5);
+  });
+
+  it("SkeletonBomPanel renders skeleton elements", () => {
+    const { container } = render(<SkeletonBomPanel />);
+    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("SkeletonPriceComparison renders 3 items", () => {
+    const { container } = render(<SkeletonPriceComparison />);
+    const items = container.querySelectorAll("[style*='border']");
+    expect(items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("SkeletonProjectEditor renders header and body sections", () => {
+    const { container } = render(<SkeletonProjectEditor />);
+    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/web/src/__tests__/waste-panel.test.tsx
+++ b/web/src/__tests__/waste-panel.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockGetWasteEstimate = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getWasteEstimate: (...args: unknown[]) => mockGetWasteEstimate(...args),
+  },
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import WasteEstimatePanel from "@/components/WasteEstimatePanel";
+import type { WasteEstimateResponse } from "@/types";
+
+const mockEstimate: WasteEstimateResponse = {
+  totalWeightKg: 450,
+  totalVolumeM3: 3.2,
+  totalDisposalCost: 120,
+  containerRecommendation: { count: 1, size: "4 m\u00B3", costEur: 250 },
+  categories: [
+    { type: "puujate", weightKg: 200, volumeM3: 1.5, recyclable: true, disposalCost: 0 },
+    { type: "metallijate", weightKg: 100, volumeM3: 0.4, recyclable: true, disposalCost: 0 },
+    { type: "sekajate", weightKg: 80, volumeM3: 0.8, recyclable: false, disposalCost: 80 },
+    { type: "vaarallinen_jate", weightKg: 70, volumeM3: 0.5, recyclable: false, disposalCost: 40 },
+  ],
+  sortingGuide: [
+    {
+      wasteType: "puujate",
+      sortingInstruction_fi: "Puhdas puu",
+      sortingInstruction_en: "Clean wood",
+      acceptedAt: "Sortti-asemat",
+    },
+    {
+      wasteType: "metallijate",
+      sortingInstruction_fi: "Puhdas metalli",
+      sortingInstruction_en: "Clean metal",
+      acceptedAt: "Sortti-asemat",
+    },
+    {
+      wasteType: "sekajate",
+      sortingInstruction_fi: "Sekajate",
+      sortingInstruction_en: "Mixed waste",
+      acceptedAt: "Sortti-asemat",
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetWasteEstimate.mockResolvedValue(mockEstimate);
+});
+
+describe("WasteEstimatePanel", () => {
+  it("shows title and subtitle", () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    expect(screen.getByText("waste.title")).toBeInTheDocument();
+    expect(screen.getByText("waste.subtitle")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no projectId", () => {
+    render(<WasteEstimatePanel bomCount={3} />);
+    expect(screen.getByText("waste.noWasteDesc")).toBeInTheDocument();
+  });
+
+  it("shows empty state when bomCount is 0", () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={0} />);
+    expect(screen.getByText("waste.noWasteDesc")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockGetWasteEstimate.mockReturnValue(new Promise(() => {}));
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    expect(screen.getByText("waste.estimateLoading")).toBeInTheDocument();
+  });
+
+  it("shows error state on API failure", async () => {
+    mockGetWasteEstimate.mockRejectedValue(new Error("fail"));
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText("waste.estimateFailed")).toBeInTheDocument();
+    });
+  });
+
+  it("renders summary boxes after loading", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText("waste.totalWeight")).toBeInTheDocument();
+      expect(screen.getByText("waste.totalVolume")).toBeInTheDocument();
+      expect(screen.getByText("waste.totalDisposalCost")).toBeInTheDocument();
+      expect(screen.getByText("waste.containerRecommendation")).toBeInTheDocument();
+    });
+  });
+
+  it("renders weight values", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText(/450/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders category breakdown", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText("waste.categories")).toBeInTheDocument();
+      expect(screen.getAllByText("waste.puujate").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("waste.metallijate").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("shows recyclable/not-recyclable labels", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      const recyclableLabels = screen.getAllByText("waste.recyclable");
+      const notRecyclableLabels = screen.getAllByText("waste.notRecyclable");
+      expect(recyclableLabels.length).toBe(2);
+      expect(notRecyclableLabels.length).toBe(2);
+    });
+  });
+
+  it("renders sorting guide entries", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText("waste.sortingGuide")).toBeInTheDocument();
+      expect(screen.getByText("Clean wood")).toBeInTheDocument();
+      expect(screen.getByText("Clean metal")).toBeInTheDocument();
+    });
+  });
+
+  it("shows recycling rate badge", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText(/waste\.recyclingRate/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows asbestos warning for pre-1994 buildings", async () => {
+    render(
+      <WasteEstimatePanel
+        projectId="p1"
+        bomCount={3}
+        buildingInfo={{ year_built: 1970 } as any}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/waste\.asbestosWarning/)).toBeInTheDocument();
+    });
+  });
+
+  it("does not show asbestos warning for post-1994 buildings", async () => {
+    render(
+      <WasteEstimatePanel
+        projectId="p1"
+        bomCount={3}
+        buildingInfo={{ year_built: 2000 } as any}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("waste.categories")).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/waste\.asbestosWarning/)).not.toBeInTheDocument();
+  });
+
+  it("shows container recommendation", async () => {
+    render(<WasteEstimatePanel projectId="p1" bomCount={3} />);
+    await waitFor(() => {
+      expect(screen.getByText(/1 x 4/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/waste-panel.test.tsx
+++ b/web/src/__tests__/waste-panel.test.tsx
@@ -28,12 +28,12 @@ const mockEstimate: WasteEstimateResponse = {
   totalWeightKg: 450,
   totalVolumeM3: 3.2,
   totalDisposalCost: 120,
-  containerRecommendation: { count: 1, size: "4 m\u00B3", costEur: 250 },
+  containerRecommendation: { count: 1, size: "4 m\u00B3", totalCost: 250 },
   categories: [
-    { type: "puujate", weightKg: 200, volumeM3: 1.5, recyclable: true, disposalCost: 0 },
-    { type: "metallijate", weightKg: 100, volumeM3: 0.4, recyclable: true, disposalCost: 0 },
-    { type: "sekajate", weightKg: 80, volumeM3: 0.8, recyclable: false, disposalCost: 80 },
-    { type: "vaarallinen_jate", weightKg: 70, volumeM3: 0.5, recyclable: false, disposalCost: 40 },
+    { type: "puujate", weightKg: 200, volumeM3: 1.5, recyclable: true, disposalCostEur: 0 },
+    { type: "metallijate", weightKg: 100, volumeM3: 0.4, recyclable: true, disposalCostEur: 0 },
+    { type: "sekajate", weightKg: 80, volumeM3: 0.8, recyclable: false, disposalCostEur: 80 },
+    { type: "vaarallinen_jate", weightKg: 70, volumeM3: 0.5, recyclable: false, disposalCostEur: 40 },
   ],
   sortingGuide: [
     {


### PR DESCRIPTION
## Summary
- 18 tests for `Skeleton` — SkeletonBlock defaults, all 4 variants (text/card/circle/rect), 5 composite skeletons (ProjectCard, TableRow, BomPanel, PriceComparison, ProjectEditor)
- 17 tests for `ConfidenceBadge` + `StalePriceBadge` — all 4 confidence levels, compact mode, tooltip hover/focus, aria-labels, source display
- 14 tests for `WasteEstimatePanel` — loading/error/empty states, summary boxes, category breakdown, recycling labels, sorting guide, asbestos warning, container recommendation

## Test plan
- [x] All 49 tests pass locally
- [x] WasteEstimatePanel tests mock API; Skeleton and ConfidenceBadge are pure render tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)