### PR TITLE
test: 38 tests for SharePresentationPanel, useDraftRecovery, MaterialTrendDashboard

### DIFF
--- a/web/src/__tests__/draft-recovery.test.tsx
+++ b/web/src/__tests__/draft-recovery.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDraftRecovery } from "@/hooks/useDraftRecovery";
+
+const mockStorage: Record<string, string> = {};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  Object.keys(mockStorage).forEach((k) => delete mockStorage[k]);
+  vi.spyOn(Storage.prototype, "getItem").mockImplementation((key: string) => mockStorage[key] ?? null);
+  vi.spyOn(Storage.prototype, "setItem").mockImplementation((key: string, value: string) => {
+    mockStorage[key] = value;
+  });
+  vi.spyOn(Storage.prototype, "removeItem").mockImplementation((key: string) => {
+    delete mockStorage[key];
+  });
+});
+
+describe("useDraftRecovery", () => {
+  it("returns hasDraft false when no stored draft", () => {
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "script", "script", vi.fn()),
+    );
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("detects existing draft that differs from saved", () => {
+    mockStorage["helscoop-draft-p1"] = "modified script";
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "saved script", "saved script", vi.fn()),
+    );
+    expect(result.current.hasDraft).toBe(true);
+  });
+
+  it("does not detect draft when it matches saved", () => {
+    mockStorage["helscoop-draft-p1"] = "saved script";
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "saved script", "saved script", vi.fn()),
+    );
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("restores draft via onRestore callback", () => {
+    mockStorage["helscoop-draft-p1"] = "draft content";
+    const onRestore = vi.fn();
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "saved", "saved", onRestore),
+    );
+    act(() => { result.current.restore(); });
+    expect(onRestore).toHaveBeenCalledWith("draft content");
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("discards draft from localStorage", () => {
+    mockStorage["helscoop-draft-p1"] = "draft content";
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "saved", "saved", vi.fn()),
+    );
+    act(() => { result.current.discard(); });
+    expect(result.current.hasDraft).toBe(false);
+    expect(mockStorage["helscoop-draft-p1"]).toBeUndefined();
+  });
+
+  it("clearDraft removes from localStorage", () => {
+    mockStorage["helscoop-draft-p1"] = "draft content";
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "saved", "saved", vi.fn()),
+    );
+    act(() => { result.current.clearDraft(); });
+    expect(mockStorage["helscoop-draft-p1"]).toBeUndefined();
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("returns no draft when projectId is null", () => {
+    const { result } = renderHook(() =>
+      useDraftRecovery(null, "script", "script", vi.fn()),
+    );
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("saves draft to localStorage after debounce", () => {
+    const { result } = renderHook(() =>
+      useDraftRecovery("p1", "saved", "saved", vi.fn()),
+    );
+    // Tick past initial check
+    act(() => { vi.advanceTimersByTime(0); });
+    // Re-render with changed script
+    const { rerender } = renderHook(
+      ({ script }) => useDraftRecovery("p1", script, "saved", vi.fn()),
+      { initialProps: { script: "saved" } },
+    );
+    // Tick past initial check for the new hook instance
+    act(() => { vi.advanceTimersByTime(0); });
+    rerender({ script: "modified" });
+    // Before debounce — not yet saved
+    expect(mockStorage["helscoop-draft-p1"]).toBeUndefined();
+    // After debounce (2000ms)
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(mockStorage["helscoop-draft-p1"]).toBe("modified");
+
+    vi.useRealTimers();
+  });
+
+  it("clears draft when script matches saved", () => {
+    mockStorage["helscoop-draft-p1"] = "old draft";
+    const { rerender } = renderHook(
+      ({ script, saved }) => useDraftRecovery("p1", script, saved, vi.fn()),
+      { initialProps: { script: "modified", saved: "saved" } },
+    );
+    act(() => { vi.advanceTimersByTime(0); });
+    rerender({ script: "saved", saved: "saved" });
+    act(() => { vi.advanceTimersByTime(0); });
+    expect(mockStorage["helscoop-draft-p1"]).toBeUndefined();
+
+    vi.useRealTimers();
+  });
+});

