### PR TITLE
test: 80 tests for 5 lib modules (compliance, heating, materials, shortcuts)

### DIFF
--- a/web/src/__tests__/compliance.test.ts
+++ b/web/src/__tests__/compliance.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { checkCompliance, RULE_COUNT } from "@/lib/compliance";
+
+describe("checkCompliance", () => {
+  it("returns empty array for empty scene", () => {
+    expect(checkCompliance("")).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only scene", () => {
+    expect(checkCompliance("   ")).toEqual([]);
+  });
+
+  it("returns empty array for unparseable scene", () => {
+    expect(checkCompliance("console.log('hello')")).toEqual([]);
+  });
+
+  it("exports RULE_COUNT", () => {
+    expect(RULE_COUNT).toBe(5);
+  });
+
+  describe("minimum ceiling height", () => {
+    it("warns when wall height is below 2.5m", () => {
+      const scene = `const wall = box(4, 2.3, 0.15);
+scene.add(wall, { material: "lumber" });`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.ruleId === "FI-RakMK-G1-2.1");
+      expect(w).toBeTruthy();
+      expect(w!.severity).toBe("error");
+      expect(w!.params.height).toBe(2300);
+    });
+
+    it("does not warn when wall height is 2.5m", () => {
+      const scene = `const wall = box(4, 2.5, 0.15);
+scene.add(wall, { material: "lumber" });`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-G1-2.1")).toBeUndefined();
+    });
+
+    it("does not warn for non-residential building type", () => {
+      const scene = `const wall = box(4, 2.3, 0.15);`;
+      const warnings = checkCompliance(scene, { type: "kerrostalo" });
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-G1-2.1")).toBeUndefined();
+    });
+
+    it("warns for omakotitalo type", () => {
+      const scene = `const wall = box(4, 2.3, 0.15);`;
+      const warnings = checkCompliance(scene, { type: "omakotitalo" });
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-G1-2.1")).toBeTruthy();
+    });
+  });
+
+  describe("minimum door width", () => {
+    it("warns when door opening is less than 800mm", () => {
+      const scene = `const wall = box(6, 2.8, 0.15);
+const doorHole = box(0.7, 2.1, 0.15);
+const wallWithDoor = subtract(wall, doorHole);`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.ruleId === "FI-RakMK-F1-2.3");
+      expect(w).toBeTruthy();
+      expect(w!.severity).toBe("error");
+      expect(w!.params.width).toBe(700);
+    });
+
+    it("does not warn when door is 900mm wide", () => {
+      const scene = `const wall = box(6, 2.8, 0.15);
+const doorHole = box(0.9, 2.1, 0.15);
+const wallWithDoor = subtract(wall, doorHole);`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-F1-2.3")).toBeUndefined();
+    });
+  });
+
+  describe("handrail required", () => {
+    it("warns when elevated platform has no posts", () => {
+      const scene = `const deck = translate(box(3, 0.08, 2), 0, 0.6, 0);`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.ruleId === "FI-RakMK-F2-3.2");
+      expect(w).toBeTruthy();
+      expect(w!.severity).toBe("warning");
+    });
+
+    it("does not warn when posts are present near platform", () => {
+      const scene = `const deck = translate(box(3, 0.08, 2), 0, 0.6, 0);
+const post1 = translate(box(0.1, 1.0, 0.1), -1.3, 0.6, -0.8);
+const post2 = translate(box(0.1, 1.0, 0.1), 1.3, 0.6, -0.8);`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-F2-3.2")).toBeUndefined();
+    });
+
+    it("does not warn for ground-level platform", () => {
+      const scene = `const deck = translate(box(3, 0.08, 2), 0, 0.3, 0);`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-F2-3.2")).toBeUndefined();
+    });
+  });
+
+  describe("maximum building height", () => {
+    it("warns when building exceeds 12m", () => {
+      const scene = `const tower = translate(box(2, 14, 2), 0, 7, 0);`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.ruleId === "FI-MRL-115");
+      expect(w).toBeTruthy();
+      expect(w!.severity).toBe("error");
+    });
+
+    it("does not warn when building is under 12m", () => {
+      const scene = `const wall = translate(box(4, 2.8, 0.15), 0, 1.4, 0);`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.find((w) => w.ruleId === "FI-MRL-115")).toBeUndefined();
+    });
+  });
+
+  describe("minimum room area", () => {
+    it("warns when floor area is less than 7m²", () => {
+      const scene = `const floor = box(2, 0.2, 3);`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.ruleId === "FI-RakMK-G1-2.2");
+      expect(w).toBeTruthy();
+      expect(w!.severity).toBe("warning");
+      expect(w!.params.area).toBe(6);
+    });
+
+    it("does not warn when floor area is 7m² or more", () => {
+      const scene = `const floor = box(3.5, 0.2, 2);`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.find((w) => w.ruleId === "FI-RakMK-G1-2.2")).toBeUndefined();
+    });
+  });
+
+  describe("Three.js fallback parser", () => {
+    it("parses THREE.BoxGeometry meshes", () => {
+      const scene = `const geom = new THREE.BoxGeometry(4, 2.3, 0.15);`;
+      const warnings = checkCompliance(scene);
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("translate with reference", () => {
+    it("handles translate of named mesh reference", () => {
+      const scene = `const base = box(3, 0.08, 2);
+const deck = translate(base, 0, 0.6, 0);`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.ruleId === "FI-RakMK-F2-3.2");
+      expect(w).toBeTruthy();
+    });
+  });
+
+  describe("material tagging", () => {
+    it("tags mesh material from scene.add", () => {
+      const scene = `const wall = box(4, 2.3, 0.15);
+scene.add(wall, { material: "lumber" });`;
+      const warnings = checkCompliance(scene);
+      const w = warnings.find((w) => w.affectedMesh === "wall");
+      expect(w).toBeTruthy();
+    });
+  });
+});

--- a/web/src/__tests__/heating-grant-context.test.ts
+++ b/web/src/__tests__/heating-grant-context.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import {
+  inferHeatingGrantTarget,
+  hasFossilSourceHeating,
+  detectHeatingGrantOpportunity,
+} from "@/lib/heating-grant-context";
+
+describe("inferHeatingGrantTarget", () => {
+  it("returns null for empty text", () => {
+    expect(inferHeatingGrantTarget("")).toEqual({ target: null, matchedTerms: [] });
+  });
+
+  it("returns null for undefined", () => {
+    expect(inferHeatingGrantTarget(undefined)).toEqual({ target: null, matchedTerms: [] });
+  });
+
+  it("detects air water heat pump", () => {
+    const result = inferHeatingGrantTarget("installing air water heat pump");
+    expect(result.target).toBe("air_water_heat_pump");
+  });
+
+  it("detects AWHP abbreviation", () => {
+    const result = inferHeatingGrantTarget("AWHP installation");
+    expect(result.target).toBe("air_water_heat_pump");
+  });
+
+  it("detects ilmavesi (Finnish)", () => {
+    const result = inferHeatingGrantTarget("ilma-vesi lämpöpumppu");
+    expect(result.target).toBe("air_water_heat_pump");
+  });
+
+  it("detects ground source heat pump", () => {
+    const result = inferHeatingGrantTarget("ground source heat pump system");
+    expect(result.target).toBe("ground_source_heat_pump");
+  });
+
+  it("detects geothermal", () => {
+    const result = inferHeatingGrantTarget("geothermal heating");
+    expect(result.target).toBe("ground_source_heat_pump");
+  });
+
+  it("detects maalämpö (Finnish)", () => {
+    const result = inferHeatingGrantTarget("maalämpö asennus");
+    expect(result.target).toBe("ground_source_heat_pump");
+  });
+
+  it("detects district heat", () => {
+    const result = inferHeatingGrantTarget("district heat connection");
+    expect(result.target).toBe("district_heat");
+  });
+
+  it("detects kaukolämpö (Finnish)", () => {
+    const result = inferHeatingGrantTarget("kaukolämpö liittymä");
+    expect(result.target).toBe("district_heat");
+  });
+
+  it("detects generic heat pump as other non-fossil", () => {
+    const result = inferHeatingGrantTarget("heat pump");
+    expect(result.target).toBe("other_non_fossil");
+  });
+
+  it("detects pellet", () => {
+    const result = inferHeatingGrantTarget("pellet boiler system");
+    expect(result.target).toBe("other_non_fossil");
+  });
+
+  it("returns matched terms", () => {
+    const result = inferHeatingGrantTarget("geothermal heating system");
+    expect(result.matchedTerms.length).toBeGreaterThan(0);
+  });
+
+  it("returns null for unrelated text", () => {
+    const result = inferHeatingGrantTarget("building a sauna with wood panels");
+    expect(result.target).toBeNull();
+  });
+});
+
+describe("hasFossilSourceHeating", () => {
+  it("returns false for null", () => {
+    expect(hasFossilSourceHeating(null)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasFossilSourceHeating("")).toBe(false);
+  });
+
+  it("detects oil heating", () => {
+    expect(hasFossilSourceHeating("oil")).toBe(true);
+  });
+
+  it("detects gas heating", () => {
+    expect(hasFossilSourceHeating("gas")).toBe(true);
+  });
+
+  it("detects natural gas", () => {
+    expect(hasFossilSourceHeating("natural gas")).toBe(true);
+  });
+
+  it("detects maakaasu (Finnish for natural gas)", () => {
+    expect(hasFossilSourceHeating("maakaasu")).toBe(true);
+  });
+
+  it("detects öljy (Finnish for oil)", () => {
+    expect(hasFossilSourceHeating("öljy")).toBe(true);
+  });
+
+  it("returns false for electric", () => {
+    expect(hasFossilSourceHeating("electric")).toBe(false);
+  });
+
+  it("returns false for heat pump", () => {
+    expect(hasFossilSourceHeating("heat pump")).toBe(false);
+  });
+});
+
+describe("detectHeatingGrantOpportunity", () => {
+  it("returns shouldShow false for empty input", () => {
+    const result = detectHeatingGrantOpportunity({});
+    expect(result.shouldShow).toBe(false);
+  });
+
+  it("shows when scene mentions heat pump", () => {
+    const result = detectHeatingGrantOpportunity({
+      sceneJs: "// installing ground source heat pump",
+    });
+    expect(result.shouldShow).toBe(true);
+    expect(result.triggeredByScene).toBe(true);
+    expect(result.detectedTargetHeating).toBe("ground_source_heat_pump");
+  });
+
+  it("shows when buildingInfo has fossil heating", () => {
+    const result = detectHeatingGrantOpportunity({
+      buildingInfo: { heating: "oil" } as Parameters<typeof detectHeatingGrantOpportunity>[0]["buildingInfo"],
+    });
+    expect(result.shouldShow).toBe(true);
+    expect(result.fossilSourceHeating).toBe(true);
+  });
+
+  it("does not show for unrelated scene", () => {
+    const result = detectHeatingGrantOpportunity({
+      sceneJs: "const wall = box(4, 2.8, 0.15);",
+    });
+    expect(result.shouldShow).toBe(false);
+  });
+});

--- a/web/src/__tests__/material-affiliate.test.ts
+++ b/web/src/__tests__/material-affiliate.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { buildAffiliateRetailerUrl } from "@/lib/material-affiliate";
+
+describe("buildAffiliateRetailerUrl", () => {
+  it("returns null for null link", () => {
+    expect(buildAffiliateRetailerUrl(null, { materialId: "m1" })).toBeNull();
+  });
+
+  it("returns null for undefined link", () => {
+    expect(buildAffiliateRetailerUrl(undefined, { materialId: "m1" })).toBeNull();
+  });
+
+  it("returns null for empty string link", () => {
+    expect(buildAffiliateRetailerUrl("", { materialId: "m1" })).toBeNull();
+  });
+
+  it("adds UTM params to absolute URL", () => {
+    const result = buildAffiliateRetailerUrl("https://shop.example.com/product", {
+      materialId: "pine-board",
+    });
+    expect(result).toContain("utm_source=helscoop");
+    expect(result).toContain("utm_medium=material_configurator");
+    expect(result).toContain("utm_campaign=bom_to_retailer");
+    expect(result).toContain("hsc_material=pine-board");
+  });
+
+  it("adds supplier param when provided", () => {
+    const result = buildAffiliateRetailerUrl("https://shop.example.com/product", {
+      materialId: "m1",
+      supplier: "K-Rauta",
+    });
+    expect(result).toContain("hsc_supplier=K-Rauta");
+  });
+
+  it("does not add supplier param when null", () => {
+    const result = buildAffiliateRetailerUrl("https://shop.example.com/product", {
+      materialId: "m1",
+      supplier: null,
+    });
+    expect(result).not.toContain("hsc_supplier");
+  });
+
+  it("uses custom source when provided", () => {
+    const result = buildAffiliateRetailerUrl("https://shop.example.com", {
+      materialId: "m1",
+      source: "bom_panel",
+    });
+    expect(result).toContain("hsc_source=bom_panel");
+  });
+
+  it("defaults source to material_configurator", () => {
+    const result = buildAffiliateRetailerUrl("https://shop.example.com", {
+      materialId: "m1",
+    });
+    expect(result).toContain("hsc_source=material_configurator");
+  });
+
+  it("handles relative URL with query params", () => {
+    const result = buildAffiliateRetailerUrl("/products/123?color=red", {
+      materialId: "m1",
+    });
+    expect(result).toContain("&utm_source=helscoop");
+    expect(result).toContain("color=red");
+  });
+
+  it("handles relative URL without query params", () => {
+    const result = buildAffiliateRetailerUrl("/products/123", {
+      materialId: "m1",
+    });
+    expect(result).toContain("?utm_source=helscoop");
+  });
+
+  it("preserves hash fragment in relative URL", () => {
+    const result = buildAffiliateRetailerUrl("/products/123#details", {
+      materialId: "m1",
+    });
+    expect(result).toContain("#details");
+    expect(result).toContain("utm_source=helscoop");
+  });
+
+  it("preserves existing query params on absolute URL", () => {
+    const result = buildAffiliateRetailerUrl("https://shop.example.com/product?sku=ABC", {
+      materialId: "m1",
+    });
+    expect(result).toContain("sku=ABC");
+    expect(result).toContain("utm_source=helscoop");
+  });
+});

--- a/web/src/__tests__/scene-materials.test.ts
+++ b/web/src/__tests__/scene-materials.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { replaceSceneMaterialReferences } from "@/lib/scene-materials";
+
+describe("replaceSceneMaterialReferences", () => {
+  it("returns unchanged code when from equals to", () => {
+    const code = 'scene.add(wall, { material: "lumber" });';
+    const result = replaceSceneMaterialReferences(code, "lumber", "lumber");
+    expect(result).toEqual({ code, replacements: 0 });
+  });
+
+  it("returns unchanged code when from is empty", () => {
+    const code = 'scene.add(wall, { material: "lumber" });';
+    const result = replaceSceneMaterialReferences(code, "", "stone");
+    expect(result).toEqual({ code, replacements: 0 });
+  });
+
+  it("replaces material in scene.add options", () => {
+    const code = 'scene.add(wall, { material: "lumber", color: [1,1,1] });';
+    const result = replaceSceneMaterialReferences(code, "lumber", "stone");
+    expect(result.code).toContain('"stone"');
+    expect(result.code).not.toContain('"lumber"');
+    expect(result.replacements).toBe(1);
+  });
+
+  it("replaces material with single quotes", () => {
+    const code = "scene.add(wall, { material: 'lumber' });";
+    const result = replaceSceneMaterialReferences(code, "lumber", "stone");
+    expect(result.code).toContain("'stone'");
+    expect(result.replacements).toBe(1);
+  });
+
+  it("replaces withMaterial references", () => {
+    const code = 'withMaterial(wall, "lumber")';
+    const result = replaceSceneMaterialReferences(code, "lumber", "foundation");
+    expect(result.code).toContain('"foundation"');
+    expect(result.replacements).toBe(1);
+  });
+
+  it("replaces multiple occurrences", () => {
+    const code = `scene.add(wall1, { material: "lumber" });
+scene.add(wall2, { material: "lumber" });`;
+    const result = replaceSceneMaterialReferences(code, "lumber", "roofing");
+    expect(result.replacements).toBe(2);
+  });
+
+  it("does not replace unrelated strings", () => {
+    const code = 'scene.add(wall, { material: "stone" });';
+    const result = replaceSceneMaterialReferences(code, "lumber", "roofing");
+    expect(result.code).toBe(code);
+    expect(result.replacements).toBe(0);
+  });
+
+  it("handles regex special chars in material id", () => {
+    const code = 'scene.add(wall, { material: "a.b" });';
+    const result = replaceSceneMaterialReferences(code, "a.b", "stone");
+    expect(result.code).toContain('"stone"');
+    expect(result.replacements).toBe(1);
+  });
+});

--- a/web/src/__tests__/shortcut-label.test.ts
+++ b/web/src/__tests__/shortcut-label.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { modKey, shortcutLabel, _resetPlatformCache } from "@/lib/shortcut-label";
+
+beforeEach(() => {
+  _resetPlatformCache();
+});
+
+describe("modKey", () => {
+  it("returns Ctrl on non-Mac platform", () => {
+    Object.defineProperty(navigator, "platform", { value: "Win32", configurable: true });
+    expect(modKey()).toBe("Ctrl");
+  });
+
+  it("returns ⌘ on Mac platform", () => {
+    Object.defineProperty(navigator, "platform", { value: "MacIntel", configurable: true });
+    _resetPlatformCache();
+    expect(modKey()).toBe("⌘");
+  });
+});
+
+describe("shortcutLabel", () => {
+  describe("on non-Mac", () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, "platform", { value: "Win32", configurable: true });
+      _resetPlatformCache();
+    });
+
+    it("formats Cmd+S as Ctrl+S", () => {
+      expect(shortcutLabel("Cmd+S")).toBe("Ctrl+S");
+    });
+
+    it("formats Cmd+Shift+Z as Ctrl+Shift+Z", () => {
+      expect(shortcutLabel("Cmd+Shift+Z")).toBe("Ctrl+Shift+Z");
+    });
+
+    it("formats Escape as Esc", () => {
+      expect(shortcutLabel("Escape")).toBe("Esc");
+    });
+
+    it("formats Cmd+Enter as Ctrl+Enter", () => {
+      expect(shortcutLabel("Cmd+Enter")).toBe("Ctrl+Enter");
+    });
+
+    it("formats Cmd+/ as Ctrl+/", () => {
+      expect(shortcutLabel("Cmd+/")).toBe("Ctrl+/");
+    });
+  });
+
+  describe("on Mac", () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, "platform", { value: "MacIntel", configurable: true });
+      _resetPlatformCache();
+    });
+
+    it("formats Cmd+S as ⌘S", () => {
+      expect(shortcutLabel("Cmd+S")).toBe("⌘S");
+    });
+
+    it("formats Cmd+Shift+Z as ⌘⇧Z", () => {
+      expect(shortcutLabel("Cmd+Shift+Z")).toBe("⌘⇧Z");
+    });
+
+    it("formats Escape as Esc", () => {
+      expect(shortcutLabel("Escape")).toBe("ESC");
+    });
+
+    it("formats Cmd+Enter as ⌘↵", () => {
+      expect(shortcutLabel("Cmd+Enter")).toBe("⌘↵");
+    });
+
+    it("formats Cmd+K as ⌘K", () => {
+      expect(shortcutLabel("Cmd+K")).toBe("⌘K");
+    });
+
+    it("formats Cmd+/ as ⌘/", () => {
+      expect(shortcutLabel("Cmd+/")).toBe("⌘/");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 20 tests for `compliance.ts`: Finnish building code rules (ceiling height, door width, handrail, max height, room area, Three.js fallback parser)
- 27 tests for `heating-grant-context.ts`: heating type detection (AWHP, GSHP, district, fossil), Finnish terms, grant opportunity detection
- 12 tests for `material-affiliate.ts`: affiliate URL building, UTM params, supplier/source, relative URLs, hash preservation
- 8 tests for `scene-materials.ts`: material reference replacement in scene DSL code
- 13 tests for `shortcut-label.ts`: platform-aware keyboard shortcut labels (Mac ⌘/⇧ vs Ctrl+)

## Test plan
- [x] All 80 tests pass locally with vitest
- [x] TypeScript type-check passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)