### PR TITLE
test: UpgradeGate, useAnalytics, ThemeProvider, email unit tests

### DIFF
--- a/api/src/__tests__/email-unit.test.ts
+++ b/api/src/__tests__/email-unit.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  sendEmail,
+  sendPasswordResetEmail,
+  sendVerificationEmail,
+  sendPriceAlertEmail,
+} from "../email";
+
+let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+describe("sendEmail", () => {
+  it("returns true", async () => {
+    const result = await sendEmail("user@example.com", "Test", "Body");
+    expect(result).toBe(true);
+  });
+
+  it("logs recipient and subject", async () => {
+    await sendEmail("user@example.com", "Hello", "Body text");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("user@example.com"),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Hello"),
+    );
+  });
+
+  it("logs attachment count when attachments provided", async () => {
+    await sendEmail("user@example.com", "With attachment", "Body", [
+      { filename: "file.pdf", content: "data", contentType: "application/pdf" },
+    ]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("1 attachment"),
+    );
+  });
+
+  it("does not mention attachments when none provided", async () => {
+    await sendEmail("user@example.com", "No attachment", "Body");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.not.stringContaining("attachment"),
+    );
+  });
+
+  it("handles multiple attachments", async () => {
+    await sendEmail("user@example.com", "Multi", "Body", [
+      { filename: "a.pdf", content: "a", contentType: "application/pdf" },
+      { filename: "b.csv", content: "b", contentType: "text/csv" },
+    ]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("2 attachment"),
+    );
+  });
+});
+
+describe("sendPasswordResetEmail", () => {
+  it("returns true", async () => {
+    const result = await sendPasswordResetEmail("user@example.com", "token123");
+    expect(result).toBe(true);
+  });
+
+  it("logs email and token", async () => {
+    await sendPasswordResetEmail("user@example.com", "tok-abc");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("user@example.com"),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("tok-abc"),
+    );
+  });
+});
+
+describe("sendVerificationEmail", () => {
+  it("returns true", async () => {
+    const result = await sendVerificationEmail("user@example.com", "verify-xyz");
+    expect(result).toBe(true);
+  });
+
+  it("logs email and token", async () => {
+    await sendVerificationEmail("new@example.com", "vrf-123");
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("new@example.com"),
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("vrf-123"),
+    );
+  });
+});
+
+describe("sendPriceAlertEmail", () => {
+  it("returns true", async () => {
+    const result = await sendPriceAlertEmail("user@example.com", { material: "wood" });
+    expect(result).toBe(true);
+  });
+
+  it("logs email", async () => {
+    await sendPriceAlertEmail("alert@example.com", {});
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("alert@example.com"),
+    );
+  });
+});

