### PR TITLE
test: 33 tests for ProjectCard, HeroIllustration, BomSavingsPanel

### DIFF
--- a/web/src/__tests__/bom-savings-panel.test.tsx
+++ b/web/src/__tests__/bom-savings-panel.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockBuildSavingsRecommendations = vi.fn();
+const mockSumSavings = vi.fn();
+const mockTrack = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
+vi.mock("@/lib/bom-savings", () => ({
+  buildSavingsRecommendations: (...args: unknown[]) => mockBuildSavingsRecommendations(...args),
+  sumSavings: (...args: unknown[]) => mockSumSavings(...args),
+}));
+
+import BomSavingsPanel from "@/components/BomSavingsPanel";
+import type { BomItem, Material } from "@/types";
+
+const mockBom: BomItem[] = [
+  { material_id: "m1", quantity: 10, unit: "kpl" },
+];
+
+const mockMaterials: Material[] = [
+  {
+    id: "m1",
+    name: "Board",
+    name_fi: "Lauta",
+    name_en: "Board",
+    category_name: "wood",
+    category_name_fi: "puu",
+    image_url: null,
+    pricing: [{ unit_price: 5, unit: "kpl", supplier_name: "K-Rauta", is_primary: true }],
+  },
+];
+
+const mockRecommendation = {
+  id: "rec-1",
+  type: "supplier_switch" as const,
+  materialId: "m1",
+  materialName: "Board",
+  currentUnitPrice: 5,
+  targetUnitPrice: 3.5,
+  unit: "kpl",
+  savingsAmount: 15,
+  savingsPercent: 30,
+  fromSupplier: "K-Rauta",
+  toSupplier: "Stark",
+  link: null,
+  stockLevel: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBuildSavingsRecommendations.mockReturnValue([mockRecommendation]);
+  mockSumSavings.mockReturnValue(15);
+});
+
+describe("BomSavingsPanel", () => {
+  it("returns null for empty bom", () => {
+    const { container } = render(
+      <BomSavingsPanel
+        bom={[]}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders section with aria-label", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("bomSavings.title")).toBeInTheDocument();
+  });
+
+  it("renders eyebrow text", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("bomSavings.eyebrow")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("bomSavings.title")).toBeInTheDocument();
+  });
+
+  it("renders total savings", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("bomSavings.totalAvailable")).toBeInTheDocument();
+    const totalEl = screen.getByText("bomSavings.totalAvailable").closest(".bom-savings-total")!;
+    expect(totalEl.textContent).toContain("15");
+  });
+
+  it("renders saving type group toggles", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("bomSavings.supplier_switch")).toBeInTheDocument();
+    expect(screen.getByText("bomSavings.material_substitution")).toBeInTheDocument();
+    expect(screen.getByText("bomSavings.bulk_discount")).toBeInTheDocument();
+    expect(screen.getByText("bomSavings.seasonal_stock")).toBeInTheDocument();
+  });
+
+  it("shows no savings message when empty", () => {
+    mockBuildSavingsRecommendations.mockReturnValue([]);
+    mockSumSavings.mockReturnValue(0);
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("bomSavings.noSavings")).toBeInTheDocument();
+  });
+
+  it("renders recommendation text", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/bomSavings\.supplierSwitchText/)).toBeInTheDocument();
+  });
+
+  it("renders apply button", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onApplySupplierPrice={vi.fn()}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("bomSavings.applySupplier")).toBeInTheDocument();
+  });
+
+  it("calls onApplySupplierPrice when apply clicked", () => {
+    const onApply = vi.fn();
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onApplySupplierPrice={onApply}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("bomSavings.applySupplier"));
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        materialId: "m1",
+        unitPrice: 3.5,
+        unit: "kpl",
+        supplier: "Stark",
+      }),
+    );
+  });
+
+  it("tracks analytics on apply", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onApplySupplierPrice={vi.fn()}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("bomSavings.applySupplier"));
+    expect(mockTrack).toHaveBeenCalledWith("bom_optimization_applied", expect.objectContaining({ type: "supplier_switch" }));
+  });
+
+  it("dismisses recommendation on dismiss click", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("bom.dismiss"));
+    expect(mockTrack).toHaveBeenCalledWith("bom_optimization_dismissed", expect.objectContaining({ type: "supplier_switch" }));
+  });
+
+  it("toggles group expansion", () => {
+    render(
+      <BomSavingsPanel
+        bom={mockBom}
+        materials={mockMaterials}
+        onCompareMaterial={vi.fn()}
+        onOpenMaterialPicker={vi.fn()}
+      />,
+    );
+    const toggle = screen.getByText("bomSavings.supplier_switch").closest("button")!;
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/web/src/__tests__/hero-illustration.test.tsx
+++ b/web/src/__tests__/hero-illustration.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+import HeroIllustration from "@/components/HeroIllustration";
+
+describe("HeroIllustration", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it("renders SVG", () => {
+    vi.useFakeTimers();
+    const { container } = render(<HeroIllustration />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("starts hidden (opacity 0)", () => {
+    vi.useFakeTimers();
+    const { container } = render(<HeroIllustration />);
+    const wrapper = container.querySelector(".hero-illustration") as HTMLElement;
+    expect(wrapper.style.opacity).toBe("0");
+    vi.useRealTimers();
+  });
+
+  it("becomes visible after 200ms", () => {
+    vi.useFakeTimers();
+    const { container } = render(<HeroIllustration />);
+    act(() => { vi.advanceTimersByTime(200); });
+    const wrapper = container.querySelector(".hero-illustration") as HTMLElement;
+    expect(wrapper.style.opacity).toBe("1");
+    vi.useRealTimers();
+  });
+
+  it("has aria-hidden on SVG", () => {
+    vi.useFakeTimers();
+    const { container } = render(<HeroIllustration />);
+    expect(container.querySelector("svg")?.getAttribute("aria-hidden")).toBe("true");
+    vi.useRealTimers();
+  });
+
+  it("renders house elements", () => {
+    vi.useFakeTimers();
+    const { container } = render(<HeroIllustration />);
+    const rects = container.querySelectorAll("rect");
+    expect(rects.length).toBeGreaterThan(3);
+    vi.useRealTimers();
+  });
+
+  it("renders dimension text", () => {
+    vi.useFakeTimers();
+    render(<HeroIllustration />);
+    expect(screen.getByText("12 000")).toBeInTheDocument();
+    expect(screen.getByText("7 000")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+
+  it("has blueprint CSS classes", () => {
+    vi.useFakeTimers();
+    const { container } = render(<HeroIllustration />);
+    expect(container.querySelector(".bp-line")).toBeInTheDocument();
+    expect(container.querySelector(".bp-dim")).toBeInTheDocument();
+    expect(container.querySelector(".bp-text")).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+});

--- a/web/src/__tests__/project-card.test.tsx
+++ b/web/src/__tests__/project-card.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import ProjectCard from "@/components/ProjectCard";
+import type { Project } from "@/types";
+
+const mockProject: Project = {
+  id: "p1",
+  name: "Sauna Reno",
+  description: "Renovating the old sauna",
+  estimated_cost: 8500,
+  created_at: "2026-01-15T10:00:00Z",
+  updated_at: "2026-04-20T14:30:00Z",
+  thumbnail_url: null,
+  view_count: 42,
+};
+
+const mockOnDuplicate = vi.fn();
+const mockOnDelete = vi.fn();
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("ProjectCard", () => {
+  it("renders project name as link", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    const link = screen.getByText("Sauna Reno").closest("a");
+    expect(link).toHaveAttribute("href", "/project/p1");
+  });
+
+  it("renders project description", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.getByText("Renovating the old sauna")).toBeInTheDocument();
+  });
+
+  it("renders estimated cost badge", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.getByText(/8500/)).toBeInTheDocument();
+  });
+
+  it("hides cost badge when estimated_cost is 0", () => {
+    const noCost = { ...mockProject, estimated_cost: 0 };
+    const { container } = render(<ProjectCard project={noCost} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(container.querySelector(".badge-amber")).not.toBeInTheDocument();
+  });
+
+  it("renders view count badge", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.getByText(/project\.viewCount/)).toBeInTheDocument();
+  });
+
+  it("hides view count badge when 0", () => {
+    const noViews = { ...mockProject, view_count: 0 };
+    render(<ProjectCard project={noViews} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.queryByText(/project\.viewCount/)).not.toBeInTheDocument();
+  });
+
+  it("shows empty description placeholder", () => {
+    const noDesc = { ...mockProject, description: "" };
+    render(<ProjectCard project={noDesc} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.getByText("project.emptyDescription")).toBeInTheDocument();
+  });
+
+  it("renders date", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    const date = new Date("2026-04-20T14:30:00Z").toLocaleDateString("en-GB");
+    expect(screen.getByText(date)).toBeInTheDocument();
+  });
+
+  it("calls onDuplicate when copy button clicked", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText(/project\.copyAriaLabel/));
+    expect(mockOnDuplicate).toHaveBeenCalledWith("p1");
+  });
+
+  it("calls onDelete when delete button clicked", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    fireEvent.click(screen.getByLabelText(/project\.deleteAriaLabel/));
+    expect(mockOnDelete).toHaveBeenCalledWith("p1");
+  });
+
+  it("renders copy and delete buttons", () => {
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.getByText("project.copy")).toBeInTheDocument();
+    expect(screen.getByText("project.delete")).toBeInTheDocument();
+  });
+
+  it("shows placeholder SVG when no thumbnail", () => {
+    const { container } = render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("uses animation delay from index", () => {
+    const { container } = render(<ProjectCard project={mockProject} index={3} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    const card = container.querySelector(".project-card-grid") as HTMLElement;
+    expect(card.style.animationDelay).toBe("0.12s");
+  });
+});


### PR DESCRIPTION
## Summary
- 13 tests for ProjectCard (link, cost badge, view count, duplicate/delete)
- 7 tests for HeroIllustration (SVG, opacity fade-in, aria-hidden, dimensions)
- 13 tests for BomSavingsPanel (type groups, total savings, apply/dismiss/track)

## Test plan
- [x] All 33 tests pass
- [x] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)