### PR TITLE
test: MobileEditorTabs, EmailVerificationBanner, household-deduction unit tests

### DIFF
--- a/web/src/__tests__/email-verification-banner.test.tsx
+++ b/web/src/__tests__/email-verification-banner.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+const mockResendVerification = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    resendVerification: (...args: unknown[]) => mockResendVerification(...args),
+  },
+}));
+
+import EmailVerificationBanner from "@/components/EmailVerificationBanner";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EmailVerificationBanner", () => {
+  it("renders banner when email not verified", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    expect(screen.getByText("emailVerification.banner")).toBeInTheDocument();
+  });
+
+  it("returns null when email is verified", () => {
+    const { container } = render(<EmailVerificationBanner emailVerified={true} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders resend button", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    expect(screen.getByText("emailVerification.resend")).toBeInTheDocument();
+  });
+
+  it("renders dismiss button", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    expect(screen.getByLabelText("emailVerification.dismiss")).toBeInTheDocument();
+  });
+
+  it("dismisses banner on dismiss click", () => {
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByLabelText("emailVerification.dismiss"));
+    expect(screen.queryByText("emailVerification.banner")).not.toBeInTheDocument();
+  });
+
+  it("shows resent message after successful resend", async () => {
+    mockResendVerification.mockResolvedValue({});
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByText("emailVerification.resend"));
+    await waitFor(() => {
+      expect(screen.getByText("emailVerification.resent")).toBeInTheDocument();
+    });
+  });
+
+  it("calls api.resendVerification on resend click", async () => {
+    mockResendVerification.mockResolvedValue({});
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByText("emailVerification.resend"));
+    await waitFor(() => {
+      expect(mockResendVerification).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows error toast on resend failure", async () => {
+    mockResendVerification.mockRejectedValue(new Error("fail"));
+    render(<EmailVerificationBanner emailVerified={false} />);
+    fireEvent.click(screen.getByText("emailVerification.resend"));
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith("emailVerification.resendFailed", "error");
+    });
+  });
+
+  it("renders close icon SVG", () => {
+    const { container } = render(<EmailVerificationBanner emailVerified={false} />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/household-deduction.test.ts
+++ b/web/src/__tests__/household-deduction.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  HOUSEHOLD_DEDUCTION_2026,
+  buildHouseholdDeductionRows,
+  calculateHouseholdDeduction,
+} from "@/lib/household-deduction";
+import type { HouseholdDeductionRow } from "@/lib/household-deduction";
+import type { Quote } from "@/lib/quote-engine";
+
+const makeQuote = (materialSubtotal: number, labourSubtotal: number): Quote => ({
+  lines: [],
+  materialSubtotal,
+  labourSubtotal,
+  wastageTotal: 0,
+  subtotalExVat: materialSubtotal + labourSubtotal,
+  vatTotal: (materialSubtotal + labourSubtotal) * 0.255,
+  grandTotal: (materialSubtotal + labourSubtotal) * 1.255,
+  config: {
+    mode: "homeowner",
+    vatRate: 0.255,
+    labourRatePerHour: 45,
+    wastagePercent: 0.10,
+  },
+  generatedAt: "2026-04-22T00:00:00Z",
+});
+
+describe("HOUSEHOLD_DEDUCTION_2026", () => {
+  it("has 35% company work rate", () => {
+    expect(HOUSEHOLD_DEDUCTION_2026.companyWorkRate).toBe(0.35);
+  });
+
+  it("has 150€ threshold per claimant", () => {
+    expect(HOUSEHOLD_DEDUCTION_2026.annualThresholdPerClaimant).toBe(150);
+  });
+
+  it("has 1600€ max credit per claimant", () => {
+    expect(HOUSEHOLD_DEDUCTION_2026.maxCreditPerClaimant).toBe(1600);
+  });
+
+  it("has Vero source URL", () => {
+    expect(HOUSEHOLD_DEDUCTION_2026.sourceUrl).toContain("vero.fi");
+  });
+});
+
+describe("buildHouseholdDeductionRows", () => {
+  it("returns 2 rows (material + labour)", () => {
+    const rows = buildHouseholdDeductionRows(makeQuote(1000, 500));
+    expect(rows).toHaveLength(2);
+    expect(rows[0].type).toBe("material");
+    expect(rows[1].type).toBe("labour");
+  });
+
+  it("includes VAT in amounts", () => {
+    const rows = buildHouseholdDeductionRows(makeQuote(1000, 500));
+    expect(rows[0].amount).toBeCloseTo(1000 * 1.255, 1);
+    expect(rows[1].amount).toBeCloseTo(500 * 1.255, 1);
+  });
+
+  it("labels rows correctly", () => {
+    const rows = buildHouseholdDeductionRows(makeQuote(100, 200));
+    expect(rows[0].label).toBe("Materials");
+    expect(rows[1].label).toBe("Labour");
+  });
+});
+
+describe("calculateHouseholdDeduction", () => {
+  it("computes gross cost as sum of all rows", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "material", label: "Mat", amount: 1000 },
+      { type: "labour", label: "Lab", amount: 2000 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.grossCost).toBe(3000);
+  });
+
+  it("computes labour cost from labour rows only", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "material", label: "Mat", amount: 1000 },
+      { type: "labour", label: "Lab", amount: 2000 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.labourCost).toBe(2000);
+  });
+
+  it("computes raw credit at 35% of labour", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: 1000 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.rawCredit).toBe(350);
+  });
+
+  it("subtracts 150€ threshold for single claimant", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: 1000 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.threshold).toBe(150);
+    expect(result.credit).toBe(200); // 350 - 150 = 200
+  });
+
+  it("doubles threshold for couple mode", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: 1000 },
+    ];
+    const result = calculateHouseholdDeduction(rows, { coupleMode: true });
+    expect(result.threshold).toBe(300);
+    expect(result.claimantCount).toBe(2);
+    expect(result.credit).toBe(50); // 350 - 300 = 50
+  });
+
+  it("caps credit at 1600€ for single", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: 10000 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.credit).toBe(1600);
+  });
+
+  it("caps credit at 3200€ for couple", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: 20000 },
+    ];
+    const result = calculateHouseholdDeduction(rows, { coupleMode: true });
+    expect(result.credit).toBe(3200);
+  });
+
+  it("credit is 0 when labour too low for threshold", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: 400 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    // 400 * 0.35 = 140, below 150 threshold
+    expect(result.credit).toBe(0);
+  });
+
+  it("netCost = grossCost - credit", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "material", label: "Mat", amount: 5000 },
+      { type: "labour", label: "Lab", amount: 3000 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.netCost).toBe(result.grossCost - result.credit);
+  });
+
+  it("handles empty rows", () => {
+    const result = calculateHouseholdDeduction([]);
+    expect(result.grossCost).toBe(0);
+    expect(result.labourCost).toBe(0);
+    expect(result.credit).toBe(0);
+    expect(result.netCost).toBe(0);
+  });
+
+  it("ignores negative amounts", () => {
+    const rows: HouseholdDeductionRow[] = [
+      { type: "labour", label: "Lab", amount: -500 },
+    ];
+    const result = calculateHouseholdDeduction(rows);
+    expect(result.labourCost).toBe(0);
+  });
+});

