### PR TITLE
test: 36 tests for FeatureHighlights, LandingFooter, TemplateGrid, ViewportContextMenu

### DIFF
--- a/web/src/__tests__/landing-components.test.tsx
+++ b/web/src/__tests__/landing-components.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ScrollReveal", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div data-testid="scroll-reveal">{children}</div>,
+}));
+
+import FeatureHighlights from "@/components/FeatureHighlights";
+import LandingFooter from "@/components/LandingFooter";
+
+describe("FeatureHighlights", () => {
+  it("renders the feature section", () => {
+    render(<FeatureHighlights />);
+    expect(screen.getByText("landing.featuresTitle")).toBeInTheDocument();
+  });
+
+  it("renders the features label", () => {
+    render(<FeatureHighlights />);
+    expect(screen.getByText("landing.featuresLabel")).toBeInTheDocument();
+  });
+
+  it("renders three feature cards", () => {
+    render(<FeatureHighlights />);
+    expect(screen.getByText("landing.feature1Title")).toBeInTheDocument();
+    expect(screen.getByText("landing.feature2Title")).toBeInTheDocument();
+    expect(screen.getByText("landing.feature3Title")).toBeInTheDocument();
+  });
+
+  it("renders feature descriptions", () => {
+    render(<FeatureHighlights />);
+    expect(screen.getByText("landing.feature1Desc")).toBeInTheDocument();
+    expect(screen.getByText("landing.feature2Desc")).toBeInTheDocument();
+    expect(screen.getByText("landing.feature3Desc")).toBeInTheDocument();
+  });
+
+  it("renders step numbers 01, 02, 03", () => {
+    const { container } = render(<FeatureHighlights />);
+    const steps = container.querySelectorAll(".feature-card-step");
+    expect(steps).toHaveLength(3);
+    expect(steps[0].textContent).toBe("01");
+    expect(steps[1].textContent).toBe("02");
+    expect(steps[2].textContent).toBe("03");
+  });
+
+  it("marks first feature as hero", () => {
+    const { container } = render(<FeatureHighlights />);
+    const heroCards = container.querySelectorAll(".feature-card--hero");
+    expect(heroCards).toHaveLength(1);
+  });
+
+  it("has sr-only heading for a11y", () => {
+    render(<FeatureHighlights />);
+    const heading = screen.getByText("landing.featuresHeading");
+    expect(heading.className).toBe("sr-only");
+  });
+
+  it("wraps features in ScrollReveal", () => {
+    render(<FeatureHighlights />);
+    const reveals = screen.getAllByTestId("scroll-reveal");
+    expect(reveals.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("LandingFooter", () => {
+  it("renders the brand name", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("Hel")).toBeInTheDocument();
+    expect(screen.getByText("scoop")).toBeInTheDocument();
+  });
+
+  it("renders footer description", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.footerDescription")).toBeInTheDocument();
+  });
+
+  it("renders data source names", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("DVV")).toBeInTheDocument();
+    expect(screen.getByText("MML")).toBeInTheDocument();
+    expect(screen.getByText("K-Rauta")).toBeInTheDocument();
+    expect(screen.getByText("Stark")).toBeInTheDocument();
+  });
+
+  it("renders data sources label", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.dataSources")).toBeInTheDocument();
+  });
+
+  it("renders privacy and terms links", () => {
+    render(<LandingFooter />);
+    const privacyLink = screen.getByText("landing.privacyPolicy");
+    const termsLink = screen.getByText("landing.termsOfService");
+    expect(privacyLink.closest("a")).toHaveAttribute("href", "/privacy");
+    expect(termsLink.closest("a")).toHaveAttribute("href", "/terms");
+  });
+
+  it("renders current year in copyright", () => {
+    render(<LandingFooter />);
+    const year = new Date().getFullYear();
+    expect(screen.getByText(new RegExp(`${year}`))).toBeInTheDocument();
+  });
+
+  it("renders Helsinki location", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("Helsinki, Finland")).toBeInTheDocument();
+  });
+
+  it("renders EU data disclaimer", () => {
+    render(<LandingFooter />);
+    const year = new Date().getFullYear();
+    const copyrightEl = screen.getByText(new RegExp(`${year}`));
+    expect(copyrightEl.textContent).toContain("landing.dataInEu");
+  });
+});

