### PR TITLE
test: 45 tests for waste-factors and material-trends modules

### DIFF
--- a/api/src/__tests__/material-trends-unit.test.ts
+++ b/api/src/__tests__/material-trends-unit.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMaterialTrend,
+  buildProjectTrendSummary,
+} from "../material-trends";
+import type { MaterialTrendInput, MaterialTrendResult } from "../material-trends";
+
+const baseInput: MaterialTrendInput = {
+  materialId: "m1",
+  materialName: "Pine Board",
+  categoryName: "lumber",
+  quantity: 20,
+  unit: "kpl",
+  unitPrice: 4.5,
+  lineCost: 90,
+};
+
+const now = new Date("2026-06-15T00:00:00Z");
+
+describe("buildMaterialTrend", () => {
+  it("returns correct materialId and name", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(result.materialId).toBe("m1");
+    expect(result.materialName).toBe("Pine Board");
+  });
+
+  it("returns current unit price and line cost", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(result.currentUnitPrice).toBe(4.5);
+    expect(result.currentLineCost).toBe(90);
+  });
+
+  it("uses seasonal model when no history", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(result.source).toBe("seasonal_model");
+    expect(result.confidence).toBe("low");
+  });
+
+  it("generates 12 seasonal points when no history", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(result.points.length).toBe(12);
+    expect(result.points[0].source).toBe("seasonal_model");
+  });
+
+  it("uses retailer_history when enough data points", () => {
+    const history = Array.from({ length: 6 }, (_, i) => ({
+      unitPrice: 4 + i * 0.1,
+      scrapedAt: new Date(Date.UTC(2026, i, 15)).toISOString(),
+    }));
+    const result = buildMaterialTrend({ ...baseInput, history }, now);
+    expect(result.source).toBe("retailer_history");
+    expect(result.confidence).toBe("high");
+  });
+
+  it("uses medium confidence with 2-5 history points", () => {
+    const history = [
+      { unitPrice: 4.0, scrapedAt: "2026-03-15" },
+      { unitPrice: 4.3, scrapedAt: "2026-04-15" },
+      { unitPrice: 4.5, scrapedAt: "2026-05-15" },
+    ];
+    const result = buildMaterialTrend({ ...baseInput, history }, now);
+    expect(result.confidence).toBe("medium");
+  });
+
+  it("computes vs3mPct and vs12mPct", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(result.vs3mPct).not.toBeNull();
+    expect(result.vs12mPct).not.toBeNull();
+  });
+
+  it("detects rising direction for lumber in summer", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(["rising", "stable", "falling"]).toContain(result.direction);
+  });
+
+  it("computes bestBuyMonth", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    if (result.bestBuyMonth) {
+      expect(result.bestBuyMonth).toMatch(/^\d{4}-\d{2}$/);
+    }
+  });
+
+  it("computes estimatedWaitSavings", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(result.estimatedWaitSavings).toBeGreaterThanOrEqual(0);
+  });
+
+  it("provides recommendation", () => {
+    const result = buildMaterialTrend(baseInput, now);
+    expect(["buy_now", "wait", "watch"]).toContain(result.recommendation);
+  });
+
+  it("handles null categoryName", () => {
+    const input = { ...baseInput, categoryName: null };
+    const result = buildMaterialTrend(input, now);
+    expect(result.categoryName).toBeNull();
+    expect(result.points.length).toBe(12);
+  });
+
+  it("filters invalid history prices", () => {
+    const history = [
+      { unitPrice: 4.0, scrapedAt: "2026-03-15" },
+      { unitPrice: -1, scrapedAt: "2026-04-15" },
+      { unitPrice: 4.5, scrapedAt: "2026-05-15" },
+    ];
+    const result = buildMaterialTrend({ ...baseInput, history }, now);
+    expect(result.points.every((p) => p.unitPrice > 0)).toBe(true);
+  });
+
+  it("detects falling direction", () => {
+    const history = [
+      { unitPrice: 6.0, scrapedAt: "2026-01-15" },
+      { unitPrice: 5.5, scrapedAt: "2026-02-15" },
+      { unitPrice: 5.0, scrapedAt: "2026-03-15" },
+      { unitPrice: 4.5, scrapedAt: "2026-04-15" },
+      { unitPrice: 4.0, scrapedAt: "2026-05-15" },
+      { unitPrice: 3.5, scrapedAt: "2026-06-15" },
+    ];
+    const result = buildMaterialTrend({ ...baseInput, history }, now);
+    expect(result.direction).toBe("falling");
+  });
+
+  it("recommends buy_now when below 12m average", () => {
+    const history = Array.from({ length: 8 }, (_, i) => ({
+      unitPrice: 5.0,
+      scrapedAt: new Date(Date.UTC(2025, 10 + i, 15)).toISOString(),
+    }));
+    const result = buildMaterialTrend({ ...baseInput, unitPrice: 4.0, lineCost: 80, history }, now);
+    expect(result.recommendation).toBe("buy_now");
+  });
+
+  it("lumber seasonal peaks in summer", () => {
+    const winterNow = new Date("2026-01-15T00:00:00Z");
+    const result = buildMaterialTrend(baseInput, winterNow);
+    const jan = result.points.find((p) => p.month.endsWith("-01"));
+    const jun = result.points.find((p) => p.month.endsWith("-06"));
+    if (jan && jun) {
+      expect(jun.unitPrice).toBeGreaterThan(jan.unitPrice);
+    }
+  });
+});
+
+describe("buildProjectTrendSummary", () => {
+  it("computes total current cost", () => {
+    const items: MaterialTrendResult[] = [
+      buildMaterialTrend(baseInput, now),
+      buildMaterialTrend({ ...baseInput, materialId: "m2", lineCost: 60, unitPrice: 3 }, now),
+    ];
+    const summary = buildProjectTrendSummary(items);
+    expect(summary.totalCurrentCost).toBe(150);
+  });
+
+  it("counts buy/wait/watch items", () => {
+    const items = [
+      buildMaterialTrend(baseInput, now),
+    ];
+    const summary = buildProjectTrendSummary(items);
+    expect(summary.buyNowCount + summary.waitCount + summary.watchCount).toBe(items.length);
+  });
+
+  it("returns empty summary for no items", () => {
+    const summary = buildProjectTrendSummary([]);
+    expect(summary.totalCurrentCost).toBe(0);
+    expect(summary.buyNowCount).toBe(0);
+    expect(summary.waitCount).toBe(0);
+    expect(summary.watchCount).toBe(0);
+    expect(summary.bestBuyMonth).toBeNull();
+  });
+
+  it("computes weighted vs12mPct", () => {
+    const items = [buildMaterialTrend(baseInput, now)];
+    const summary = buildProjectTrendSummary(items);
+    if (items[0].vs12mPct != null) {
+      expect(summary.weightedVs12mPct).not.toBeNull();
+    }
+  });
+
+  it("computes best buy month from items", () => {
+    const items = [
+      buildMaterialTrend(baseInput, now),
+      buildMaterialTrend({ ...baseInput, materialId: "m2", categoryName: "roofing" }, now),
+    ];
+    const summary = buildProjectTrendSummary(items);
+    if (items.some((i) => i.bestBuyMonth)) {
+      expect(summary.bestBuyMonth).toMatch(/^\d{4}-\d{2}$/);
+    }
+  });
+
+  it("includes items in summary", () => {
+    const items = [buildMaterialTrend(baseInput, now)];
+    const summary = buildProjectTrendSummary(items);
+    expect(summary.items).toHaveLength(1);
+    expect(summary.items[0].materialId).toBe("m1");
+  });
+});

