### PR TITLE
test: quote-engine, presentation-export, ifc-generator unit tests

### DIFF
--- a/api/src/__tests__/ifc-generator-unit.test.ts
+++ b/api/src/__tests__/ifc-generator-unit.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from "vitest";
+import {
+  IFC_SCHEMA,
+  IFC_VIEW_DEFINITION,
+  IFC_PERMIT_EXPORT_PURPOSE,
+  classifyElement,
+  parseSceneObjects,
+  generateIFC,
+} from "../ifc-generator";
+
+describe("IFC constants", () => {
+  it("uses IFC4X3_ADD2 schema", () => {
+    expect(IFC_SCHEMA).toBe("IFC4X3_ADD2");
+  });
+
+  it("uses ReferenceView_V1.2", () => {
+    expect(IFC_VIEW_DEFINITION).toBe("ReferenceView_V1.2");
+  });
+
+  it("has Finnish permit export purpose", () => {
+    expect(IFC_PERMIT_EXPORT_PURPOSE).toContain("Rakentamislaki");
+  });
+});
+
+describe("classifyElement", () => {
+  it("classifies 'wall' as wall", () => {
+    expect(classifyElement("wall_01")).toBe("wall");
+  });
+
+  it("classifies 'seinä' as wall (Finnish)", () => {
+    expect(classifyElement("ulko_seina")).toBe("wall");
+  });
+
+  it("classifies 'roof' as roof", () => {
+    expect(classifyElement("main_roof")).toBe("roof");
+  });
+
+  it("classifies 'katto' as roof (Finnish)", () => {
+    expect(classifyElement("katto_panel")).toBe("roof");
+  });
+
+  it("classifies 'door' as door", () => {
+    expect(classifyElement("front_door")).toBe("door");
+  });
+
+  it("classifies 'ovi' as door (Finnish)", () => {
+    expect(classifyElement("ulko_ovi")).toBe("door");
+  });
+
+  it("classifies 'window' as window", () => {
+    expect(classifyElement("side_window")).toBe("window");
+  });
+
+  it("classifies 'ikkuna' as window (Finnish)", () => {
+    expect(classifyElement("ikkuna_1")).toBe("window");
+  });
+
+  it("classifies 'floor' as slab", () => {
+    expect(classifyElement("floor_slab")).toBe("slab");
+  });
+
+  it("classifies 'lattia' as slab (Finnish)", () => {
+    expect(classifyElement("lattia_plate")).toBe("slab");
+  });
+
+  it("classifies 'foundation' as slab", () => {
+    expect(classifyElement("foundation_base")).toBe("slab");
+  });
+
+  it("classifies 'gate' as door", () => {
+    expect(classifyElement("main_gate")).toBe("door");
+  });
+
+  it("classifies 'portti' as door (Finnish)", () => {
+    expect(classifyElement("portti_1")).toBe("door");
+  });
+
+  it("falls back to material-based classification", () => {
+    expect(classifyElement("element_1", "roofing_metal")).toBe("roof");
+  });
+
+  it("concrete material classifies as slab", () => {
+    expect(classifyElement("base_1", "betoni")).toBe("slab");
+  });
+
+  it("defaults to wall for unclassified elements", () => {
+    expect(classifyElement("structural_beam")).toBe("wall");
+  });
+});
+
+describe("parseSceneObjects", () => {
+  it("returns empty array for empty scene", () => {
+    expect(parseSceneObjects("")).toHaveLength(0);
+  });
+
+  it("parses box with translate", () => {
+    const scene = `
+const wall = translate(box(4, 2.5, 0.2), 0, 0, 0)
+scene.add(wall)
+`;
+    const objs = parseSceneObjects(scene);
+    expect(objs).toHaveLength(1);
+    expect(objs[0].name).toBe("wall");
+    expect(objs[0].type).toBe("wall");
+    expect(objs[0].dimensions).toEqual({ x: 4, y: 2.5, z: 0.2 });
+    expect(objs[0].position).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it("parses standalone box", () => {
+    const scene = `
+const slab = box(10, 0.3, 8)
+scene.add(slab)
+`;
+    const objs = parseSceneObjects(scene);
+    expect(objs).toHaveLength(1);
+    expect(objs[0].dimensions).toEqual({ x: 10, y: 0.3, z: 8 });
+    expect(objs[0].position).toEqual({ x: 0, y: 0, z: 0 });
+  });
+
+  it("extracts material from scene.add options", () => {
+    const scene = `
+const roof = translate(box(10, 0.1, 8), 0, 3, 0)
+scene.add(roof, { material: "pelti_katto" })
+`;
+    const objs = parseSceneObjects(scene);
+    expect(objs).toHaveLength(1);
+    expect(objs[0].material).toBe("pelti_katto");
+  });
+
+  it("parses multiple scene objects", () => {
+    const scene = `
+const wall_left = translate(box(0.2, 2.5, 8), 0, 0, 0)
+const wall_right = translate(box(0.2, 2.5, 8), 10, 0, 0)
+const roof = translate(box(10.4, 0.1, 8.4), -0.2, 2.5, -0.2)
+scene.add(wall_left)
+scene.add(wall_right)
+scene.add(roof)
+`;
+    const objs = parseSceneObjects(scene);
+    expect(objs).toHaveLength(3);
+    expect(objs.map((o) => o.name)).toEqual(["wall_left", "wall_right", "roof"]);
+  });
+
+  it("classifies elements by name", () => {
+    const scene = `
+const front_door = translate(box(0.9, 2.1, 0.05), 3, 0, 0)
+const side_window = translate(box(1.2, 1.0, 0.05), 6, 1.2, 0)
+scene.add(front_door)
+scene.add(side_window)
+`;
+    const objs = parseSceneObjects(scene);
+    expect(objs[0].type).toBe("door");
+    expect(objs[1].type).toBe("window");
+  });
+
+  it("ignores variables not added to scene", () => {
+    const scene = `
+const wall = translate(box(4, 2.5, 0.2), 0, 0, 0)
+const unused = box(1, 1, 1)
+scene.add(wall)
+`;
+    const objs = parseSceneObjects(scene);
+    expect(objs).toHaveLength(1);
+    expect(objs[0].name).toBe("wall");
+  });
+});
+
+describe("generateIFC", () => {
+  const minimalInput = {
+    project: { id: "p1", name: "Test Sauna" },
+    bom: [],
+  };
+
+  it("produces valid STEP file structure", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("ISO-10303-21;");
+    expect(ifc).toContain("HEADER;");
+    expect(ifc).toContain("DATA;");
+    expect(ifc).toContain("ENDSEC;");
+    expect(ifc).toContain("END-ISO-10303-21;");
+  });
+
+  it("contains IFC4X3 schema reference", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("IFC4X3_ADD2");
+  });
+
+  it("contains project name", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("Test Sauna");
+  });
+
+  it("contains IFCPROJECT entity", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("IFCPROJECT(");
+  });
+
+  it("contains spatial hierarchy", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("IFCSITE(");
+    expect(ifc).toContain("IFCBUILDING(");
+    expect(ifc).toContain("IFCBUILDINGSTOREY(");
+  });
+
+  it("contains aggregation relationships", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("IFCRELAGGREGATES(");
+  });
+
+  it("contains unit definitions", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("IFCSIUNIT");
+    expect(ifc).toContain(".METRE.");
+    expect(ifc).toContain(".SQUARE_METRE.");
+  });
+
+  it("includes building info in metadata", () => {
+    const ifc = generateIFC({
+      ...minimalInput,
+      buildingInfo: {
+        address: "Mannerheimintie 1",
+        buildingType: "omakotitalo",
+        yearBuilt: 1985,
+      },
+    });
+    expect(ifc).toContain("Mannerheimintie 1");
+    expect(ifc).toContain("omakotitalo");
+  });
+
+  it("includes scene objects as IFC elements", () => {
+    const ifc = generateIFC({
+      project: {
+        id: "p2",
+        name: "Mökki",
+        scene_js: `
+const wall = translate(box(4, 2.5, 0.2), 0, 0, 0)
+scene.add(wall)
+`,
+      },
+      bom: [],
+    });
+    expect(ifc).toContain("IFCWALL(");
+    expect(ifc).toContain("IFCRELCONTAINEDINSPATIALSTRUCTURE(");
+  });
+
+  it("includes material assignments", () => {
+    const ifc = generateIFC({
+      project: {
+        id: "p3",
+        name: "Talo",
+        scene_js: `
+const roof = translate(box(10, 0.1, 8), 0, 3, 0)
+scene.add(roof, { material: "pelti" })
+`,
+      },
+      bom: [{ material_id: "pelti", material_name: "Peltikatteen", quantity: 80, unit: "m2" }],
+    });
+    expect(ifc).toContain("IFCMATERIAL(");
+    expect(ifc).toContain("IFCRELASSOCIATESMATERIAL(");
+    expect(ifc).toContain("Peltikatteen");
+  });
+
+  it("includes permit metadata property set", () => {
+    const ifc = generateIFC({
+      ...minimalInput,
+      permitMetadata: {
+        permanentBuildingIdentifier: "103456789A",
+        propertyIdentifier: "091-001-0001-0001",
+        municipalityNumber: "091",
+        energyClass: "C",
+      },
+    });
+    expect(ifc).toContain("Pset_HelscoopPermitMetadata");
+    expect(ifc).toContain("103456789A");
+    expect(ifc).toContain("091-001-0001-0001");
+  });
+
+  it("maps window type to IFCWINDOW", () => {
+    const ifc = generateIFC({
+      project: {
+        id: "p4",
+        name: "Talo",
+        scene_js: `
+const window_1 = translate(box(1.2, 1.0, 0.05), 3, 1, 0)
+scene.add(window_1)
+`,
+      },
+      bom: [],
+    });
+    expect(ifc).toContain("IFCWINDOW(");
+  });
+
+  it("maps door type to IFCDOOR", () => {
+    const ifc = generateIFC({
+      project: {
+        id: "p5",
+        name: "Talo",
+        scene_js: `
+const front_door = translate(box(0.9, 2.1, 0.05), 2, 0, 0)
+scene.add(front_door)
+`,
+      },
+      bom: [],
+    });
+    expect(ifc).toContain("IFCDOOR(");
+  });
+
+  it("escapes single quotes in project name", () => {
+    const ifc = generateIFC({
+      project: { id: "p6", name: "Matti's Talo" },
+      bom: [],
+    });
+    expect(ifc).toContain("Matti''s Talo");
+  });
+
+  it("contains Helscoop organization", () => {
+    const ifc = generateIFC(minimalInput);
+    expect(ifc).toContain("IFCORGANIZATION");
+    expect(ifc).toContain("Helscoop");
+  });
+});