--- a/web/src/__tests__/template-grid.test.tsx
+++ b/web/src/__tests__/template-grid.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import TemplateGrid from "@/components/TemplateGrid";
+import type { Template } from "@/types";
+
+const mockTemplates: Template[] = [
+  {
+    id: "t1",
+    name: "Sauna Renovation",
+    description: "A cozy sauna project",
+    icon: "sauna",
+    estimated_cost: 8500,
+    scene_js: "// sauna",
+    bom: [{ material_id: "m1", quantity: 10, unit: "kpl" }],
+  },
+  {
+    id: "t2",
+    name: "Garage Build",
+    description: "Double garage with storage",
+    icon: "garage",
+    estimated_cost: 15000,
+    scene_js: "// garage",
+    bom: [],
+  },
+];
+
+describe("TemplateGrid", () => {
+  it("renders section label", () => {
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(screen.getByText("project.orStartFromTemplate")).toBeInTheDocument();
+  });
+
+  it("renders template names", () => {
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(screen.getByText("Sauna Renovation")).toBeInTheDocument();
+    expect(screen.getByText("Garage Build")).toBeInTheDocument();
+  });
+
+  it("renders template descriptions", () => {
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(screen.getByText("A cozy sauna project")).toBeInTheDocument();
+    expect(screen.getByText("Double garage with storage")).toBeInTheDocument();
+  });
+
+  it("renders cost badges", () => {
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(screen.getByText(/8,500/)).toBeInTheDocument();
+    expect(screen.getByText(/15,000/)).toBeInTheDocument();
+  });
+
+  it("fires onCreateFromTemplate when clicked", () => {
+    const onCreate = vi.fn();
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={false} onCreateFromTemplate={onCreate} />,
+    );
+    fireEvent.click(screen.getByText("Sauna Renovation"));
+    expect(onCreate).toHaveBeenCalledWith(mockTemplates[0]);
+  });
+
+  it("disables buttons when creating", () => {
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={true} onCreateFromTemplate={vi.fn()} />,
+    );
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it("has aria-label with template name", () => {
+    render(
+      <TemplateGrid templates={mockTemplates} loading={false} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/project\.useTemplate.*Sauna/)).toBeInTheDocument();
+  });
+
+  it("shows skeleton loaders when loading", () => {
+    const { container } = render(
+      <TemplateGrid templates={[]} loading={true} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
+  });
+
+  it("renders nothing for empty templates list", () => {
+    const { container } = render(
+      <TemplateGrid templates={[]} loading={false} creating={false} onCreateFromTemplate={vi.fn()} />,
+    );
+    expect(screen.getByText("project.orStartFromTemplate")).toBeInTheDocument();
+    expect(container.querySelector(".template-grid")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/viewport-context-menu.test.tsx
+++ b/web/src/__tests__/viewport-context-menu.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+let rafCallback: ((ts: number) => void) | null = null;
+vi.stubGlobal("requestAnimationFrame", (cb: (ts: number) => void) => {
+  rafCallback = cb;
+  return 1;
+});
+
+import ViewportContextMenu from "@/components/ViewportContextMenu";
+import type { ContextMenuItem } from "@/components/ViewportContextMenu";
+
+const mockItems: ContextMenuItem[] = [
+  { id: "delete", label: "Delete", icon: "M3 6h18M8 6V4h8v2M5 6v12a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V6", onClick: vi.fn() },
+  { id: "copy", label: "Copy", icon: "M8 4v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V8l-6-4", onClick: vi.fn() },
+  { id: "rotate", label: "Rotate", icon: "M23 4v6h-6M1 20v-6h6", onClick: vi.fn(), active: true },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rafCallback = null;
+});
+
+function renderOpen(onClose = vi.fn()) {
+  const result = render(
+    <ViewportContextMenu items={mockItems} position={{ x: 400, y: 300 }} onClose={onClose} />,
+  );
+  if (rafCallback) act(() => rafCallback!(0));
+  return { ...result, onClose };
+}
+
+describe("ViewportContextMenu", () => {
+  it("returns null when position is null", () => {
+    const { container } = render(
+      <ViewportContextMenu items={mockItems} position={null} onClose={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders menu when position is provided", () => {
+    renderOpen();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("renders all menu items", () => {
+    renderOpen();
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems).toHaveLength(3);
+  });
+
+  it("has aria-label on menu items", () => {
+    renderOpen();
+    expect(screen.getByLabelText("Delete")).toBeInTheDocument();
+    expect(screen.getByLabelText("Copy")).toBeInTheDocument();
+    expect(screen.getByLabelText("Rotate")).toBeInTheDocument();
+  });
+
+  it("has menu aria-label", () => {
+    renderOpen();
+    expect(screen.getByRole("menu")).toHaveAttribute("aria-label", "viewport.contextMenuLabel");
+  });
+
+  it("calls onClick and onClose when item is clicked", () => {
+    const onClose = vi.fn();
+    renderOpen(onClose);
+    fireEvent.click(screen.getByLabelText("Delete"));
+    expect(mockItems[0].onClick).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("calls onClose on Escape key", () => {
+    const onClose = vi.fn();
+    renderOpen(onClose);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("navigates items with ArrowDown", () => {
+    renderOpen();
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    const items = screen.getAllByRole("menuitem");
+    expect(items[1]).toHaveFocus();
+  });
+
+  it("navigates items with ArrowUp (wraps around)", () => {
+    renderOpen();
+    fireEvent.keyDown(window, { key: "ArrowUp" });
+    const items = screen.getAllByRole("menuitem");
+    expect(items[2]).toHaveFocus();
+  });
+
+  it("activates item with Enter key", () => {
+    const onClose = vi.fn();
+    renderOpen(onClose);
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(mockItems[0].onClick).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("first item has tabIndex 0, others have -1", () => {
+    renderOpen();
+    const items = screen.getAllByRole("menuitem");
+    expect(items[0]).toHaveAttribute("tabindex", "0");
+    expect(items[1]).toHaveAttribute("tabindex", "-1");
+    expect(items[2]).toHaveAttribute("tabindex", "-1");
+  });
+});


### PR DESCRIPTION
## Summary
- 16 tests for FeatureHighlights and LandingFooter (feature cards, step numbers, hero variant, sr-only a11y heading, brand rendering, data sources, copyright, EU disclaimer)
- 9 tests for TemplateGrid (rendering, cost badges, click handler, disabled state, skeleton loaders, empty state)
- 11 tests for ViewportContextMenu (radial menu rendering, keyboard navigation with ArrowUp/ArrowDown wrap, Enter activation, Escape close, tabIndex management)

## Test plan
- [x] All 36 tests pass via `npx vitest run`
- [x] Type-check clean via `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)