### PR TITLE
test: 27 tests for EmailVerificationBanner, KeyboardShortcutsHelp, ScrollReveal

### DIFF
--- a/web/src/__tests__/email-verification.test.tsx
+++ b/web/src/__tests__/email-verification.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockResendVerification = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    resendVerification: (...args: unknown[]) => mockResendVerification(...args),
+  },
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import EmailVerificationBanner from "@/components/EmailVerificationBanner";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResendVerification.mockResolvedValue({});
+});
+
+describe("EmailVerificationBanner", () => {
+  it("renders banner when email not verified", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    expect(screen.getByText("emailVerification.banner")).toBeInTheDocument();
+  });
+
+  it("returns null when email is verified", () => {
+    const { container } = render(<EmailVerificationBanner emailVerified={true} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows resend button", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    expect(screen.getByText("emailVerification.resend")).toBeInTheDocument();
+  });
+
+  it("calls resendVerification on button click", async () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByText("emailVerification.resend"));
+    await waitFor(() => {
+      expect(mockResendVerification).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("shows resent confirmation after successful resend", async () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByText("emailVerification.resend"));
+    await waitFor(() => {
+      expect(screen.getByText("emailVerification.resent")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error toast on resend failure", async () => {
+    mockResendVerification.mockRejectedValue(new Error("fail"));
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByText("emailVerification.resend"));
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith("emailVerification.resendFailed", "error");
+    });
+  });
+
+  it("dismisses on close button click", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByLabelText("emailVerification.dismiss"));
+    expect(screen.queryByText("emailVerification.banner")).not.toBeInTheDocument();
+  });
+
+  it("has dismiss button with aria-label", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    expect(screen.getByLabelText("emailVerification.dismiss")).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/keyboard-shortcuts-help.test.tsx
+++ b/web/src/__tests__/keyboard-shortcuts-help.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+import KeyboardShortcutsHelp from "@/components/KeyboardShortcutsHelp";
+import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
+
+const mockShortcuts: KeyboardShortcut[] = [
+  { key: "Ctrl+S", code: "s", mod: true, descriptionKey: "shortcuts.save", action: vi.fn() },
+  { key: "Ctrl+Z", code: "z", mod: true, descriptionKey: "shortcuts.undo", action: vi.fn() },
+  { key: "Ctrl+Shift+Z", code: "z", mod: true, shift: true, descriptionKey: "shortcuts.redo", action: vi.fn() },
+  { key: "Enter", code: "Enter", descriptionKey: "shortcuts.run", action: vi.fn() },
+  { key: "/", code: "/", descriptionKey: "shortcuts.search", action: vi.fn() },
+];
+
+describe("KeyboardShortcutsHelp", () => {
+  it("returns null when not open", () => {
+    const { container } = render(
+      <KeyboardShortcutsHelp open={false} onClose={vi.fn()} shortcuts={mockShortcuts} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders dialog when open", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("shows dialog title", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    expect(screen.getByText("shortcuts.title")).toBeInTheDocument();
+  });
+
+  it("renders all shortcut descriptions", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    expect(screen.getByText("shortcuts.save")).toBeInTheDocument();
+    expect(screen.getByText("shortcuts.undo")).toBeInTheDocument();
+    expect(screen.getByText("shortcuts.redo")).toBeInTheDocument();
+    expect(screen.getByText("shortcuts.run")).toBeInTheDocument();
+    expect(screen.getByText("shortcuts.search")).toBeInTheDocument();
+  });
+
+  it("renders kbd elements for each shortcut", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    const kbds = document.querySelectorAll("kbd");
+    expect(kbds.length).toBe(mockShortcuts.length);
+  });
+
+  it("shows close button with aria-label", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    expect(screen.getByLabelText("shortcuts.close")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<KeyboardShortcutsHelp open={true} onClose={onClose} shortcuts={mockShortcuts} />);
+    fireEvent.click(screen.getByLabelText("shortcuts.close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on Escape key", () => {
+    const onClose = vi.fn();
+    render(<KeyboardShortcutsHelp open={true} onClose={onClose} shortcuts={mockShortcuts} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows escape hint footer", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    expect(screen.getByText("shortcuts.escToClose")).toBeInTheDocument();
+  });
+
+  it("has aria-modal attribute", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("formats Ctrl modifier on non-Mac", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    const kbds = document.querySelectorAll("kbd");
+    const saveKbd = kbds[0];
+    expect(saveKbd.textContent).toContain("Ctrl");
+    expect(saveKbd.textContent).toContain("S");
+  });
+
+  it("formats Enter key symbol", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    const kbds = document.querySelectorAll("kbd");
+    const enterKbd = Array.from(kbds).find((kbd) => kbd.textContent?.includes("\u23CE"));
+    expect(enterKbd).toBeTruthy();
+  });
+
+  it("formats Shift modifier", () => {
+    render(<KeyboardShortcutsHelp open={true} onClose={vi.fn()} shortcuts={mockShortcuts} />);
+    const kbds = document.querySelectorAll("kbd");
+    const redoKbd = kbds[2];
+    expect(redoKbd.textContent).toContain("Shift");
+  });
+});

--- a/web/src/__tests__/scroll-reveal.test.tsx
+++ b/web/src/__tests__/scroll-reveal.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      custom,
+      ...rest
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      custom?: string;
+      [key: string]: unknown;
+    }) => (
+      <div className={className} data-custom={custom} data-testid="scroll-reveal">
+        {children}
+      </div>
+    ),
+  },
+}));
+
+import ScrollReveal from "@/components/ScrollReveal";
+
+describe("ScrollReveal", () => {
+  it("renders children", () => {
+    render(<ScrollReveal><span>Hello</span></ScrollReveal>);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("applies className", () => {
+    render(<ScrollReveal className="my-class"><span>Content</span></ScrollReveal>);
+    const el = screen.getByTestId("scroll-reveal");
+    expect(el).toHaveClass("my-class");
+  });
+
+  it("passes direction as custom prop", () => {
+    render(<ScrollReveal direction="left"><span>Left</span></ScrollReveal>);
+    const el = screen.getByTestId("scroll-reveal");
+    expect(el.dataset.custom).toBe("left");
+  });
+
+  it("defaults direction to up", () => {
+    render(<ScrollReveal><span>Default</span></ScrollReveal>);
+    const el = screen.getByTestId("scroll-reveal");
+    expect(el.dataset.custom).toBe("up");
+  });
+
+  it("renders with right direction", () => {
+    render(<ScrollReveal direction="right"><span>Right</span></ScrollReveal>);
+    const el = screen.getByTestId("scroll-reveal");
+    expect(el.dataset.custom).toBe("right");
+  });
+
+  it("renders without className when not provided", () => {
+    render(<ScrollReveal><span>No class</span></ScrollReveal>);
+    const el = screen.getByTestId("scroll-reveal");
+    expect(el.className).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- 8 tests for `EmailVerificationBanner` — render/hide states, resend API call, success confirmation, error toast, dismiss button
- 13 tests for `KeyboardShortcutsHelp` — dialog rendering, all shortcut descriptions, kbd formatting (Ctrl/Shift/Enter symbols), Escape close, aria-modal
- 6 tests for `ScrollReveal` — children rendering, className passthrough, direction variants (up/left/right) via framer-motion mock

## Test plan
- [x] All 27 tests pass locally
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] ScrollReveal uses framer-motion mock to avoid animation engine in jsdom

🤖 Generated with [Claude Code](https://claude.com/claude-code)