### PR TITLE
test: 42 tests for ScreenshotPopover, QuoteRequestModal, ProjectVersionPanel

### DIFF
--- a/web/src/__tests__/project-version-panel.test.tsx
+++ b/web/src/__tests__/project-version-panel.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockGetProjectVersions = vi.fn();
+const mockCreateProjectVersion = vi.fn();
+const mockCreateProjectBranch = vi.fn();
+const mockRestoreProjectVersion = vi.fn();
+const mockCompareProjectVersions = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getProjectVersions: (...args: unknown[]) => mockGetProjectVersions(...args),
+    createProjectVersion: (...args: unknown[]) => mockCreateProjectVersion(...args),
+    createProjectBranch: (...args: unknown[]) => mockCreateProjectBranch(...args),
+    restoreProjectVersion: (...args: unknown[]) => mockRestoreProjectVersion(...args),
+    compareProjectVersions: (...args: unknown[]) => mockCompareProjectVersions(...args),
+  },
+}));
+
+import ProjectVersionPanel from "@/components/ProjectVersionPanel";
+import type { ProjectBranch, ProjectVersion, ProjectVersionSnapshot } from "@/types";
+
+const mockBranch: ProjectBranch = {
+  id: "b1",
+  project_id: "p1",
+  name: "Main",
+  forked_from_version_id: null,
+  is_default: true,
+  created_at: "2026-04-20T10:00:00Z",
+};
+
+const mockVersion: ProjectVersion = {
+  id: "v1",
+  project_id: "p1",
+  branch_id: "b1",
+  parent_version_id: null,
+  restored_from_version_id: null,
+  name: "Initial checkpoint",
+  description: null,
+  event_type: "named",
+  delta: { changedFields: ["scene_js"], bom: { added: 2, removed: 0, quantityChanged: 0, unitChanged: 0 } },
+  thumbnail_url: null,
+  created_at: "2026-04-20T10:00:00Z",
+};
+
+const mockSnapshot: ProjectVersionSnapshot = {
+  name: "Test Project",
+  description: "A test",
+  scene_js: "// scene",
+  bom: [],
+};
+
+const baseProps = {
+  projectId: "p1",
+  open: true,
+  snapshot: mockSnapshot,
+  activeBranchId: "b1",
+  saveNow: vi.fn().mockResolvedValue(undefined),
+  onClose: vi.fn(),
+  onActiveBranchChange: vi.fn(),
+  onRestored: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetProjectVersions.mockResolvedValue({
+    branches: [mockBranch],
+    versions: [mockVersion],
+  });
+});
+
+describe("ProjectVersionPanel", () => {
+  it("returns null when not open", () => {
+    const { container } = render(<ProjectVersionPanel {...baseProps} open={false} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders dialog when open", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("has aria-label", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toHaveAttribute("aria-label", "versions.title");
+    });
+  });
+
+  it("renders eyebrow text", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.eyebrow")).toBeInTheDocument();
+    });
+  });
+
+  it("renders title", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.title")).toBeInTheDocument();
+    });
+  });
+
+  it("renders subtitle", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.subtitle")).toBeInTheDocument();
+    });
+  });
+
+  it("renders close button", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByLabelText("dialog.close")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onClose when close button clicked", async () => {
+    const onClose = vi.fn();
+    render(<ProjectVersionPanel {...baseProps} onClose={onClose} />);
+    await waitFor(() => {
+      fireEvent.click(screen.getByLabelText("dialog.close"));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders branch buttons", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("Main")).toBeInTheDocument();
+    });
+  });
+
+  it("renders branch creation input", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.createBranch")).toBeInTheDocument();
+    });
+  });
+
+  it("renders checkpoint creation input", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.saveCheckpoint")).toBeInTheDocument();
+    });
+  });
+
+  it("disables save checkpoint when name is empty", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      const btn = screen.getByText("versions.saveCheckpoint").closest("button")!;
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it("renders version name", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("Initial checkpoint")).toBeInTheDocument();
+    });
+  });
+
+  it("renders version event type badge", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.event.named")).toBeInTheDocument();
+    });
+  });
+
+  it("renders compare and restore buttons for version", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.compare")).toBeInTheDocument();
+      expect(screen.getByText("versions.restore")).toBeInTheDocument();
+    });
+  });
+
+  it("renders delta summary", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText(/versions\.fieldScene/)).toBeInTheDocument();
+      expect(screen.getByText(/versions\.bomChanges/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty message when no versions", async () => {
+    mockGetProjectVersions.mockResolvedValue({ branches: [mockBranch], versions: [] });
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.empty")).toBeInTheDocument();
+    });
+  });
+
+  it("fetches versions on mount", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(mockGetProjectVersions).toHaveBeenCalledWith("p1");
+    });
+  });
+
+  it("renders branches label", async () => {
+    render(<ProjectVersionPanel {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByText("versions.branches")).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/quote-request-modal.test.tsx
+++ b/web/src/__tests__/quote-request-modal.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockSubmitQuoteRequest = vi.fn();
+const mockMe = vi.fn();
+const mockToast = vi.fn();
+const mockTrack = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    submitQuoteRequest: (...args: unknown[]) => mockSubmitQuoteRequest(...args),
+    me: (...args: unknown[]) => mockMe(...args),
+  },
+}));
+
+import QuoteRequestModal from "@/components/QuoteRequestModal";
+import type { BomItem } from "@/types";
+
+const mockBom: BomItem[] = [
+  { material_id: "m1", quantity: 10, unit: "kpl" },
+];
+
+const baseProps = {
+  open: true,
+  projectId: "p1",
+  projectName: "Sauna Build",
+  bom: mockBom,
+  totalCost: 5000,
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMe.mockResolvedValue({ name: "", email: "" });
+  mockSubmitQuoteRequest.mockResolvedValue({
+    id: "qr-1",
+    status: "submitted",
+    created_at: "2026-04-22T10:00:00Z",
+    email_sent: true,
+    bom_line_count: 1,
+    estimated_cost: 5000,
+    matched_contractor_count: 3,
+  });
+});
+
+describe("QuoteRequestModal", () => {
+  it("returns null when not open", () => {
+    const { container } = render(<QuoteRequestModal {...baseProps} open={false} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders dialog when open", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("has aria-modal true", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("renders eyebrow text", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("quoteRequest.eyebrow")).toBeInTheDocument();
+  });
+
+  it("renders title", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("quoteRequest.title")).toBeInTheDocument();
+  });
+
+  it("renders subtitle", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("quoteRequest.subtitle")).toBeInTheDocument();
+  });
+
+  it("renders project summary", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("quoteRequest.summaryProject")).toBeInTheDocument();
+    expect(screen.getByText("Sauna Build")).toBeInTheDocument();
+  });
+
+  it("renders form fields", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("quoteRequest.contactName")).toBeInTheDocument();
+    expect(screen.getByText("quoteRequest.contactEmail")).toBeInTheDocument();
+    expect(screen.getByText("quoteRequest.contactPhone")).toBeInTheDocument();
+    expect(screen.getByText("quoteRequest.postcode")).toBeInTheDocument();
+    expect(screen.getByText("quoteRequest.workScope")).toBeInTheDocument();
+  });
+
+  it("renders partner note", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("quoteRequest.partnerNote")).toBeInTheDocument();
+  });
+
+  it("renders cancel and submit buttons", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText("dialog.cancel")).toBeInTheDocument();
+    expect(screen.getByText("quoteRequest.submit")).toBeInTheDocument();
+  });
+
+  it("submit button is disabled initially", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    const submitBtn = screen.getByText("quoteRequest.submit").closest("button")!;
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("closes on Escape key", () => {
+    const onClose = vi.fn();
+    render(<QuoteRequestModal {...baseProps} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes on close button click", () => {
+    const onClose = vi.fn();
+    render(<QuoteRequestModal {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByLabelText("dialog.cancel"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("prefills user data from API", async () => {
+    mockMe.mockResolvedValue({ name: "Jane", email: "jane@example.com" });
+    render(<QuoteRequestModal {...baseProps} />);
+    await waitFor(() => {
+      expect(mockMe).toHaveBeenCalled();
+    });
+  });
+
+  it("renders total cost in summary", () => {
+    render(<QuoteRequestModal {...baseProps} />);
+    expect(screen.getByText(/5,000/)).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/screenshot-popover.test.tsx
+++ b/web/src/__tests__/screenshot-popover.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockToast = vi.fn();
+let rafCallback: ((ts: number) => void) | null = null;
+
+vi.stubGlobal("requestAnimationFrame", (cb: (ts: number) => void) => {
+  rafCallback = cb;
+  return 1;
+});
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import ScreenshotPopover from "@/components/ScreenshotPopover";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rafCallback = null;
+});
+
+function renderPopover(imageDataUrl: string | null = "data:image/png;base64,abc", onClose = vi.fn()) {
+  const result = render(
+    <ScreenshotPopover imageDataUrl={imageDataUrl} projectName="Test" onClose={onClose} />,
+  );
+  if (rafCallback) act(() => { rafCallback!(0); });
+  return { ...result, onClose };
+}
+
+describe("ScreenshotPopover", () => {
+  it("returns null when imageDataUrl is null", () => {
+    const { container } = render(
+      <ScreenshotPopover imageDataUrl={null} projectName="Test" onClose={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders dialog when imageDataUrl is provided", () => {
+    renderPopover();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("has aria-label on dialog", () => {
+    renderPopover();
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-label", "screenshot.popoverLabel");
+  });
+
+  it("has aria-modal true", () => {
+    renderPopover();
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("renders preview image", () => {
+    renderPopover();
+    const img = screen.getByAltText("screenshot.previewAlt");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "data:image/png;base64,abc");
+  });
+
+  it("renders download button", () => {
+    renderPopover();
+    expect(screen.getByText("screenshot.download")).toBeInTheDocument();
+  });
+
+  it("renders copy button", () => {
+    renderPopover();
+    expect(screen.getByText("screenshot.copy")).toBeInTheDocument();
+  });
+
+  it("closes on Escape key", () => {
+    const onClose = vi.fn();
+    renderPopover("data:image/png;base64,abc", onClose);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 8 tests for ScreenshotPopover (null guard, dialog rendering, aria-label/modal, preview image, download/copy buttons, Escape close)
- 15 tests for QuoteRequestModal (null when closed, dialog rendering, aria-modal, eyebrow/title/subtitle, project summary, form fields, partner note, submit disabled initially, Escape/close button, user prefill, total cost)
- 19 tests for ProjectVersionPanel (null when closed, dialog/aria, eyebrow/title/subtitle, close button, branch buttons/creation, checkpoint input/disabled, version name/event badge, compare/restore buttons, delta summary, empty state, API fetch, branches label)

## Test plan
- [x] All 42 tests pass via `npx vitest run`
- [x] Type-check clean via `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)