--- a/api/src/__tests__/waste-factors-unit.test.ts
+++ b/api/src/__tests__/waste-factors-unit.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  WASTE_FACTORS,
+  DEFAULT_WASTE_FACTOR,
+  CONTAINER_SIZES,
+  SORTING_GUIDE,
+  recommendContainer,
+} from "../waste-factors";
+
+describe("WASTE_FACTORS", () => {
+  it("has entries for common categories", () => {
+    expect(WASTE_FACTORS.lumber).toBeDefined();
+    expect(WASTE_FACTORS.panels).toBeDefined();
+    expect(WASTE_FACTORS.insulation).toBeDefined();
+    expect(WASTE_FACTORS.roofing).toBeDefined();
+    expect(WASTE_FACTORS.foundation).toBeDefined();
+    expect(WASTE_FACTORS.fasteners).toBeDefined();
+    expect(WASTE_FACTORS.plumbing).toBeDefined();
+    expect(WASTE_FACTORS.electrical).toBeDefined();
+    expect(WASTE_FACTORS.windows).toBeDefined();
+    expect(WASTE_FACTORS.paint).toBeDefined();
+  });
+
+  it("lumber waste is free at Sortti", () => {
+    expect(WASTE_FACTORS.lumber.disposalCostPerTonne).toBe(0);
+  });
+
+  it("metal roofing is highly recyclable", () => {
+    expect(WASTE_FACTORS.roofing.recyclingRate).toBeGreaterThan(0.9);
+  });
+
+  it("paint is hazardous waste", () => {
+    expect(WASTE_FACTORS.paint.wasteType).toBe("vaarallinen_jate");
+    expect(WASTE_FACTORS.paint.recyclingRate).toBe(0);
+  });
+
+  it("electrical has secondary hazardous waste type", () => {
+    expect(WASTE_FACTORS.electrical.secondaryWasteType).toBe("vaarallinen_jate");
+  });
+
+  it("all factors have positive kgPerUnit", () => {
+    for (const [, factor] of Object.entries(WASTE_FACTORS)) {
+      expect(factor.kgPerUnit).toBeGreaterThan(0);
+    }
+  });
+
+  it("all recycling rates are between 0 and 1", () => {
+    for (const [, factor] of Object.entries(WASTE_FACTORS)) {
+      expect(factor.recyclingRate).toBeGreaterThanOrEqual(0);
+      expect(factor.recyclingRate).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("DEFAULT_WASTE_FACTOR", () => {
+  it("is classified as mixed waste", () => {
+    expect(DEFAULT_WASTE_FACTOR.wasteType).toBe("sekajate");
+  });
+
+  it("has conservative recycling rate", () => {
+    expect(DEFAULT_WASTE_FACTOR.recyclingRate).toBe(0.3);
+  });
+});
+
+describe("CONTAINER_SIZES", () => {
+  it("has 3 sizes", () => {
+    expect(CONTAINER_SIZES.length).toBe(3);
+  });
+
+  it("sizes are in ascending order", () => {
+    for (let i = 1; i < CONTAINER_SIZES.length; i++) {
+      expect(CONTAINER_SIZES[i].sizeM3).toBeGreaterThan(CONTAINER_SIZES[i - 1].sizeM3);
+    }
+  });
+
+  it("costs increase with size", () => {
+    for (let i = 1; i < CONTAINER_SIZES.length; i++) {
+      expect(CONTAINER_SIZES[i].costEur).toBeGreaterThan(CONTAINER_SIZES[i - 1].costEur);
+    }
+  });
+
+  it("has Finnish labels", () => {
+    for (const size of CONTAINER_SIZES) {
+      expect(size.labelFi).toContain("vaihtolavat");
+    }
+  });
+});
+
+describe("recommendContainer", () => {
+  it("recommends smallest container for small waste", () => {
+    const result = recommendContainer(2, 1000);
+    expect(result.size.sizeM3).toBe(4);
+    expect(result.count).toBe(1);
+  });
+
+  it("recommends container that fits volume in 1-2 units", () => {
+    const result = recommendContainer(5, 2000);
+    expect(result.size.sizeM3 * result.count).toBeGreaterThanOrEqual(5);
+    expect(result.count).toBeLessThanOrEqual(2);
+  });
+
+  it("recommends multiple containers for large waste", () => {
+    const result = recommendContainer(25, 5000);
+    expect(result.count).toBeGreaterThan(1);
+  });
+
+  it("considers weight limit", () => {
+    const result = recommendContainer(3, 7000);
+    expect(result.size.sizeM3).toBeGreaterThanOrEqual(6);
+  });
+
+  it("total cost is count * unit cost", () => {
+    const result = recommendContainer(3, 1000);
+    expect(result.totalCost).toBe(result.size.costEur * result.count);
+  });
+
+  it("always returns at least 1 container", () => {
+    const result = recommendContainer(0.1, 10);
+    expect(result.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to largest for very large waste", () => {
+    const result = recommendContainer(100, 50000);
+    expect(result.size.sizeM3).toBe(10);
+    expect(result.count).toBeGreaterThan(2);
+  });
+});
+
+describe("SORTING_GUIDE", () => {
+  it("has entries for all waste types", () => {
+    const types = SORTING_GUIDE.map((e) => e.wasteType);
+    expect(types).toContain("puujate");
+    expect(types).toContain("metallijate");
+    expect(types).toContain("kivijate");
+    expect(types).toContain("sekajate");
+    expect(types).toContain("vaarallinen_jate");
+    expect(types).toContain("muovijate");
+    expect(types).toContain("lasijate");
+    expect(types).toContain("eristejate");
+  });
+
+  it("has Finnish and English instructions for each", () => {
+    for (const entry of SORTING_GUIDE) {
+      expect(entry.sortingInstruction_fi.length).toBeGreaterThan(0);
+      expect(entry.sortingInstruction_en.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has accepted location for each entry", () => {
+    for (const entry of SORTING_GUIDE) {
+      expect(entry.acceptedAt.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 23 tests for `waste-factors.ts`: waste factor entries validation, container recommendation algorithm, sorting guide completeness, recycling rates, disposal costs
- 22 tests for `material-trends.ts`: `buildMaterialTrend` (seasonal model, retailer history, confidence levels, direction detection, recommendations, seasonal peaks) and `buildProjectTrendSummary` (aggregation, weighted averages, best buy month)

## Test plan
- [x] All 45 tests pass locally with vitest
- [x] Pure function tests — no API/DB mocking needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)