--- a/api/src/__tests__/email-unit.test.ts
+++ b/api/src/__tests__/email-unit.test.ts
@@ -38,7 +38,7 @@ describe("sendEmail", () => {
   });
 
   it("does not mention attachments when none provided", async () => {
-    await sendEmail("user@example.com", "No attachment", "Body");
+    await sendEmail("user@example.com", "Plain message", "Body");
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.not.stringContaining("attachment"),
     );

--- a/web/src/__tests__/theme-provider.test.tsx
+++ b/web/src/__tests__/theme-provider.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, renderHook } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { ThemeProvider, useTheme, DARK_MOODS } from "@/components/ThemeProvider";
+
+let mockMediaMatches = true;
+let changeHandler: ((e: { matches: boolean }) => void) | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMediaMatches = true;
+  changeHandler = null;
+  localStorage.clear();
+  document.documentElement.removeAttribute("data-theme");
+  document.documentElement.removeAttribute("data-mood");
+  document.documentElement.classList.remove("theme-transitioning");
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      get matches() {
+        return mockMediaMatches;
+      },
+      addEventListener: (_event: string, handler: (e: { matches: boolean }) => void) => {
+        changeHandler = handler;
+      },
+      removeEventListener: vi.fn(),
+    })),
+  });
+});
+
+function TestConsumer() {
+  const { theme, resolved, mood, toggle, setTheme, setMood } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolved}</span>
+      <span data-testid="mood">{mood}</span>
+      <button data-testid="toggle" onClick={toggle}>toggle</button>
+      <button data-testid="set-light" onClick={() => setTheme("light")}>light</button>
+      <button data-testid="set-auto" onClick={() => setTheme("auto")}>auto</button>
+      <button data-testid="set-mood-cool" onClick={() => setMood("cool")}>cool</button>
+      <button data-testid="set-mood-black" onClick={() => setMood("black")}>black</button>
+    </div>
+  );
+}
+
+describe("ThemeProvider", () => {
+  it("renders children", () => {
+    render(<ThemeProvider><span>child</span></ThemeProvider>);
+    expect(screen.getByText("child")).toBeInTheDocument();
+  });
+
+  it("defaults to dark theme", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+  });
+
+  it("defaults to warm mood", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(screen.getByTestId("mood").textContent).toBe("warm");
+  });
+
+  it("toggles through dark → light → auto cycle", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("auto");
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+  });
+
+  it("setTheme updates theme and persists to localStorage", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-light").click();
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(localStorage.getItem("helscoop-theme")).toBe("light");
+  });
+
+  it("resolves auto to dark when system prefers dark", () => {
+    mockMediaMatches = true;
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-auto").click();
+    });
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+  });
+
+  it("resolves auto to light when system prefers light", () => {
+    mockMediaMatches = false;
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-auto").click();
+    });
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+  });
+
+  it("setMood updates mood and persists to localStorage", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-mood-cool").click();
+    });
+    expect(screen.getByTestId("mood").textContent).toBe("cool");
+    expect(localStorage.getItem("helscoop-mood")).toBe("cool");
+  });
+
+  it("reads stored theme from localStorage on mount", () => {
+    localStorage.setItem("helscoop-theme", "light");
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+  });
+
+  it("reads stored mood from localStorage on mount", () => {
+    localStorage.setItem("helscoop-mood", "black");
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(screen.getByTestId("mood").textContent).toBe("black");
+  });
+
+  it("sets data-theme attribute on document", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("sets data-mood attribute for dark theme", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(document.documentElement.getAttribute("data-mood")).toBe("warm");
+  });
+
+  it("clears data-mood for light theme", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-light").click();
+    });
+    expect(document.documentElement.getAttribute("data-mood")).toBe("");
+  });
+
+  it("toggle persists to localStorage", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("toggle").click();
+    });
+    expect(localStorage.getItem("helscoop-theme")).toBe("light");
+  });
+
+  it("responds to system preference changes", () => {
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-auto").click();
+    });
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    act(() => {
+      mockMediaMatches = false;
+      changeHandler?.({ matches: false });
+    });
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+  });
+});
+
+describe("DARK_MOODS", () => {
+  it("has warm, cool, and black", () => {
+    expect(DARK_MOODS).toEqual(["warm", "cool", "black"]);
+  });
+});
+
+describe("useTheme outside provider", () => {
+  it("returns default values without provider", () => {
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.theme).toBe("dark");
+    expect(result.current.resolved).toBe("dark");
+    expect(result.current.mood).toBe("warm");
+  });
+});

