### PR TITLE
test: 40 tests for useAutoSave hook and SceneApiReference

### DIFF
--- a/web/src/__tests__/scene-api-reference.test.tsx
+++ b/web/src/__tests__/scene-api-reference.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import SceneApiReference from "@/components/SceneApiReference";
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe("SceneApiReference", () => {
+  it("renders the panel", () => {
+    const { container } = render(<SceneApiReference />);
+    expect(container.querySelector(".api-ref-panel")).toBeInTheDocument();
+  });
+
+  it("renders Scene API title", () => {
+    render(<SceneApiReference />);
+    expect(screen.getByText("Scene API")).toBeInTheDocument();
+  });
+
+  it("renders section tabs", () => {
+    render(<SceneApiReference />);
+    expect(screen.getByText("apiRef.primitives")).toBeInTheDocument();
+    expect(screen.getByText("apiRef.transforms")).toBeInTheDocument();
+    expect(screen.getByText("apiRef.booleans")).toBeInTheDocument();
+    expect(screen.getByText("scene.add")).toBeInTheDocument();
+    expect(screen.getByText("apiRef.materials")).toBeInTheDocument();
+    expect(screen.getByText("apiRef.cookbook")).toBeInTheDocument();
+    expect(screen.getByText("apiRef.coords")).toBeInTheDocument();
+  });
+
+  it("shows primitives section by default", () => {
+    render(<SceneApiReference />);
+    expect(screen.getByText("Primitive shapes")).toBeInTheDocument();
+    expect(screen.getByText("box(width, height, depth)")).toBeInTheDocument();
+  });
+
+  it("renders box function signature and params", () => {
+    render(<SceneApiReference />);
+    expect(screen.getByText("box(width, height, depth)")).toBeInTheDocument();
+    expect(screen.getByText("Width along X axis (meters)")).toBeInTheDocument();
+  });
+
+  it("renders cylinder function", () => {
+    render(<SceneApiReference />);
+    expect(screen.getByText("cylinder(radius, height)")).toBeInTheDocument();
+  });
+
+  it("renders sphere function", () => {
+    render(<SceneApiReference />);
+    expect(screen.getByText("sphere(radius)")).toBeInTheDocument();
+  });
+
+  it("switches to transforms tab", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.transforms"));
+    expect(screen.getByText("Transform functions")).toBeInTheDocument();
+    expect(screen.getByText("translate(mesh, x, y, z)")).toBeInTheDocument();
+    expect(screen.getByText("rotate(mesh, rx, ry, rz)")).toBeInTheDocument();
+  });
+
+  it("switches to booleans tab", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.booleans"));
+    expect(screen.getByText("Boolean operations")).toBeInTheDocument();
+    expect(screen.getByText("union(a, b)")).toBeInTheDocument();
+    expect(screen.getByText("subtract(a, b)")).toBeInTheDocument();
+    expect(screen.getByText("intersect(a, b)")).toBeInTheDocument();
+  });
+
+  it("switches to scene.add tab", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("scene.add"));
+    expect(screen.getByText("Adding to the scene")).toBeInTheDocument();
+    expect(screen.getByText("scene.add(mesh, options?)")).toBeInTheDocument();
+  });
+
+  it("switches to materials tab", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.materials"));
+    expect(screen.getByText("Built-in materials")).toBeInTheDocument();
+    expect(screen.getByText("foundation")).toBeInTheDocument();
+    expect(screen.getByText("lumber")).toBeInTheDocument();
+    expect(screen.getByText("roofing")).toBeInTheDocument();
+  });
+
+  it("renders material swatches", () => {
+    const { container } = render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.materials"));
+    const swatches = container.querySelectorAll(".api-ref-material-swatch");
+    expect(swatches.length).toBe(7);
+  });
+
+  it("renders material hint", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.materials"));
+    expect(screen.getByText("apiRef.materialHint")).toBeInTheDocument();
+  });
+
+  it("switches to cookbook tab", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.cookbook"));
+    expect(screen.getByText("Common patterns")).toBeInTheDocument();
+    expect(screen.getByText("Cut a door from a wall")).toBeInTheDocument();
+    expect(screen.getByText("Add a window")).toBeInTheDocument();
+    expect(screen.getByText("Create a pitched roof")).toBeInTheDocument();
+  });
+
+  it("switches to coords tab", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.coords"));
+    expect(screen.getByText("apiRef.coordSystem")).toBeInTheDocument();
+    expect(screen.getByText("apiRef.coordHint")).toBeInTheDocument();
+  });
+
+  it("search filters functions", () => {
+    render(<SceneApiReference />);
+    const input = screen.getByPlaceholderText("editor.searchDocs");
+    fireEvent.change(input, { target: { value: "cylinder" } });
+    expect(screen.getByText("cylinder(radius, height)")).toBeInTheDocument();
+    expect(screen.queryByText("box(width, height, depth)")).not.toBeInTheDocument();
+  });
+
+  it("search shows no results message", () => {
+    render(<SceneApiReference />);
+    const input = screen.getByPlaceholderText("editor.searchDocs");
+    fireEvent.change(input, { target: { value: "xyznonexistent" } });
+    expect(screen.getByText(/apiRef\.noResults/)).toBeInTheDocument();
+  });
+
+  it("hides tabs during search", () => {
+    render(<SceneApiReference />);
+    const input = screen.getByPlaceholderText("editor.searchDocs");
+    fireEvent.change(input, { target: { value: "box" } });
+    expect(screen.queryByText("apiRef.primitives")).not.toBeInTheDocument();
+  });
+
+  it("search clear button resets search", () => {
+    const { container } = render(<SceneApiReference />);
+    const input = screen.getByPlaceholderText("editor.searchDocs");
+    fireEvent.change(input, { target: { value: "box" } });
+    const clearBtn = container.querySelector(".api-ref-search-clear")!;
+    fireEvent.click(clearBtn);
+    expect(screen.getByText("apiRef.primitives")).toBeInTheDocument();
+  });
+
+  it("search matches cookbook entries", () => {
+    render(<SceneApiReference />);
+    const input = screen.getByPlaceholderText("editor.searchDocs");
+    fireEvent.change(input, { target: { value: "pitched roof" } });
+    expect(screen.getByText("Create a pitched roof")).toBeInTheDocument();
+  });
+
+  it("calls onInsertCode when copy button clicked", () => {
+    const onInsert = vi.fn();
+    render(<SceneApiReference onInsertCode={onInsert} />);
+    const copyBtns = screen.getAllByLabelText("Copy to clipboard");
+    fireEvent.click(copyBtns[0]);
+    expect(onInsert).toHaveBeenCalledWith("const wall = box(4, 2.8, 0.15);");
+  });
+
+  it("renders copy-to-editor buttons in cookbook", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.cookbook"));
+    const editorBtns = screen.getAllByLabelText("Copy to editor");
+    expect(editorBtns.length).toBeGreaterThan(0);
+  });
+
+  it("renders return type for functions", () => {
+    render(<SceneApiReference />);
+    const returns = screen.getAllByText(/→ Mesh/);
+    expect(returns.length).toBeGreaterThan(0);
+  });
+
+  it("renders coord note text", () => {
+    render(<SceneApiReference />);
+    fireEvent.click(screen.getByText("apiRef.coords"));
+    expect(screen.getByText(/Y is up/)).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/use-auto-save.test.tsx
+++ b/web/src/__tests__/use-auto-save.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAutoSave } from "@/hooks/useAutoSave";
+import type { SaveableFields, AutoSaveCallbacks, AutoSaveOptions } from "@/hooks/useAutoSave";
+
+const baseFields: SaveableFields = {
+  name: "Project A",
+  description: "A test project",
+  scene_js: "box(1,1,1);",
+  bom: [{ material_id: "m1", quantity: 5, unit: "kpl" }],
+};
+
+function makeCallbacks(overrides?: Partial<AutoSaveCallbacks>): AutoSaveCallbacks {
+  return {
+    onSaveProject: vi.fn().mockResolvedValue(undefined),
+    onSaveBom: vi.fn().mockResolvedValue(undefined),
+    onSaveThumbnail: vi.fn().mockResolvedValue(undefined),
+    onStatusChange: vi.fn(),
+    onSaveSuccess: vi.fn(),
+    onSaveError: vi.fn(),
+    ...overrides,
+  };
+}
+
+const baseOptions: AutoSaveOptions = {
+  debounceMs: 2000,
+  typingDebounceMs: 4000,
+  rapidFireThresholdMs: 800,
+  initialLoadDone: true,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAutoSave", () => {
+  it("returns saveNow and setSavedSnapshot", () => {
+    const cb = makeCallbacks();
+    const { result } = renderHook(() => useAutoSave(baseFields, cb, baseOptions));
+    expect(typeof result.current.saveNow).toBe("function");
+    expect(typeof result.current.setSavedSnapshot).toBe("function");
+  });
+
+  it("does not trigger save when initialLoadDone is false", () => {
+    const cb = makeCallbacks();
+    const opts = { ...baseOptions, initialLoadDone: false };
+    const changed = { ...baseFields, name: "Changed" };
+    renderHook(() => useAutoSave(changed, cb, opts));
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(cb.onSaveProject).not.toHaveBeenCalled();
+  });
+
+  it("triggers save after debounce when field changes", async () => {
+    const cb = makeCallbacks();
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, name: "Changed" } });
+    expect(cb.onSaveProject).not.toHaveBeenCalled();
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveProject).toHaveBeenCalledWith({ name: "Changed" });
+  });
+
+  it("calls onStatusChange unsaved then saving then saved", async () => {
+    const cb = makeCallbacks();
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, description: "Updated" } });
+    expect(cb.onStatusChange).toHaveBeenCalledWith("unsaved");
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onStatusChange).toHaveBeenCalledWith("saving");
+    expect(cb.onStatusChange).toHaveBeenCalledWith("saved");
+  });
+
+  it("only sends changed fields in save", async () => {
+    const cb = makeCallbacks();
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, description: "New desc" } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveProject).toHaveBeenCalledWith({ description: "New desc" });
+    expect(cb.onSaveBom).not.toHaveBeenCalled();
+  });
+
+  it("calls onSaveBom when BOM changes", async () => {
+    const cb = makeCallbacks();
+    const newBom = [{ material_id: "m2", quantity: 10, unit: "m2" }];
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, bom: newBom } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveBom).toHaveBeenCalledWith(newBom);
+  });
+
+  it("calls onSaveThumbnail when scene_js changes", async () => {
+    const cb = makeCallbacks();
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, scene_js: "cylinder(1,2);" } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveThumbnail).toHaveBeenCalled();
+  });
+
+  it("does not call onSaveThumbnail when only name changes", async () => {
+    const cb = makeCallbacks();
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, name: "Renamed" } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveThumbnail).not.toHaveBeenCalled();
+  });
+
+  it("calls onSaveError on save failure", async () => {
+    const err = new Error("save failed");
+    const cb = makeCallbacks({
+      onSaveProject: vi.fn().mockRejectedValue(err),
+    });
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, name: "Fail" } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveError).toHaveBeenCalledWith(err);
+    expect(cb.onStatusChange).toHaveBeenCalledWith("unsaved");
+  });
+
+  it("saveNow triggers immediate save", async () => {
+    const cb = makeCallbacks();
+    const { result, rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, name: "Immediate" } });
+    await act(async () => { await result.current.saveNow(); });
+    expect(cb.onSaveProject).toHaveBeenCalledWith({ name: "Immediate" });
+  });
+
+  it("does not save when fields are unchanged", async () => {
+    const cb = makeCallbacks();
+    const { result } = renderHook(() => useAutoSave(baseFields, cb, baseOptions));
+    await act(async () => { await result.current.saveNow(); });
+    expect(cb.onSaveProject).not.toHaveBeenCalled();
+    expect(cb.onSaveBom).not.toHaveBeenCalled();
+  });
+
+  it("calls onSaveSuccess with saved fields", async () => {
+    const cb = makeCallbacks();
+    const changed = { ...baseFields, name: "Success" };
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: changed });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveSuccess).toHaveBeenCalledWith(changed);
+  });
+
+  it("saves both project and BOM when both change", async () => {
+    const cb = makeCallbacks();
+    const newBom = [{ material_id: "m3", quantity: 1, unit: "kpl" }];
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, name: "Both", bom: newBom } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveProject).toHaveBeenCalledWith({ name: "Both" });
+    expect(cb.onSaveBom).toHaveBeenCalledWith(newBom);
+  });
+
+  it("setSavedSnapshot updates the baseline", async () => {
+    const cb = makeCallbacks();
+    const updated = { ...baseFields, name: "Updated Baseline" };
+    const { result } = renderHook(() => useAutoSave(updated, cb, baseOptions));
+    act(() => { result.current.setSavedSnapshot(updated); });
+    await act(async () => { await result.current.saveNow(); });
+    expect(cb.onSaveProject).not.toHaveBeenCalled();
+  });
+
+  it("detects BOM quantity change", async () => {
+    const cb = makeCallbacks();
+    const changedBom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, bom: changedBom } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveBom).toHaveBeenCalled();
+  });
+
+  it("detects BOM length change", async () => {
+    const cb = makeCallbacks();
+    const longerBom = [
+      { material_id: "m1", quantity: 5, unit: "kpl" },
+      { material_id: "m2", quantity: 3, unit: "m2" },
+    ];
+    const { rerender } = renderHook(
+      ({ fields }) => useAutoSave(fields, cb, baseOptions),
+      { initialProps: { fields: baseFields } },
+    );
+    rerender({ fields: { ...baseFields, bom: longerBom } });
+    await act(async () => { vi.advanceTimersByTime(2500); });
+    expect(cb.onSaveBom).toHaveBeenCalledWith(longerBom);
+  });
+});


### PR DESCRIPTION
## Summary
- 16 tests for `useAutoSave` hook: debounce behavior, dirty field detection, BOM changes, scene_js thumbnail capture, save errors, saveNow, setSavedSnapshot
- 24 tests for `SceneApiReference` component: tab navigation, search filtering, function card rendering, materials/cookbook/coords sections, copy-to-editor callbacks

## Test plan
- [x] All 40 tests pass locally with vitest
- [x] TypeScript type-check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)