### PR TITLE
test: fix auth home e2e server startup

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -52,6 +52,7 @@ const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
 const app = express();
 const PORT = parseInt(process.env.PORT || "3001");
 const IS_TEST = process.env.NODE_ENV === "test";
+const IS_E2E = process.env.E2E === "1";
 const startedAt = Date.now();
 const IS_DEV = process.env.NODE_ENV === "development";
 
@@ -1065,8 +1066,9 @@ app.use((err: Error, _req: express.Request, res: express.Response, _next: expres
   res.status(500).json({ error: "Internal server error" });
 });
 
-// Only start listening when run directly, not when imported for testing
-if (!IS_TEST) {
+// Only start listening when run directly. Playwright runs the real server with
+// NODE_ENV=test for deterministic limits, so it opts in via E2E=1.
+if (!IS_TEST || IS_E2E) {
   app.listen(PORT, () => {
     logger.info({ port: PORT, env: process.env.NODE_ENV || "development" }, "Helscoop API running");
   });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
         DATABASE_URL: "postgres://dingcad:dingcad_dev@localhost:5433/dingcad",
         JWT_SECRET: "helscoop-e2e-test-secret",
         NODE_ENV: "test",
+        E2E: "1",
       },
     },
     {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -5,13 +5,16 @@ import { LocaleProvider } from "@/components/LocaleProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import ConnectionBanner from "@/components/ConnectionBanner";
 
+const SITE_TITLE = "Helscoop — Suunnittele remonttisi 3D:ssä";
+const SITE_DESCRIPTION =
+  "Suunnittele talosi remontti 3D-mallinnuksella. Näe muutokset reaaliajassa, saa automaattinen materiaaliluettelo ja hinnat K-Raudasta. Ilmainen työkalu suomalaisille kodinrakentajille.";
+
 export const metadata: Metadata = {
   title: {
-    default: "Helscoop — Suunnittele remonttisi 3D:ssä",
+    default: SITE_TITLE,
     template: "%s | Helscoop",
   },
-  description:
-    "Suunnittele talosi remontti 3D-mallinnuksella. Näe muutokset reaaliajassa, saa automaattinen materiaaliluettelo ja hinnat K-Raudasta. Ilmainen työkalu suomalaisille kodinrakentajille.",
+  description: SITE_DESCRIPTION,
   keywords: [
     "remontti",
     "talosuunnittelu",
@@ -37,7 +40,7 @@ export const metadata: Metadata = {
     follow: true,
   },
   openGraph: {
-    title: "Helscoop — Suunnittele remonttisi 3D:ssä",
+    title: SITE_TITLE,
     description:
       "3D-mallinna talosi, suunnittele remontti ja saa materiaalihinnat reaaliajassa. Ilmainen työkalu suomalaisille kodinrakentajille.",
     type: "website",
@@ -47,7 +50,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Helscoop — Suunnittele remonttisi 3D:ssä",
+    title: SITE_TITLE,
     description:
       "3D-mallinna talosi, suunnittele remontti ja saa materiaalihinnat reaaliajassa.",
   },


### PR DESCRIPTION
## Summary

- Allow the API server to listen during Playwright runs when `E2E=1`, even though the E2E harness uses `NODE_ENV=test`.
- Set `E2E=1` in the Playwright API webServer environment so the documented repro command starts from a clean checkout.
- Centralize the home page metadata title/description constants to keep the title source consistent.

## Verification

- `e2e`: `npx playwright test tests/auth.spec.ts:8 --reporter=line` — 1 passed.
- `api`: `npm test` — 40 passed, 1 skipped; 867 tests passed, 23 skipped.
- `api`: `npm run build`
- `web`: `npm run build`
- `git diff --check`

Notes: web build still prints the pre-existing Next config warning for `experimental.viewTransition`.

Closes #324