--- a/web/src/__tests__/upgrade-gate.test.tsx
+++ b/web/src/__tests__/upgrade-gate.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import UpgradeGate from "@/components/UpgradeGate";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete (window as any).location;
+  (window as any).location = { href: "" };
+});
+
+describe("UpgradeGate", () => {
+  it("renders headline for generic feature", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByText("upgrade.title")).toBeInTheDocument();
+  });
+
+  it("renders AI quota headline for aiMessages feature", () => {
+    render(<UpgradeGate feature="aiMessages" requiredPlan="pro" currentPlan="free" aiLimit={10} />);
+    expect(screen.getByText("upgrade.aiQuotaExhausted")).toBeInTheDocument();
+  });
+
+  it("renders AI quota description with limit", () => {
+    render(<UpgradeGate feature="aiMessages" requiredPlan="pro" currentPlan="free" aiLimit={25} />);
+    expect(screen.getByText(/upgrade\.aiQuotaDesc.*25/)).toBeInTheDocument();
+  });
+
+  it("renders pro CTA when requiredPlan is pro", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByText("upgrade.ctaPro")).toBeInTheDocument();
+  });
+
+  it("renders enterprise CTA when requiredPlan is enterprise", () => {
+    render(<UpgradeGate feature="apiAccess" requiredPlan="enterprise" currentPlan="free" />);
+    expect(screen.getByText("upgrade.ctaEnterprise")).toBeInTheDocument();
+  });
+
+  it("renders dismiss button with aria-label", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByLabelText("upgrade.dismiss")).toBeInTheDocument();
+  });
+
+  it("dismisses on dismiss button click", () => {
+    const onDismiss = vi.fn();
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByLabelText("upgrade.dismiss"));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("returns null after dismiss", () => {
+    const { container } = render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    fireEvent.click(screen.getByLabelText("upgrade.dismiss"));
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("dismisses on ghost button click", () => {
+    const onDismiss = vi.fn();
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" onDismiss={onDismiss} />);
+    const buttons = screen.getAllByText("upgrade.dismiss");
+    const ghostBtn = buttons.find((b) => b.closest("button")?.classList.contains("btn-ghost"));
+    fireEvent.click(ghostBtn!);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("navigates to /pricing on CTA click", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    fireEvent.click(screen.getByText("upgrade.ctaPro"));
+    expect(window.location.href).toBe("/pricing");
+  });
+
+  it("renders feature comparison table header", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByText("upgrade.featureComparison")).toBeInTheDocument();
+  });
+
+  it("renders all three plan names", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByText("upgrade.free")).toBeInTheDocument();
+    expect(screen.getByText("upgrade.pro")).toBeInTheDocument();
+    expect(screen.getByText("upgrade.enterprise")).toBeInTheDocument();
+  });
+
+  it("renders feature rows", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByText("upgrade.featureAiMessages")).toBeInTheDocument();
+    expect(screen.getByText("upgrade.featurePremiumExport")).toBeInTheDocument();
+    expect(screen.getByText("upgrade.featureCustomMaterials")).toBeInTheDocument();
+    expect(screen.getByText("upgrade.featureApiAccess")).toBeInTheDocument();
+  });
+
+  it("shows unlimited text for enterprise features", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    const unlimiteds = screen.getAllByText("upgrade.unlimited");
+    expect(unlimiteds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders as modal overlay by default", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("renders with aria-modal on dialog", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("renders inline without dialog role", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" inline />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("dismisses on Escape key in modal mode", () => {
+    const onDismiss = vi.fn();
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" onDismiss={onDismiss} />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("dismisses on backdrop click", () => {
+    const onDismiss = vi.fn();
+    const { container } = render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" onDismiss={onDismiss} />);
+    const backdrop = container.firstChild as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("shows numeric values for free plan AI messages", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+  });
+
+  it("renders upgrade icon SVG", () => {
+    render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
+    const dialog = screen.getByRole("dialog");
+    const svgs = dialog.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/web/src/__tests__/use-analytics.test.ts
+++ b/web/src/__tests__/use-analytics.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useAnalytics, useEditorSession, PLAUSIBLE_DOMAIN } from "@/hooks/useAnalytics";
 
-let consoleSpy: ReturnType<typeof vi.spyOn>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let consoleSpy: any;
+const win = window as any;
 
 beforeEach(() => {
   vi.clearAllMocks();
   consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
-  window.plausible = undefined;
+  win.plausible = undefined;
   Object.defineProperty(window, "location", {
     value: { hostname: "localhost" },
     writable: true,
@@ -44,7 +46,7 @@ describe("useAnalytics", () => {
 
   it("does not call plausible on localhost even if defined", () => {
     const mockPlausible = vi.fn();
-    window.plausible = mockPlausible;
+    win.plausible = mockPlausible;
     const { result } = renderHook(() => useAnalytics());
     act(() => {
       result.current.track("page_view", { path: "/test" });
@@ -54,7 +56,7 @@ describe("useAnalytics", () => {
 
   it("calls window.plausible in production", () => {
     const mockPlausible = vi.fn();
-    window.plausible = mockPlausible;
+    win.plausible = mockPlausible;
     Object.defineProperty(window, "location", {
       value: { hostname: "helscoop.fi" },
       writable: true,
@@ -75,7 +77,7 @@ describe("useAnalytics", () => {
       writable: true,
       configurable: true,
     });
-    window.plausible = undefined;
+    win.plausible = undefined;
     const { result } = renderHook(() => useAnalytics());
     expect(() => {
       act(() => {
@@ -86,7 +88,7 @@ describe("useAnalytics", () => {
 
   it("passes props to plausible in production", () => {
     const mockPlausible = vi.fn();
-    window.plausible = mockPlausible;
+    win.plausible = mockPlausible;
     Object.defineProperty(window, "location", {
       value: { hostname: "helscoop.fi" },
       writable: true,

--- a/web/src/__tests__/use-analytics.test.ts
+++ b/web/src/__tests__/use-analytics.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAnalytics, useEditorSession, PLAUSIBLE_DOMAIN } from "@/hooks/useAnalytics";
+
+let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+  window.plausible = undefined;
+  Object.defineProperty(window, "location", {
+    value: { hostname: "localhost" },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  consoleSpy.mockRestore();
+});
+
+describe("PLAUSIBLE_DOMAIN", () => {
+  it("is helscoop.fi", () => {
+    expect(PLAUSIBLE_DOMAIN).toBe("helscoop.fi");
+  });
+});
+
+describe("useAnalytics", () => {
+  it("returns a track function", () => {
+    const { result } = renderHook(() => useAnalytics());
+    expect(typeof result.current.track).toBe("function");
+  });
+
+  it("logs to console.debug on localhost", () => {
+    const { result } = renderHook(() => useAnalytics());
+    act(() => {
+      result.current.track("address_search", { query_length: 5, had_result: true });
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[analytics] address_search",
+      expect.objectContaining({ query_length: 5, had_result: true }),
+    );
+  });
+
+  it("does not call plausible on localhost even if defined", () => {
+    const mockPlausible = vi.fn();
+    window.plausible = mockPlausible;
+    const { result } = renderHook(() => useAnalytics());
+    act(() => {
+      result.current.track("page_view", { path: "/test" });
+    });
+    expect(mockPlausible).not.toHaveBeenCalled();
+  });
+
+  it("calls window.plausible in production", () => {
+    const mockPlausible = vi.fn();
+    window.plausible = mockPlausible;
+    Object.defineProperty(window, "location", {
+      value: { hostname: "helscoop.fi" },
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useAnalytics());
+    act(() => {
+      result.current.track("project_created", { source: "template" });
+    });
+    expect(mockPlausible).toHaveBeenCalledWith("project_created", {
+      props: { source: "template" },
+    });
+  });
+
+  it("is a no-op when plausible not loaded in production", () => {
+    Object.defineProperty(window, "location", {
+      value: { hostname: "helscoop.fi" },
+      writable: true,
+      configurable: true,
+    });
+    window.plausible = undefined;
+    const { result } = renderHook(() => useAnalytics());
+    expect(() => {
+      act(() => {
+        result.current.track("auth_login", {} as any);
+      });
+    }).not.toThrow();
+  });
+
+  it("passes props to plausible in production", () => {
+    const mockPlausible = vi.fn();
+    window.plausible = mockPlausible;
+    Object.defineProperty(window, "location", {
+      value: { hostname: "helscoop.fi" },
+      writable: true,
+      configurable: true,
+    });
+    const { result } = renderHook(() => useAnalytics());
+    act(() => {
+      result.current.track("bom_exported", { format: "pdf" });
+    });
+    expect(mockPlausible).toHaveBeenCalledWith("bom_exported", {
+      props: { format: "pdf" },
+    });
+  });
+});
+
+describe("useEditorSession", () => {
+  it("returns markCodeEditor and markChat functions", () => {
+    const { result } = renderHook(() => useEditorSession());
+    expect(typeof result.current.markCodeEditor).toBe("function");
+    expect(typeof result.current.markChat).toBe("function");
+  });
+
+  it("calls markCodeEditor without error", () => {
+    const { result } = renderHook(() => useEditorSession());
+    expect(() => {
+      act(() => {
+        result.current.markCodeEditor();
+      });
+    }).not.toThrow();
+  });
+
+  it("calls markChat without error", () => {
+    const { result } = renderHook(() => useEditorSession());
+    expect(() => {
+      act(() => {
+        result.current.markChat();
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- 21 tests for **UpgradeGate** component (modal/inline rendering, dismiss, CTA, feature comparison, keyboard/backdrop dismiss, plan tiers)
- 10 tests for **useAnalytics** hook (Plausible integration, localhost debug logging, production dispatch, editor session)
- 17 tests for **ThemeProvider** (dark/light/auto cycle, mood selection, localStorage persistence, system preference reactivity)
- 11 tests for **email** module (sendEmail with/without attachments, password reset, verification, price alert)

**59 new tests total across 4 files**

## Test plan
- [x] All new tests pass locally
- [x] No regressions in existing test suite
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)