--- a/web/src/__tests__/mobile-editor-tabs.test.tsx
+++ b/web/src/__tests__/mobile-editor-tabs.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import MobileEditorTabs from "@/components/MobileEditorTabs";
+import type { MobileEditorTab } from "@/components/MobileEditorTabs";
+
+const tabs: MobileEditorTab<"code" | "preview" | "bom">[] = [
+  { id: "code", label: "Code" },
+  { id: "preview", label: "Preview" },
+  { id: "bom", label: "BOM", badge: 5 },
+];
+
+describe("MobileEditorTabs", () => {
+  it("renders all tabs", () => {
+    render(<MobileEditorTabs active="code" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    expect(screen.getByText("Preview")).toBeInTheDocument();
+    expect(screen.getByText("BOM")).toBeInTheDocument();
+  });
+
+  it("has tablist role", () => {
+    render(<MobileEditorTabs active="code" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+
+  it("has aria-label", () => {
+    render(<MobileEditorTabs active="code" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    expect(screen.getByRole("tablist")).toHaveAttribute("aria-label", "Editor tabs");
+  });
+
+  it("renders tab buttons with tab role", () => {
+    render(<MobileEditorTabs active="code" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    const tabElements = screen.getAllByRole("tab");
+    expect(tabElements).toHaveLength(3);
+  });
+
+  it("marks active tab with aria-selected", () => {
+    render(<MobileEditorTabs active="preview" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    const tabElements = screen.getAllByRole("tab");
+    expect(tabElements[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabElements[0]).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("calls onChange with tab id on click", () => {
+    const onChange = vi.fn();
+    render(<MobileEditorTabs active="code" tabs={tabs} onChange={onChange} ariaLabel="Editor tabs" />);
+    fireEvent.click(screen.getByText("Preview"));
+    expect(onChange).toHaveBeenCalledWith("preview");
+  });
+
+  it("renders badge when present", () => {
+    render(<MobileEditorTabs active="code" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("hides badge when value is 0", () => {
+    const tabsWithZero: MobileEditorTab<"a">[] = [{ id: "a", label: "Tab", badge: 0 }];
+    render(<MobileEditorTabs active="a" tabs={tabsWithZero} onChange={vi.fn()} ariaLabel="Test" />);
+    const badges = screen.queryAllByText("0");
+    expect(badges).toHaveLength(0);
+  });
+
+  it("shows badge when value is string", () => {
+    const tabsWithStr: MobileEditorTab<"a">[] = [{ id: "a", label: "Tab", badge: "new" }];
+    render(<MobileEditorTabs active="a" tabs={tabsWithStr} onChange={vi.fn()} ariaLabel="Test" />);
+    expect(screen.getByText("new")).toBeInTheDocument();
+  });
+
+  it("sets data-active attribute on active tab", () => {
+    const { container } = render(<MobileEditorTabs active="bom" tabs={tabs} onChange={vi.fn()} ariaLabel="Editor tabs" />);
+    const activeTabs = container.querySelectorAll('[data-active="true"]');
+    expect(activeTabs).toHaveLength(1);
+  });
+});

--- a/web/src/__tests__/ryhti-submission-panel.test.tsx
+++ b/web/src/__tests__/ryhti-submission-panel.test.tsx
@@ -201,14 +201,16 @@ describe("RyhtiSubmissionPanel", () => {
   it("saves metadata on check button click", async () => {
     mockUpdateRyhtiMetadata.mockResolvedValue(mockPackage);
     render(<RyhtiSubmissionPanel projectId="p1" bomCount={5} />);
+    // Wait for loading to complete (button becomes enabled)
     await waitFor(() => {
-      expect(screen.getByText("ryhti.check")).toBeInTheDocument();
-    });
+      const btn = screen.getByText("ryhti.check").closest("button")!;
+      expect(btn).not.toBeDisabled();
+    }, { timeout: 5000 });
     const checkBtn = screen.getByText("ryhti.check").closest("button")!;
     fireEvent.click(checkBtn);
     await waitFor(() => {
       expect(mockUpdateRyhtiMetadata).toHaveBeenCalled();
-    }, { timeout: 3000 });
+    }, { timeout: 5000 });
   });
 
   it("renders address from buildingInfo", async () => {


### PR DESCRIPTION
## Summary
- 10 tests for `MobileEditorTabs`: tab rendering, ARIA tablist/tab roles, badge display (number/string/zero), active state, onChange callback, data-active attribute
- 9 tests for `EmailVerificationBanner`: render when unverified, null when verified, resend button, dismiss, success/error states, API call, toast on failure
- 18 tests for `household-deduction`: Finnish tax deduction constants (35% rate, 150€ threshold, 1600€ cap), row building with VAT, credit calculation with thresholds, couple mode doubling, caps, empty/negative amounts

**37 new unit tests total**

## Test plan
- [x] All 37 tests pass via `vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)