### PR TITLE
test: 63 tests for LanguageSwitcher, ThemeToggle, EditorStatusBar, HouseholdDeductionPanel, RenovationRoiPanel

### DIFF
--- a/web/src/__tests__/editor-status-bar.test.tsx
+++ b/web/src/__tests__/editor-status-bar.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import EditorStatusBar from "@/components/EditorStatusBar";
+
+const baseProps = {
+  objectCount: 12,
+  materialCount: 5,
+  scriptByteSize: 2048,
+  saveStatus: "saved" as const,
+  lastSavedAt: null,
+  warningCount: 0,
+};
+
+describe("EditorStatusBar", () => {
+  it("renders object count", () => {
+    render(<EditorStatusBar {...baseProps} />);
+    expect(screen.getByText(/editor\.objectCount/)).toBeInTheDocument();
+  });
+
+  it("renders material count", () => {
+    render(<EditorStatusBar {...baseProps} />);
+    expect(screen.getByText(/5/)).toBeInTheDocument();
+    expect(screen.getByText(/editor\.statusMaterials/)).toBeInTheDocument();
+  });
+
+  it("formats bytes as KB", () => {
+    render(<EditorStatusBar {...baseProps} scriptByteSize={2048} />);
+    expect(screen.getByText("2.0 KB")).toBeInTheDocument();
+  });
+
+  it("formats bytes under 1024 as B", () => {
+    render(<EditorStatusBar {...baseProps} scriptByteSize={500} />);
+    expect(screen.getByText("500 B")).toBeInTheDocument();
+  });
+
+  it("shows saved status text", () => {
+    render(<EditorStatusBar {...baseProps} saveStatus="saved" />);
+    expect(screen.getByText("editor.saved")).toBeInTheDocument();
+  });
+
+  it("shows saving status text", () => {
+    render(<EditorStatusBar {...baseProps} saveStatus="saving" />);
+    expect(screen.getByText("editor.saving")).toBeInTheDocument();
+  });
+
+  it("shows error status text", () => {
+    render(<EditorStatusBar {...baseProps} saveStatus="error" />);
+    expect(screen.getByText("editor.saveFailed")).toBeInTheDocument();
+  });
+
+  it("shows unsaved status text", () => {
+    render(<EditorStatusBar {...baseProps} saveStatus="unsaved" />);
+    expect(screen.getByText("editor.unsaved")).toBeInTheDocument();
+  });
+
+  it("hides warnings when count is 0", () => {
+    render(<EditorStatusBar {...baseProps} warningCount={0} />);
+    expect(screen.queryByText(/editor\.statusWarning/)).not.toBeInTheDocument();
+  });
+
+  it("shows singular warning label for 1 warning", () => {
+    render(<EditorStatusBar {...baseProps} warningCount={1} />);
+    expect(screen.getByText(/1 editor\.statusWarning$/)).toBeInTheDocument();
+  });
+
+  it("shows plural warning label for multiple warnings", () => {
+    render(<EditorStatusBar {...baseProps} warningCount={3} />);
+    expect(screen.getByText(/3 editor\.statusWarnings/)).toBeInTheDocument();
+  });
+
+  it("formats lastSavedAt as relative time", () => {
+    const thirtySecsAgo = new Date(Date.now() - 30000);
+    render(<EditorStatusBar {...baseProps} lastSavedAt={thirtySecsAgo} />);
+    expect(screen.getByText("30s ago")).toBeInTheDocument();
+  });
+
+  it("shows 'just now' for recent saves", () => {
+    const justNow = new Date(Date.now() - 3000);
+    render(<EditorStatusBar {...baseProps} lastSavedAt={justNow} />);
+    expect(screen.getByText("just now")).toBeInTheDocument();
+  });
+
+  it("shows minutes for older saves", () => {
+    const twoMinsAgo = new Date(Date.now() - 120000);
+    render(<EditorStatusBar {...baseProps} lastSavedAt={twoMinsAgo} />);
+    expect(screen.getByText("2m ago")).toBeInTheDocument();
+  });
+
+  it("has status pulse class when saving", () => {
+    const { container } = render(<EditorStatusBar {...baseProps} saveStatus="saving" />);
+    expect(container.querySelector(".status-pulse")).toBeInTheDocument();
+  });
+
+  it("has no-print class", () => {
+    const { container } = render(<EditorStatusBar {...baseProps} />);
+    expect(container.querySelector(".no-print")).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/household-deduction-panel.test.tsx
+++ b/web/src/__tests__/household-deduction-panel.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockCalculateHouseholdDeduction = vi.fn();
+const mockBuildRows = vi.fn();
+const mockCalculateQuote = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/lib/quote-engine", () => ({
+  calculateQuote: (...args: unknown[]) => mockCalculateQuote(...args),
+  defaultQuoteConfig: () => ({ type: "homeowner" }),
+}));
+
+vi.mock("@/lib/household-deduction", () => ({
+  HOUSEHOLD_DEDUCTION_2026: {
+    companyWorkRate: 0.35,
+    annualThresholdPerClaimant: 150,
+    maxCreditPerClaimant: 1600,
+    sourceUrl: "https://www.vero.fi/en/individuals/deductions/Tax-credit-for-household-expenses/calculator-for-tax-credit-for-household-expenses/",
+  },
+  buildHouseholdDeductionRows: (...args: unknown[]) => mockBuildRows(...args),
+  calculateHouseholdDeduction: (...args: unknown[]) => mockCalculateHouseholdDeduction(...args),
+}));
+
+import HouseholdDeductionPanel from "@/components/HouseholdDeductionPanel";
+import type { BomItem, Material } from "@/types";
+
+const mockBom: BomItem[] = [
+  { material_id: "m1", quantity: 10, unit: "kpl" },
+];
+
+const mockMaterials: Material[] = [
+  {
+    id: "m1",
+    name: "Board",
+    name_fi: "Lauta",
+    name_en: "Board",
+    category_name: "wood",
+    category_name_fi: "puu",
+    image_url: null,
+    pricing: [{ unit_price: 5, unit: "kpl", supplier_name: "K-Rauta", is_primary: true }],
+  },
+];
+
+const mockDeduction = {
+  grossCost: 5000,
+  labourCost: 1750,
+  rawCredit: 612.5,
+  threshold: 150,
+  maxCredit: 1600,
+  credit: 462.5,
+  netCost: 4537.5,
+  claimantCount: 1 as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCalculateQuote.mockReturnValue({ totalLabour: 1750 });
+  mockBuildRows.mockReturnValue([]);
+  mockCalculateHouseholdDeduction.mockReturnValue(mockDeduction);
+});
+
+describe("HouseholdDeductionPanel", () => {
+  it("returns null for empty bom", () => {
+    const { container } = render(
+      <HouseholdDeductionPanel bom={[]} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders section with aria-label", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByLabelText("householdDeduction.title")).toBeInTheDocument();
+  });
+
+  it("renders eyebrow text", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText("householdDeduction.eyebrow")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText("householdDeduction.title")).toBeInTheDocument();
+  });
+
+  it("renders couple mode checkbox", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+    expect(screen.getByText("householdDeduction.coupleMode")).toBeInTheDocument();
+  });
+
+  it("fires onCoupleModeChange when toggled", () => {
+    const onChange = vi.fn();
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={onChange} />,
+    );
+    fireEvent.click(screen.getByRole("checkbox"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("renders labour basis amount", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText("householdDeduction.labourBasis")).toBeInTheDocument();
+    expect(screen.getByText(/1,750/)).toBeInTheDocument();
+  });
+
+  it("renders credit line with rate", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText(/householdDeduction\.credit/)).toBeInTheDocument();
+  });
+
+  it("renders net cost line", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText("householdDeduction.netCost")).toBeInTheDocument();
+  });
+
+  it("renders register warning", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText("householdDeduction.registerWarning")).toBeInTheDocument();
+  });
+
+  it("renders vero link", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    const link = screen.getByText("householdDeduction.veroLink");
+    expect(link.closest("a")).toHaveAttribute("href", expect.stringContaining("vero.fi"));
+  });
+
+  it("renders pro CTA button", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText("householdDeduction.proCta")).toBeInTheDocument();
+  });
+
+  it("shows cap note when credit > 0", () => {
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText(/householdDeduction\.capNote/)).toBeInTheDocument();
+  });
+
+  it("shows threshold note when credit is 0", () => {
+    mockCalculateHouseholdDeduction.mockReturnValue({ ...mockDeduction, credit: 0 });
+    render(
+      <HouseholdDeductionPanel bom={mockBom} materials={mockMaterials} coupleMode={false} onCoupleModeChange={vi.fn()} />,
+    );
+    expect(screen.getByText(/householdDeduction\.thresholdNote/)).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/language-switcher.test.tsx
+++ b/web/src/__tests__/language-switcher.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockSetLocale = vi.fn();
+let mockLocale = "en";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: mockLocale,
+    setLocale: mockSetLocale,
+    t: (key: string) => key,
+  }),
+}));
+
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+
+describe("LanguageSwitcher", () => {
+  it("renders FI and EN labels", () => {
+    render(<LanguageSwitcher />);
+    expect(screen.getByText("FI")).toBeInTheDocument();
+    expect(screen.getByText("EN")).toBeInTheDocument();
+  });
+
+  it("has aria-label", () => {
+    render(<LanguageSwitcher />);
+    expect(screen.getByLabelText("aria.switchLanguage")).toBeInTheDocument();
+  });
+
+  it("switches from en to fi on click", () => {
+    mockLocale = "en";
+    render(<LanguageSwitcher />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockSetLocale).toHaveBeenCalledWith("fi");
+  });
+
+  it("switches from fi to en on click", () => {
+    mockLocale = "fi";
+    render(<LanguageSwitcher />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockSetLocale).toHaveBeenCalledWith("en");
+  });
+
+  it("renders separator", () => {
+    render(<LanguageSwitcher />);
+    expect(screen.getByText("|")).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/renovation-roi-panel.test.tsx
+++ b/web/src/__tests__/renovation-roi-panel.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockEstimateRoi = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/lib/renovation-roi", () => ({
+  estimateRenovationRoi: (...args: unknown[]) => mockEstimateRoi(...args),
+  ROI_MARKET_CONFIG_2026: {
+    sourceCheckedAt: "2026-04-21",
+    euribor12mPercent: 2.685,
+  },
+}));
+
+import RenovationRoiPanel from "@/components/RenovationRoiPanel";
+import type { BomItem, Material } from "@/types";
+
+const mockBom: BomItem[] = [
+  { material_id: "m1", quantity: 10, unit: "kpl" },
+];
+
+const mockMaterials: Material[] = [
+  {
+    id: "m1",
+    name: "Insulation",
+    name_fi: "Eriste",
+    name_en: "Insulation",
+    category_name: "insulation",
+    category_name_fi: "eristys",
+    image_url: null,
+    pricing: [{ unit_price: 12, unit: "m2", supplier_name: "Stark", is_primary: true }],
+  },
+];
+
+const mockEstimate = {
+  category: "energy" as const,
+  materialCost: 3000,
+  labourCost: 2000,
+  grossCost: 5000,
+  bestSubsidy: { type: "household_deduction" as const, amount: 700, warning: "Apply by Dec 2026" },
+  netCost: 4300,
+  estimatedValueIncrease: 8000,
+  valueRetentionRate: 0.6,
+  annualEnergySavings: 500,
+  paybackYears: 6.2,
+  roiPercent: 74,
+  timing: {
+    status: "act_now" as const,
+    headline: "Good time to renovate",
+    reasons: ["Low interest rates", "Contractor availability"],
+  },
+  assumptions: [],
+  summary: "Positive ROI expected",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEstimateRoi.mockReturnValue(mockEstimate);
+});
+
+describe("RenovationRoiPanel", () => {
+  it("returns null when estimate is null", () => {
+    mockEstimateRoi.mockReturnValue(null);
+    const { container } = render(
+      <RenovationRoiPanel bom={mockBom} materials={mockMaterials} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders section with aria-label", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByLabelText("renovationRoi.title")).toBeInTheDocument();
+  });
+
+  it("renders eyebrow text", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.eyebrow")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.title")).toBeInTheDocument();
+  });
+
+  it("renders category badge", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.category.energy")).toBeInTheDocument();
+  });
+
+  it("renders gross cost metric", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.grossCost")).toBeInTheDocument();
+    expect(screen.getByText(/5,000/)).toBeInTheDocument();
+  });
+
+  it("renders net cost metric", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.netCost")).toBeInTheDocument();
+    expect(screen.getByText(/4,300/)).toBeInTheDocument();
+  });
+
+  it("renders material cost metric", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.materialCost")).toBeInTheDocument();
+    expect(screen.getByText(/3,000/)).toBeInTheDocument();
+  });
+
+  it("renders labour cost metric", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.labourCost")).toBeInTheDocument();
+    expect(screen.getByText(/2,000/)).toBeInTheDocument();
+  });
+
+  it("renders subsidy amount", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.bestSubsidy")).toBeInTheDocument();
+    expect(screen.getByText(/-700/)).toBeInTheDocument();
+  });
+
+  it("renders value impact", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.valueImpact")).toBeInTheDocument();
+    expect(screen.getByText(/8,000/)).toBeInTheDocument();
+  });
+
+  it("renders energy payback years", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.energyPayback")).toBeInTheDocument();
+    expect(screen.getByText(/6.2/)).toBeInTheDocument();
+  });
+
+  it("renders no payback text when null", () => {
+    mockEstimateRoi.mockReturnValue({ ...mockEstimate, paybackYears: null });
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("No energy payback")).toBeInTheDocument();
+  });
+
+  it("renders positive ROI percent", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("renovationRoi.tenYearRoi")).toBeInTheDocument();
+    expect(screen.getByText("+74%")).toBeInTheDocument();
+  });
+
+  it("renders negative ROI without plus sign", () => {
+    mockEstimateRoi.mockReturnValue({ ...mockEstimate, roiPercent: -12 });
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("-12%")).toBeInTheDocument();
+  });
+
+  it("renders timing headline", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("Good time to renovate")).toBeInTheDocument();
+  });
+
+  it("renders timing reasons", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("Low interest rates")).toBeInTheDocument();
+    expect(screen.getByText("Contractor availability")).toBeInTheDocument();
+  });
+
+  it("renders subsidy warning", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText("Apply by Dec 2026")).toBeInTheDocument();
+  });
+
+  it("renders assumption note with config values", () => {
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    expect(screen.getByText(/renovationRoi\.assumptionNote/)).toBeInTheDocument();
+  });
+
+  it("shows 0 for subsidy when amount is 0", () => {
+    mockEstimateRoi.mockReturnValue({
+      ...mockEstimate,
+      bestSubsidy: { type: "none", amount: 0, warning: "" },
+    });
+    render(<RenovationRoiPanel bom={mockBom} materials={mockMaterials} />);
+    const subsidyLabel = screen.getByText("renovationRoi.bestSubsidy");
+    const subsidyMetric = subsidyLabel.closest("div")!.parentElement!;
+    expect(subsidyMetric.textContent).toContain("0 €");
+  });
+});