--- a/web/src/__tests__/presentation-export.test.ts
+++ b/web/src/__tests__/presentation-export.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  PRESENTATION_PRESETS,
+  getPresentationPreset,
+  buildPresentationUrl,
+  sanitizePresentationFilename,
+  formatPresentationCurrency,
+} from "@/lib/presentation-export";
+
+describe("PRESENTATION_PRESETS", () => {
+  it("has 4 presets", () => {
+    expect(PRESENTATION_PRESETS).toHaveLength(4);
+  });
+
+  it("has front, side, aerial, iso IDs", () => {
+    const ids = PRESENTATION_PRESETS.map((p) => p.id);
+    expect(ids).toEqual(["front", "side", "aerial", "iso"]);
+  });
+
+  it("camera indices are 0-3", () => {
+    PRESENTATION_PRESETS.forEach((p, i) => {
+      expect(p.cameraIndex).toBe(i);
+    });
+  });
+
+  it("all have label and description keys", () => {
+    for (const p of PRESENTATION_PRESETS) {
+      expect(p.labelKey).toMatch(/^presentation\./);
+      expect(p.descriptionKey).toMatch(/^presentation\./);
+    }
+  });
+});
+
+describe("getPresentationPreset", () => {
+  it("returns front preset for 'front'", () => {
+    expect(getPresentationPreset("front").id).toBe("front");
+  });
+
+  it("returns side preset for 'side'", () => {
+    expect(getPresentationPreset("side").id).toBe("side");
+  });
+
+  it("returns aerial preset for 'aerial'", () => {
+    expect(getPresentationPreset("aerial").id).toBe("aerial");
+  });
+
+  it("returns iso preset for 'iso'", () => {
+    expect(getPresentationPreset("iso").id).toBe("iso");
+  });
+
+  it("defaults to iso for null", () => {
+    expect(getPresentationPreset(null).id).toBe("iso");
+  });
+
+  it("defaults to iso for undefined", () => {
+    expect(getPresentationPreset(undefined).id).toBe("iso");
+  });
+
+  it("defaults to iso for unknown string", () => {
+    expect(getPresentationPreset("top-down").id).toBe("iso");
+  });
+});
+
+describe("buildPresentationUrl", () => {
+  it("builds URL with share token and preset", () => {
+    const url = buildPresentationUrl("https://helscoop.fi", "abc123", "front");
+    expect(url).toContain("/shared/abc123");
+    expect(url).toContain("presentation=1");
+    expect(url).toContain("camera=front");
+  });
+
+  it("strips trailing slash from origin", () => {
+    const url = buildPresentationUrl("https://helscoop.fi/", "tok", "side");
+    expect(url).toMatch(/^https:\/\/helscoop\.fi\/shared\//);
+    expect(url).not.toContain("helscoop.fi//");
+  });
+
+  it("encodes share token", () => {
+    const url = buildPresentationUrl("https://helscoop.fi", "a b+c", "front");
+    expect(url).toContain("a%20b%2Bc");
+  });
+
+  it("defaults to iso camera for null preset", () => {
+    const url = buildPresentationUrl("https://helscoop.fi", "tok", null);
+    expect(url).toContain("camera=iso");
+  });
+});
+
+describe("sanitizePresentationFilename", () => {
+  it("generates filename with preset ID", () => {
+    const name = sanitizePresentationFilename("My Sauna", "front");
+    expect(name).toBe("my-sauna-front.png");
+  });
+
+  it("removes special characters", () => {
+    const name = sanitizePresentationFilename("Talo #1 (uusi)", "side");
+    expect(name).toBe("talo-1-uusi-side.png");
+  });
+
+  it("defaults to iso for null preset", () => {
+    const name = sanitizePresentationFilename("Test", null);
+    expect(name).toBe("test-iso.png");
+  });
+
+  it("uses default name for empty project name", () => {
+    const name = sanitizePresentationFilename("", "front");
+    expect(name).toBe("helscoop-project-front.png");
+  });
+
+  it("uses custom extension", () => {
+    const name = sanitizePresentationFilename("Sauna", "aerial", "jpg");
+    expect(name).toBe("sauna-aerial.jpg");
+  });
+
+  it("collapses multiple dashes", () => {
+    const name = sanitizePresentationFilename("A - B - C", "front");
+    expect(name).toBe("a-b-c-front.png");
+  });
+});
+
+describe("formatPresentationCurrency", () => {
+  it("formats with Finnish locale", () => {
+    const result = formatPresentationCurrency(1500, "fi");
+    expect(result).toContain("€");
+    expect(result).toContain("1");
+    expect(result).toContain("500");
+  });
+
+  it("formats with English locale", () => {
+    const result = formatPresentationCurrency(1500, "en");
+    expect(result).toContain("€");
+    expect(result).toContain("1");
+  });
+
+  it("no decimal digits", () => {
+    const result = formatPresentationCurrency(1500.75, "en");
+    expect(result).not.toContain(".");
+    expect(result).toContain("€");
+  });
+
+  it("formats zero", () => {
+    const result = formatPresentationCurrency(0, "fi");
+    expect(result).toContain("0");
+    expect(result).toContain("€");
+  });
+});

--- a/web/src/__tests__/quote-engine.test.ts
+++ b/web/src/__tests__/quote-engine.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { calculateQuote, defaultQuoteConfig } from "@/lib/quote-engine";
+import type { QuoteConfig } from "@/lib/quote-engine";
+
+const baseMaterial = {
+  id: "m1",
+  name: "Pine Board",
+  name_en: "Pine Board",
+  name_fi: "Mäntylankku",
+  category_name: "lumber",
+  pricing: [{ unit_price: 5, unit: "kpl", is_primary: true }],
+};
+
+const baseConfig: QuoteConfig = {
+  mode: "homeowner",
+  vatRate: 0.255,
+  labourRatePerHour: 45,
+  wastagePercent: 0.10,
+};
+
+describe("defaultQuoteConfig", () => {
+  it("returns Finnish standard VAT rate 25.5%", () => {
+    const config = defaultQuoteConfig();
+    expect(config.vatRate).toBe(0.255);
+  });
+
+  it("returns 45€/h labour rate", () => {
+    const config = defaultQuoteConfig();
+    expect(config.labourRatePerHour).toBe(45);
+  });
+
+  it("returns 10% wastage", () => {
+    const config = defaultQuoteConfig();
+    expect(config.wastagePercent).toBe(0.10);
+  });
+
+  it("homeowner mode has no contractor margin", () => {
+    const config = defaultQuoteConfig("homeowner");
+    expect(config.contractorMarginPercent).toBeUndefined();
+  });
+
+  it("contractor mode has 15% margin", () => {
+    const config = defaultQuoteConfig("contractor");
+    expect(config.contractorMarginPercent).toBe(0.15);
+  });
+});
+
+describe("calculateQuote", () => {
+  it("returns empty lines for empty BOM", () => {
+    const quote = calculateQuote([], [], baseConfig);
+    expect(quote.lines).toHaveLength(0);
+    expect(quote.grandTotal).toBe(0);
+  });
+
+  it("computes material cost with wastage", () => {
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    const line = quote.lines[0];
+    expect(line.designQty).toBe(10);
+    expect(line.wastageQty).toBe(1);
+    expect(line.materialCost).toBe(55); // 11 units * 5€
+  });
+
+  it("includes labour cost based on category", () => {
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    const line = quote.lines[0];
+    // lumber = 0.5 hours/unit * 11 units = 5.5 hours * 45€/h = 247.50
+    expect(line.labourHours).toBe(5.5);
+    expect(line.labourCost).toBe(247.5);
+  });
+
+  it("computes VAT at configured rate", () => {
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    const line = quote.lines[0];
+    const expectedVat = Math.round(line.subtotal * 0.255 * 100) / 100;
+    expect(line.vatAmount).toBe(expectedVat);
+  });
+
+  it("line total = subtotal + VAT", () => {
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    const line = quote.lines[0];
+    expect(line.total).toBe(Math.round((line.subtotal + line.vatAmount) * 100) / 100);
+  });
+
+  it("aggregates across multiple BOM items", () => {
+    const mat2 = { ...baseMaterial, id: "m2", name: "Insulation", name_en: "Insulation", category_name: "insulation", pricing: [{ unit_price: 3, unit: "m2", is_primary: true }] };
+    const bom = [
+      { material_id: "m1", quantity: 10, unit: "kpl" },
+      { material_id: "m2", quantity: 20, unit: "m2" },
+    ];
+    const quote = calculateQuote(bom, [baseMaterial as any, mat2 as any], baseConfig);
+    expect(quote.lines).toHaveLength(2);
+    expect(quote.materialSubtotal).toBe(quote.lines[0].materialCost + quote.lines[1].materialCost);
+    expect(quote.labourSubtotal).toBe(quote.lines[0].labourCost + quote.lines[1].labourCost);
+  });
+
+  it("applies contractor margin in contractor mode", () => {
+    const contractorConfig: QuoteConfig = {
+      ...baseConfig,
+      mode: "contractor",
+      contractorMarginPercent: 0.15,
+    };
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], contractorConfig);
+    expect(quote.contractorMargin).toBeDefined();
+    expect(quote.contractorMargin).toBeGreaterThan(0);
+    const baseTotal = Math.round((quote.subtotalExVat + quote.vatTotal) * 100) / 100;
+    expect(quote.grandTotal).toBeGreaterThan(baseTotal);
+  });
+
+  it("no contractor margin in homeowner mode", () => {
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    expect(quote.contractorMargin).toBeUndefined();
+  });
+
+  it("uses BOM unit_price over material pricing when available", () => {
+    const bom = [{ material_id: "m1", quantity: 10, unit: "kpl", unit_price: 8 }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    // 11 units * 8€ = 88
+    expect(quote.lines[0].materialCost).toBe(88);
+  });
+
+  it("uses default labour hours for unknown category", () => {
+    const unknownMat = { ...baseMaterial, id: "mx", category_name: "exotic", pricing: [{ unit_price: 10, unit: "kpl", is_primary: true }] };
+    const bom = [{ material_id: "mx", quantity: 5, unit: "kpl" }];
+    const quote = calculateQuote(bom, [unknownMat as any], baseConfig);
+    // default = 0.2h/unit, 5.5 units * 0.2 = 1.1h
+    expect(quote.lines[0].labourHours).toBe(1.1);
+  });
+
+  it("handles missing material gracefully", () => {
+    const bom = [{ material_id: "unknown", quantity: 5, unit: "kpl", material_name: "Mystery" }];
+    const quote = calculateQuote(bom, [], baseConfig);
+    expect(quote.lines[0].materialName).toBe("Mystery");
+    expect(quote.lines[0].materialCost).toBe(0); // no price info
+  });
+
+  it("generatedAt is ISO timestamp", () => {
+    const quote = calculateQuote([], [], baseConfig);
+    expect(quote.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("config is preserved in output", () => {
+    const quote = calculateQuote([], [], baseConfig);
+    expect(quote.config).toEqual(baseConfig);
+  });
+
+  it("uses insulation category labour rate", () => {
+    const mat = { ...baseMaterial, id: "ins", category_name: "eristys", pricing: [{ unit_price: 3, unit: "m2", is_primary: true }] };
+    const bom = [{ material_id: "ins", quantity: 10, unit: "m2" }];
+    const quote = calculateQuote(bom, [mat as any], baseConfig);
+    // eristys = 0.3h/unit, 11 units * 0.3 = 3.3h
+    expect(quote.lines[0].labourHours).toBe(3.3);
+  });
+
+  it("uses foundation category labour rate", () => {
+    const mat = { ...baseMaterial, id: "fnd", category_name: "perustus", pricing: [{ unit_price: 20, unit: "m3", is_primary: true }] };
+    const bom = [{ material_id: "fnd", quantity: 5, unit: "m3" }];
+    const quote = calculateQuote(bom, [mat as any], baseConfig);
+    // perustus = 1.0h/unit, 5.5 units * 1.0 = 5.5h
+    expect(quote.lines[0].labourHours).toBe(5.5);
+  });
+
+  it("zero quantity produces zero costs", () => {
+    const bom = [{ material_id: "m1", quantity: 0, unit: "kpl" }];
+    const quote = calculateQuote(bom, [baseMaterial as any], baseConfig);
+    expect(quote.lines[0].materialCost).toBe(0);
+    expect(quote.lines[0].labourCost).toBe(0);
+    expect(quote.lines[0].total).toBe(0);
+  });
+});

--- a/web/src/__tests__/ryhti-submission-panel.test.tsx
+++ b/web/src/__tests__/ryhti-submission-panel.test.tsx
@@ -208,7 +208,7 @@ describe("RyhtiSubmissionPanel", () => {
     fireEvent.click(checkBtn);
     await waitFor(() => {
       expect(mockUpdateRyhtiMetadata).toHaveBeenCalled();
-    });
+    }, { timeout: 3000 });
   });
 
   it("renders address from buildingInfo", async () => {


### PR DESCRIPTION
## Summary
- 21 tests for `web/src/lib/quote-engine.ts`: Finnish VAT calculation, wastage, labour hours by category, contractor margins, BOM unit_price override
- 25 tests for `web/src/lib/presentation-export.ts`: preset data, URL building, share token encoding, filename sanitization, currency formatting
- 41 tests for `api/src/ifc-generator.ts`: element classification (English + Finnish terms), scene DSL parsing, STEP file structure, spatial hierarchy, permit metadata, material assignments

**87 new unit tests total**

## Test plan
- [x] All 87 tests pass via `vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)