--- a/web/src/__tests__/material-trend-dashboard.test.tsx
+++ b/web/src/__tests__/material-trend-dashboard.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockGetProjectMaterialTrends = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getProjectMaterialTrends: (...args: unknown[]) => mockGetProjectMaterialTrends(...args),
+  },
+}));
+
+import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
+import type { ProjectMaterialTrendResponse, MaterialTrendItem } from "@/types";
+
+const mockItem: MaterialTrendItem = {
+  materialId: "m1",
+  materialName: "Pine Board",
+  categoryName: "wood",
+  quantity: 20,
+  unit: "kpl",
+  currentUnitPrice: 4.5,
+  currentLineCost: 90,
+  average3m: 4.2,
+  average12m: 4.0,
+  vs3mPct: 7.1,
+  vs12mPct: 12.5,
+  direction: "rising",
+  recommendation: "wait",
+  bestBuyMonth: "2026-09",
+  estimatedWaitSavingsPct: 8,
+  estimatedWaitSavings: 7.2,
+  confidence: "medium",
+  source: "retailer_history",
+  points: [
+    { month: "2026-01", unitPrice: 3.8, source: "retailer_history" },
+    { month: "2026-02", unitPrice: 4.0, source: "retailer_history" },
+    { month: "2026-03", unitPrice: 4.5, source: "retailer_history" },
+  ],
+};
+
+const mockData: ProjectMaterialTrendResponse = {
+  projectId: "p1",
+  generatedAt: "2026-04-22T10:00:00Z",
+  dataSources: ["retailer_history"],
+  totalCurrentCost: 5000,
+  weightedVs12mPct: 5.3,
+  estimatedWaitSavings: 120,
+  bestBuyMonth: "2026-09",
+  buyNowCount: 2,
+  waitCount: 3,
+  watchCount: 1,
+  items: [mockItem],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProjectMaterialTrends.mockResolvedValue(mockData);
+});
+
+describe("MaterialTrendDashboard", () => {
+  it("returns null when no projectId", () => {
+    const { container } = render(
+      <MaterialTrendDashboard bomSignature="sig1" />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when no bomSignature", () => {
+    const { container } = render(
+      <MaterialTrendDashboard projectId="p1" bomSignature="" />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders section with aria-label after loading", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByLabelText("bomTrends.title")).toBeInTheDocument();
+    });
+  });
+
+  it("renders eyebrow text", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.eyebrow")).toBeInTheDocument();
+    });
+  });
+
+  it("renders title", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.title")).toBeInTheDocument();
+    });
+  });
+
+  it("renders data source badge for retailer history", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.source.retailer_history")).toBeInTheDocument();
+    });
+  });
+
+  it("renders above average trend text for positive pct", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/bomTrends\.aboveAverage/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders wait savings metric", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.waitSavings")).toBeInTheDocument();
+    });
+  });
+
+  it("renders best month metric", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.bestMonth")).toBeInTheDocument();
+    });
+  });
+
+  it("renders buy/wait/watch counts", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/bomTrends\.buyNowCount/)).toBeInTheDocument();
+      expect(screen.getByText(/bomTrends\.waitCount/)).toBeInTheDocument();
+      expect(screen.getByText(/bomTrends\.watchCount/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders material name in top items", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("Pine Board")).toBeInTheDocument();
+    });
+  });
+
+  it("renders recommendation for item", async () => {
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/bomTrends\.recommendation\.wait/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders sparkline SVG", async () => {
+    const { container } = render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      const svgs = container.querySelectorAll("svg[aria-hidden='true']");
+      expect(svgs.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("shows loading text initially", () => {
+    mockGetProjectMaterialTrends.mockReturnValue(new Promise(() => {}));
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    expect(screen.getByText("bomTrends.loading")).toBeInTheDocument();
+  });
+
+  it("returns null on API error with no data", async () => {
+    mockGetProjectMaterialTrends.mockRejectedValue(new Error("fail"));
+    const { container } = render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(container.querySelector("section")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows near average for small pct", async () => {
+    mockGetProjectMaterialTrends.mockResolvedValue({ ...mockData, weightedVs12mPct: 0.5 });
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.nearAverage")).toBeInTheDocument();
+    });
+  });
+
+  it("shows below average for negative pct", async () => {
+    mockGetProjectMaterialTrends.mockResolvedValue({ ...mockData, weightedVs12mPct: -5 });
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText(/bomTrends\.belowAverage/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows model note for seasonal model source", async () => {
+    mockGetProjectMaterialTrends.mockResolvedValue({
+      ...mockData,
+      dataSources: ["seasonal_model"],
+    });
+    render(<MaterialTrendDashboard projectId="p1" bomSignature="sig1" />);
+    await waitFor(() => {
+      expect(screen.getByText("bomTrends.modelNote")).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/share-presentation-panel.test.tsx
+++ b/web/src/__tests__/share-presentation-panel.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockTrack = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
+vi.mock("@/lib/presentation-export", () => ({
+  PRESENTATION_PRESETS: [
+    { id: "front", cameraIndex: 0, labelKey: "presentation.front", descriptionKey: "presentation.frontDesc" },
+    { id: "iso", cameraIndex: 3, labelKey: "presentation.iso", descriptionKey: "presentation.isoDesc" },
+  ],
+  getPresentationPreset: (id: string) => ({
+    id,
+    cameraIndex: 0,
+    labelKey: `presentation.${id}`,
+    descriptionKey: `presentation.${id}Desc`,
+  }),
+  buildPresentationUrl: (_origin: string, token: string, preset: string) =>
+    `https://example.com/p/${token}?preset=${preset}`,
+  formatPresentationCurrency: (amount: number) => `${amount} €`,
+  sanitizePresentationFilename: (name: string, preset: string) => `${name}_${preset}.png`,
+}));
+
+import SharePresentationPanel from "@/components/SharePresentationPanel";
+import type { BomItem } from "@/types";
+
+const mockBom: BomItem[] = [
+  { material_id: "m1", quantity: 5, unit: "kpl", total: 250 },
+  { material_id: "m2", quantity: 3, unit: "m2", total: 150 },
+];
+
+const mockCaptureApiRef = { current: null };
+const mockOnCopySuccess = vi.fn();
+const mockOnCopyError = vi.fn();
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("SharePresentationPanel", () => {
+  it("renders section with aria-label", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByLabelText("presentation.title")).toBeInTheDocument();
+  });
+
+  it("renders eyebrow text", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByText("presentation.eyebrow")).toBeInTheDocument();
+  });
+
+  it("renders title and description", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByText("presentation.title")).toBeInTheDocument();
+    expect(screen.getByText("presentation.description")).toBeInTheDocument();
+  });
+
+  it("renders total estimate", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByText("presentation.estimate")).toBeInTheDocument();
+    expect(screen.getByText("400 €")).toBeInTheDocument();
+  });
+
+  it("renders preset radio buttons", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    const radios = screen.getAllByRole("radio");
+    expect(radios.length).toBe(2);
+  });
+
+  it("selects iso preset by default", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    const isoRadio = screen.getAllByRole("radio").find((r) => r.getAttribute("aria-checked") === "true");
+    expect(isoRadio).toBeTruthy();
+  });
+
+  it("renders copy button", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByText("presentation.copyPresentation")).toBeInTheDocument();
+  });
+
+  it("renders download button", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByText("presentation.downloadWatermarked")).toBeInTheDocument();
+  });
+
+  it("disables download when no capture API", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={{ current: null }}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    const downloadBtn = screen.getByText("presentation.downloadWatermarked").closest("button")!;
+    expect(downloadBtn).toBeDisabled();
+  });
+
+  it("renders asset info", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByText("presentation.assetViewer")).toBeInTheDocument();
+    expect(screen.getByText(/presentation\.assetBom/)).toBeInTheDocument();
+  });
+
+  it("has radiogroup with aria-label", () => {
+    render(
+      <SharePresentationPanel
+        shareToken="abc123"
+        projectName="Test Project"
+        bom={mockBom}
+        captureApiRef={mockCaptureApiRef}
+        onCopySuccess={mockOnCopySuccess}
+        onCopyError={mockOnCopyError}
+      />,
+    );
+    expect(screen.getByRole("radiogroup")).toHaveAttribute("aria-label", "presentation.cameraPresets");
+  });
+});


### PR DESCRIPTION
## Summary
- 11 tests for SharePresentationPanel (section label, eyebrow, title, total estimate, preset radio buttons, copy/download buttons, disabled state, asset info, radiogroup a11y)
- 9 tests for useDraftRecovery hook (no draft, detect draft, match saved, restore callback, discard, clearDraft, null projectId, debounced save, clear on save match)
- 18 tests for MaterialTrendDashboard (null guards, loading state, API error, section/eyebrow/title, data source badge, trend text variants, metrics, buy/wait/watch counts, top items, sparkline, model note)

## Test plan
- [x] All 38 tests pass via `npx vitest run`
- [x] Type-check clean via `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)