### PR TITLE
test: LanguageSwitcher, LandingFooter, TrustLayer, useMediaQuery unit tests

### DIFF
--- a/web/src/__tests__/landing-footer.test.tsx
+++ b/web/src/__tests__/landing-footer.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ScrollReveal", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import LandingFooter from "@/components/LandingFooter";
+
+describe("LandingFooter", () => {
+  it("renders footer element", () => {
+    const { container } = render(<LandingFooter />);
+    expect(container.querySelector("footer")).toBeInTheDocument();
+  });
+
+  it("renders Helscoop brand name", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("Hel")).toBeInTheDocument();
+    expect(screen.getByText("scoop")).toBeInTheDocument();
+  });
+
+  it("renders footer description", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.footerDescription")).toBeInTheDocument();
+  });
+
+  it("renders all 6 data sources", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("DVV")).toBeInTheDocument();
+    expect(screen.getByText("MML")).toBeInTheDocument();
+    expect(screen.getByText("K-Rauta")).toBeInTheDocument();
+    expect(screen.getByText("Stark")).toBeInTheDocument();
+    expect(screen.getByText("Sarokas")).toBeInTheDocument();
+    expect(screen.getByText("Ruukki")).toBeInTheDocument();
+  });
+
+  it("renders data sources heading", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.dataSources")).toBeInTheDocument();
+  });
+
+  it("renders disclaimer", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.dataSourcesDisclaimer")).toBeInTheDocument();
+  });
+
+  it("renders privacy and terms links", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.privacyPolicy")).toBeInTheDocument();
+    expect(screen.getByText("landing.termsOfService")).toBeInTheDocument();
+  });
+
+  it("privacy link points to /privacy", () => {
+    const { container } = render(<LandingFooter />);
+    const privacyLink = container.querySelector('a[href="/privacy"]');
+    expect(privacyLink).toBeInTheDocument();
+  });
+
+  it("terms link points to /terms", () => {
+    const { container } = render(<LandingFooter />);
+    const termsLink = container.querySelector('a[href="/terms"]');
+    expect(termsLink).toBeInTheDocument();
+  });
+
+  it("renders current year in copyright", () => {
+    render(<LandingFooter />);
+    const year = new Date().getFullYear().toString();
+    expect(screen.getByText(new RegExp(year))).toBeInTheDocument();
+  });
+
+  it("renders Helsinki location", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("Helsinki, Finland")).toBeInTheDocument();
+  });
+
+  it("renders EU data notice", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText(/landing\.dataInEu/)).toBeInTheDocument();
+  });
+
+  it("renders links section heading", () => {
+    render(<LandingFooter />);
+    expect(screen.getByText("landing.links")).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/trust-layer.test.tsx
+++ b/web/src/__tests__/trust-layer.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+import TrustLayer from "@/components/TrustLayer";
+
+describe("TrustLayer", () => {
+  it("renders trust layer container", () => {
+    const { container } = render(<TrustLayer />);
+    expect(container.querySelector(".trust-layer")).toBeInTheDocument();
+  });
+
+  it("renders all 6 partner logos", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("K-Rauta")).toBeInTheDocument();
+    expect(screen.getByText("Stark")).toBeInTheDocument();
+    expect(screen.getByText("Ruukki")).toBeInTheDocument();
+    expect(screen.getByText("DVV")).toBeInTheDocument();
+    expect(screen.getByText("MML")).toBeInTheDocument();
+    expect(screen.getByText("Sarokas")).toBeInTheDocument();
+  });
+
+  it("renders sources label", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("trust.sourcesLabel")).toBeInTheDocument();
+  });
+
+  it("renders 4 stats", () => {
+    const { container } = render(<TrustLayer />);
+    const stats = container.querySelectorAll(".trust-stat");
+    expect(stats.length).toBe(4);
+  });
+
+  it("renders product count stat", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("1 200+")).toBeInTheDocument();
+    expect(screen.getByText("trust.products")).toBeInTheDocument();
+  });
+
+  it("renders supplier count stat", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("6")).toBeInTheDocument();
+    expect(screen.getByText("trust.suppliers")).toBeInTheDocument();
+  });
+
+  it("renders free stat", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.getByText("trust.free")).toBeInTheDocument();
+  });
+
+  it("renders GDPR stat", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("GDPR")).toBeInTheDocument();
+    expect(screen.getByText("trust.gdprCompliant")).toBeInTheDocument();
+  });
+
+  it("renders social proof section", () => {
+    const { container } = render(<TrustLayer />);
+    expect(container.querySelector(".trust-proof")).toBeInTheDocument();
+  });
+
+  it("renders proof text", () => {
+    render(<TrustLayer />);
+    expect(screen.getByText("trust.proofText")).toBeInTheDocument();
+  });
+
+  it("renders shield SVG icon", () => {
+    const { container } = render(<TrustLayer />);
+    const svg = container.querySelector(".trust-proof svg");
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/use-media-query.test.tsx
+++ b/web/src/__tests__/use-media-query.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+
+describe("useMediaQuery", () => {
+  let matchMediaListeners: Map<string, ((e: { matches: boolean }) => void)[]>;
+
+  beforeEach(() => {
+    matchMediaListeners = new Map();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn((query: string) => {
+        const listeners: ((e: { matches: boolean }) => void)[] = [];
+        matchMediaListeners.set(query, listeners);
+        return {
+          matches: false,
+          media: query,
+          addEventListener: vi.fn((_: string, cb: (e: { matches: boolean }) => void) => {
+            listeners.push(cb);
+          }),
+          removeEventListener: vi.fn((_: string, cb: (e: { matches: boolean }) => void) => {
+            const idx = listeners.indexOf(cb);
+            if (idx >= 0) listeners.splice(idx, 1);
+          }),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+        };
+      }),
+    });
+  });
+
+  it("returns false by default", () => {
+    const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns initial match state", () => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn(() => ({
+        matches: true,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when media query changes", () => {
+    let currentMatches = false;
+    const listeners: (() => void)[] = [];
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn(() => ({
+        get matches() { return currentMatches; },
+        addEventListener: vi.fn((_: string, cb: () => void) => { listeners.push(cb); }),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+
+    const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    expect(result.current).toBe(false);
+
+    currentMatches = true;
+    act(() => {
+      listeners.forEach((cb) => cb());
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("cleans up listener on unmount", () => {
+    const removeEventListener = vi.fn();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+      })),
+    });
+    const { unmount } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+    unmount();
+    expect(removeEventListener).toHaveBeenCalled();
+  });
+
+  it("updates when query string changes", () => {
+    const { result, rerender } = renderHook(
+      ({ query }) => useMediaQuery(query),
+      { initialProps: { query: "(min-width: 768px)" } },
+    );
+    expect(result.current).toBe(false);
+    rerender({ query: "(min-width: 1024px)" });
+    expect(result.current).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- 5 tests for `LanguageSwitcher`: FI/EN toggle, locale switching, aria-label, separator
- 13 tests for `LandingFooter`: brand name, 6 data sources, privacy/terms links, copyright year, Helsinki location
- 11 tests for `TrustLayer`: 6 partner logos, 4 stats (products, suppliers, free, GDPR), social proof, shield icon
- 5 tests for `useMediaQuery`: initial state, match state changes, listener cleanup, query string changes

**34 new unit tests total**

## Test plan
- [x] All 34 tests pass via `vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)