--- a/web/src/__tests__/theme-toggle.test.tsx
+++ b/web/src/__tests__/theme-toggle.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockToggle = vi.fn();
+let mockTheme = "dark";
+
+vi.mock("@/components/ThemeProvider", () => ({
+  useTheme: () => ({ theme: mockTheme, toggle: mockToggle }),
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+import { ThemeToggle } from "@/components/ThemeToggle";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ThemeToggle", () => {
+  it("renders dark theme label", () => {
+    mockTheme = "dark";
+    render(<ThemeToggle />);
+    expect(screen.getByLabelText("aria.themeDark")).toBeInTheDocument();
+  });
+
+  it("renders light theme label", () => {
+    mockTheme = "light";
+    render(<ThemeToggle />);
+    expect(screen.getByLabelText("aria.themeLight")).toBeInTheDocument();
+  });
+
+  it("renders auto theme label", () => {
+    mockTheme = "auto";
+    render(<ThemeToggle />);
+    expect(screen.getByLabelText("aria.themeAuto")).toBeInTheDocument();
+  });
+
+  it("calls toggle on click", () => {
+    mockTheme = "dark";
+    render(<ThemeToggle />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockToggle).toHaveBeenCalledOnce();
+  });
+
+  it("shows uppercase label text", () => {
+    mockTheme = "dark";
+    render(<ThemeToggle />);
+    expect(screen.getByText("ARIA.THEMEDARK")).toBeInTheDocument();
+  });
+
+  it("renders moon SVG for dark theme", () => {
+    mockTheme = "dark";
+    const { container } = render(<ThemeToggle />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders sun SVG for light theme", () => {
+    mockTheme = "light";
+    const { container } = render(<ThemeToggle />);
+    const circles = container.querySelectorAll("circle");
+    expect(circles.length).toBeGreaterThan(0);
+  });
+
+  it("renders monitor SVG for auto theme", () => {
+    mockTheme = "auto";
+    const { container } = render(<ThemeToggle />);
+    const rects = container.querySelectorAll("rect");
+    expect(rects.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- 5 tests for LanguageSwitcher (locale toggle, FI/EN labels, aria-label)
- 8 tests for ThemeToggle (dark/light/auto themes, SVG icons, click handler)
- 16 tests for EditorStatusBar (object/material counts, byte formatting, save status states, warning labels, relative time formatting, status pulse)
- 14 tests for HouseholdDeductionPanel (empty bom null, section label, eyebrow, couple mode toggle, labour/credit/net cost rows, cap/threshold notes, vero link, register warning)
- 20 tests for RenovationRoiPanel (null estimate, all 8 metrics, positive/negative ROI, payback years, timing headline/reasons, subsidy warning, assumption note)

## Test plan
- [x] All 63 tests pass via `npx vitest run`
- [x] Type-check clean via `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)