### PR TITLE
test: 33 tests for SubsidyCalculator, RyhtiSubmissionPanel

### DIFF
--- a/web/src/__tests__/ryhti-submission-panel.test.tsx
+++ b/web/src/__tests__/ryhti-submission-panel.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockGetRyhtiPackage = vi.fn();
+const mockUpdateRyhtiMetadata = vi.fn();
+const mockSubmitRyhti = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getRyhtiPackage: (...args: unknown[]) => mockGetRyhtiPackage(...args),
+    updateRyhtiMetadata: (...args: unknown[]) => mockUpdateRyhtiMetadata(...args),
+    submitRyhti: (...args: unknown[]) => mockSubmitRyhti(...args),
+  },
+}));
+
+import RyhtiSubmissionPanel from "@/components/RyhtiSubmissionPanel";
+import type { RyhtiPackageResponse } from "@/types";
+
+const mockPackage: RyhtiPackageResponse = {
+  package: {},
+  validation: {
+    ready: false,
+    generatedAt: "2026-04-22T10:00:00Z",
+    mode: "dry_run",
+    remoteConfigured: false,
+    issues: [
+      { level: "error", code: "missing_municipality", field: "municipalityNumber", message: "Municipality number required", action: "Enter municipality number" },
+      { level: "warning", code: "no_description", field: "descriptionOfAction", message: "Description recommended", action: "Add description" },
+    ],
+    summary: { errors: 1, warnings: 1, info: 0 },
+  },
+  permitMetadata: {},
+  latestSubmission: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetRyhtiPackage.mockResolvedValue(mockPackage);
+});
+
+describe("RyhtiSubmissionPanel", () => {
+  it("returns null when no projectId", () => {
+    const { container } = render(<RyhtiSubmissionPanel bomCount={5} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders title", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.title")).toBeInTheDocument();
+    });
+  });
+
+  it("renders subtitle", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.subtitle")).toBeInTheDocument();
+    });
+  });
+
+  it("shows blocked badge with issue count", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText(/ryhti\.blocked/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows ready badge when validation passes", async () => {
+    mockGetRyhtiPackage.mockResolvedValue({
+      ...mockPackage,
+      validation: { ...mockPackage.validation, ready: true, issues: [], summary: { errors: 0, warnings: 0, info: 0 } },
+    });
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.ready")).toBeInTheDocument();
+    });
+  });
+
+  it("renders municipality number input", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.municipalityNumber")).toBeInTheDocument();
+    });
+  });
+
+  it("renders property identifier input", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.propertyIdentifier")).toBeInTheDocument();
+    });
+  });
+
+  it("renders building identifier input", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.buildingIdentifier")).toBeInTheDocument();
+    });
+  });
+
+  it("renders description textarea", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.description")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Suomi.fi checkbox", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.suomiFiConfirmed")).toBeInTheDocument();
+    });
+  });
+
+  it("renders validation issues", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("Municipality number required")).toBeInTheDocument();
+      expect(screen.getByText("Description recommended")).toBeInTheDocument();
+    });
+  });
+
+  it("renders check and submit buttons", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.check")).toBeInTheDocument();
+      expect(screen.getByText("ryhti.createPackage")).toBeInTheDocument();
+    });
+  });
+
+  it("disables submit when not ready", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      const btn = screen.getByText("ryhti.createPackage").closest("button")!;
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it("renders dry run note when not remote configured", async () => {
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.dryRunNote")).toBeInTheDocument();
+    });
+  });
+
+  it("renders live mode note when remote configured", async () => {
+    mockGetRyhtiPackage.mockResolvedValue({
+      ...mockPackage,
+      validation: { ...mockPackage.validation, remoteConfigured: true },
+    });
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.liveMode")).toBeInTheDocument();
+    });
+  });
+
+  it("shows load failed on API error", async () => {
+    mockGetRyhtiPackage.mockRejectedValue(new Error("fail"));
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.loadFailed")).toBeInTheDocument();
+    });
+  });
+
+  it("renders latest submission status when present", async () => {
+    mockGetRyhtiPackage.mockResolvedValue({
+      ...mockPackage,
+      latestSubmission: {
+        id: "s1",
+        project_id: "p1",
+        mode: "dry_run",
+        status: "submitted",
+        ryhti_tracking_id: "RTI-123",
+        created_at: "2026-04-21T10:00:00Z",
+      },
+    });
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.latestStatus")).toBeInTheDocument();
+      expect(screen.getByText("submitted")).toBeInTheDocument();
+      expect(screen.getByText(/RTI-123/)).toBeInTheDocument();
+    });
+  });
+
+  it("saves metadata on check button click", async () => {
+    mockUpdateRyhtiMetadata.mockResolvedValue(mockPackage);
+    render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    await waitFor(() => {
+      expect(screen.getByText("ryhti.check")).toBeInTheDocument();
+    });
+    const checkBtn = screen.getByText("ryhti.check").closest("button")!;
+    fireEvent.click(checkBtn);
+    await waitFor(() => {
+      expect(mockUpdateRyhtiMetadata).toHaveBeenCalled();
+    });
+  });
+
+  it("renders address from buildingInfo", async () => {
+    render(
+      <RyhtiSubmissionPanel
+        projectId="p1"
+        bomCount={5}
+        buildingInfo={{ address: "Mannerheimintie 1, Helsinki" } as any}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Mannerheimintie 1, Helsinki")).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/subsidy-calculator.test.tsx
+++ b/web/src/__tests__/subsidy-calculator.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockEstimateEnergySubsidy = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    estimateEnergySubsidy: (...args: unknown[]) => mockEstimateEnergySubsidy(...args),
+  },
+}));
+
+import SubsidyCalculator from "@/components/SubsidyCalculator";
+import type { EnergySubsidyResponse } from "@/types";
+
+const mockElyProgram = {
+  program: "ely_oil_gas_heating" as const,
+  name: "ELY Centre Oil/Gas",
+  status: "eligible" as const,
+  amount: 4000,
+  netCost: 6000,
+  reasons: [],
+  warnings: [],
+  applicationDeadline: "2026-06-30",
+  applicationDeadlineAt: "2026-06-30T23:59:59Z",
+  completionDeadline: "2027-06-30",
+  paymentDeadline: "2027-09-30",
+  applicationUrl: "https://ely.fi/apply",
+  sourceUrl: "https://ely.fi",
+};
+
+const mockResult: EnergySubsidyResponse = {
+  totalCost: 10000,
+  bestAmount: 4000,
+  netCost: 6000,
+  applicationDeadline: "2026-06-30",
+  applicationDeadlineAt: "2026-06-30T23:59:59Z",
+  daysUntilApplicationDeadline: 69,
+  completionDeadline: "2027-06-30",
+  daysUntilCompletionDeadline: 434,
+  deadline: "2026-06-30",
+  daysUntilDeadline: 69,
+  generatedAt: "2026-04-22T10:00:00Z",
+  programs: [mockElyProgram],
+  disclaimer: "Estimates only, contact ELY for details.",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEstimateEnergySubsidy.mockResolvedValue(mockResult);
+});
+
+describe("SubsidyCalculator", () => {
+  it("renders section label", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.sectionLabel")).toBeInTheDocument();
+    });
+  });
+
+  it("renders scene-triggered label when triggered by scene", async () => {
+    render(<SubsidyCalculator totalCost={10000} triggeredByScene={true} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.opportunityLabel")).toBeInTheDocument();
+    });
+  });
+
+  it("renders eligible title when eligible", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.eligibleTitle")).toBeInTheDocument();
+    });
+  });
+
+  it("renders deadline countdown badge", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText(/subsidy\.applicationDeadlineCountdown/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders form selects", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.currentHeating")).toBeInTheDocument();
+      expect(screen.getByText("subsidy.targetHeating")).toBeInTheDocument();
+      expect(screen.getByText("subsidy.household")).toBeInTheDocument();
+      expect(screen.getByText("subsidy.systemCondition")).toBeInTheDocument();
+    });
+  });
+
+  it("renders year-round residential checkbox", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.yearRoundResidential")).toBeInTheDocument();
+    });
+  });
+
+  it("renders net cost when eligible", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.netCost")).toBeInTheDocument();
+    });
+  });
+
+  it("renders ELY deduction when eligible", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText(/subsidy\.elyDeduction/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders mutual exclusion note", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.mutualExclusion")).toBeInTheDocument();
+    });
+  });
+
+  it("renders apply ELY link", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      const link = screen.getByText("subsidy.applyEly");
+      expect(link.closest("a")).toHaveAttribute("href", "https://ely.fi/apply");
+    });
+  });
+
+  it("renders disclaimer", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("Estimates only, contact ELY for details.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows not eligible message when status is not eligible", async () => {
+    mockEstimateEnergySubsidy.mockResolvedValue({
+      ...mockResult,
+      programs: [{ ...mockElyProgram, status: "not_eligible", reasons: ["Oil heating required"] }],
+    });
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("Oil heating required")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error on API failure", async () => {
+    mockEstimateEnergySubsidy.mockRejectedValue(new Error("fail"));
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(screen.getByText("subsidy.error")).toBeInTheDocument();
+    });
+  });
+
+  it("calls API with totalCost", async () => {
+    render(<SubsidyCalculator totalCost={10000} />);
+    await waitFor(() => {
+      expect(mockEstimateEnergySubsidy).toHaveBeenCalledWith(
+        expect.objectContaining({ totalCost: 10000 }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 14 tests for SubsidyCalculator (section labels, eligible/not-eligible titles, deadline countdown, form selects, year-round checkbox, net cost, ELY deduction, mutual exclusion note, apply link, disclaimer, API error, API call validation)
- 19 tests for RyhtiSubmissionPanel (null guard, title/subtitle, blocked/ready badges, form inputs, Suomi.fi checkbox, validation issues, check/submit buttons, disabled submit, dry-run/live mode notes, API error, latest submission status with tracking ID, save metadata, address from buildingInfo)

## Test plan
- [x] All 33 tests pass via `npx vitest run`
- [x] Type-check clean via `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)