### PR TITLE
test: LocaleProvider, ToastProvider, useCursorGlow unit tests

### DIFF
--- a/web/src/__tests__/locale-provider.test.tsx
+++ b/web/src/__tests__/locale-provider.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, renderHook } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/lib/i18n", () => ({
+  detectLocale: vi.fn(() => "fi"),
+  persistLocale: vi.fn(),
+  getTranslation: vi.fn((locale: string) => (key: string, params?: Record<string, string | number>) => {
+    if (params) return `[${locale}]${key}:${JSON.stringify(params)}`;
+    return `[${locale}]${key}`;
+  }),
+}));
+
+import { LocaleProvider, useTranslation } from "@/components/LocaleProvider";
+import { detectLocale, persistLocale } from "@/lib/i18n";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  document.documentElement.lang = "";
+});
+
+function TestConsumer() {
+  const { locale, setLocale, t } = useTranslation();
+  return (
+    <div>
+      <span data-testid="locale">{locale}</span>
+      <span data-testid="translated">{t("hello")}</span>
+      <span data-testid="with-params">{t("greeting", { name: "Test" })}</span>
+      <button data-testid="set-en" onClick={() => setLocale("en")}>EN</button>
+      <button data-testid="set-fi" onClick={() => setLocale("fi")}>FI</button>
+    </div>
+  );
+}
+
+describe("LocaleProvider", () => {
+  it("renders children after mount", () => {
+    render(<LocaleProvider><span>child</span></LocaleProvider>);
+    expect(screen.getByText("child")).toBeInTheDocument();
+  });
+
+  it("detects locale on mount", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    expect(detectLocale).toHaveBeenCalledOnce();
+  });
+
+  it("sets document.documentElement.lang on mount", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    expect(document.documentElement.lang).toBe("fi");
+  });
+
+  it("provides detected locale to consumers", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    expect(screen.getByTestId("locale").textContent).toBe("fi");
+  });
+
+  it("translates keys using getTranslation", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    expect(screen.getByTestId("translated").textContent).toBe("[fi]hello");
+  });
+
+  it("passes params to translation function", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    expect(screen.getByTestId("with-params").textContent).toContain("Test");
+  });
+
+  it("setLocale updates locale and persists", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    act(() => {
+      screen.getByTestId("set-en").click();
+    });
+    expect(screen.getByTestId("locale").textContent).toBe("en");
+    expect(persistLocale).toHaveBeenCalledWith("en");
+  });
+
+  it("setLocale updates document.documentElement.lang", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    act(() => {
+      screen.getByTestId("set-en").click();
+    });
+    expect(document.documentElement.lang).toBe("en");
+  });
+
+  it("updates translations when locale changes", () => {
+    render(<LocaleProvider><TestConsumer /></LocaleProvider>);
+    act(() => {
+      screen.getByTestId("set-en").click();
+    });
+    expect(screen.getByTestId("translated").textContent).toBe("[en]hello");
+  });
+});
+
+describe("useTranslation", () => {
+  it("throws when used outside LocaleProvider", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => {
+      renderHook(() => useTranslation());
+    }).toThrow("useTranslation must be used within a LocaleProvider");
+    consoleError.mockRestore();
+  });
+});

--- a/web/src/__tests__/toast-provider.test.tsx
+++ b/web/src/__tests__/toast-provider.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, renderHook } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { ReactNode } from "react";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string, vars?: Record<string, unknown>) => {
+      if (vars) return `${key}:${JSON.stringify(vars)}`;
+      return key;
+    },
+  }),
+}));
+
+import { ToastProvider, useToast } from "@/components/ToastProvider";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function TestConsumer() {
+  const { toast, toastProgress, updateProgress, dismissToast } = useToast();
+  return (
+    <div>
+      <button data-testid="show-info" onClick={() => toast("Info message")}>Info</button>
+      <button data-testid="show-success" onClick={() => toast("Success!", "success")}>Success</button>
+      <button data-testid="show-error" onClick={() => toast("Error!", "error")}>Error</button>
+      <button data-testid="show-action" onClick={() => toast("With action", "info", { action: { label: "Undo", onClick: vi.fn() } })}>Action</button>
+      <button data-testid="show-progress" onClick={() => { const id = toastProgress("Uploading", 30); (window as any).__progressId = id; }}>Progress</button>
+      <button data-testid="update-progress" onClick={() => updateProgress((window as any).__progressId, 80, "Almost done")}>Update</button>
+      <button data-testid="dismiss" onClick={() => dismissToast(0)}>Dismiss</button>
+    </div>
+  );
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+describe("ToastProvider", () => {
+  it("renders children", () => {
+    render(<ToastProvider><span>child</span></ToastProvider>);
+    expect(screen.getByText("child")).toBeInTheDocument();
+  });
+
+  it("renders a status container for toasts", () => {
+    render(<ToastProvider><span>content</span></ToastProvider>);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("shows info toast", () => {
+    render(<ToastProvider><TestConsumer /></ToastProvider>);
+    act(() => {
+      screen.getByTestId("show-info").click();
+    });
+    expect(screen.getByText("Info message")).toBeInTheDocument();
+  });
+
+  it("shows success toast", () => {
+    render(<ToastProvider><TestConsumer /></ToastProvider>);
+    act(() => {
+      screen.getByTestId("show-success").click();
+    });
+    expect(screen.getByText("Success!")).toBeInTheDocument();
+  });
+
+  it("shows error toast", () => {
+    render(<ToastProvider><TestConsumer /></ToastProvider>);
+    act(() => {
+      screen.getByTestId("show-error").click();
+    });
+    expect(screen.getByText("Error!")).toBeInTheDocument();
+  });
+
+  it("shows toast with action button", () => {
+    render(<ToastProvider><TestConsumer /></ToastProvider>);
+    act(() => {
+      screen.getByTestId("show-action").click();
+    });
+    expect(screen.getByText("With action")).toBeInTheDocument();
+    expect(screen.getByText("Undo")).toBeInTheDocument();
+  });
+
+  it("shows progress toast with percentage", () => {
+    render(<ToastProvider><TestConsumer /></ToastProvider>);
+    act(() => {
+      screen.getByTestId("show-progress").click();
+    });
+    expect(screen.getByText("Uploading")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+  });
+
+  it("toast returns an id", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    let id: number;
+    act(() => {
+      id = result.current.toast("test");
+    });
+    expect(typeof id!).toBe("number");
+  });
+
+  it("toastProgress returns an id", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    let id: number;
+    act(() => {
+      id = result.current.toastProgress("uploading", 0);
+    });
+    expect(typeof id!).toBe("number");
+  });
+});
+
+describe("useToast", () => {
+  it("throws when used outside ToastProvider", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => {
+      renderHook(() => useToast());
+    }).toThrow("useToast must be used within a ToastProvider");
+    consoleError.mockRestore();
+  });
+
+  it("provides toast, toastProgress, updateProgress, dismissToast", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    expect(typeof result.current.toast).toBe("function");
+    expect(typeof result.current.toastProgress).toBe("function");
+    expect(typeof result.current.updateProgress).toBe("function");
+    expect(typeof result.current.dismissToast).toBe("function");
+  });
+});

--- a/web/src/__tests__/use-cursor-glow.test.tsx
+++ b/web/src/__tests__/use-cursor-glow.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCursorGlow } from "@/hooks/useCursorGlow";
+
+let mockRaf: (cb: FrameRequestCallback) => number;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRaf = vi.fn((cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+  vi.stubGlobal("requestAnimationFrame", mockRaf);
+});
+
+describe("useCursorGlow", () => {
+  it("returns ref, onMouseMove, and onMouseLeave", () => {
+    const { result } = renderHook(() => useCursorGlow());
+    expect(result.current.ref).toBeDefined();
+    expect(typeof result.current.onMouseMove).toBe("function");
+    expect(typeof result.current.onMouseLeave).toBe("function");
+  });
+
+  it("sets glow CSS properties on mouse move", () => {
+    const { result } = renderHook(() => useCursorGlow());
+    const el = document.createElement("div");
+    el.getBoundingClientRect = vi.fn(() => ({
+      left: 100,
+      top: 50,
+      right: 300,
+      bottom: 150,
+      width: 200,
+      height: 100,
+      x: 100,
+      y: 50,
+      toJSON: () => {},
+    }));
+    (result.current.ref as any).current = el;
+
+    act(() => {
+      result.current.onMouseMove({ clientX: 150, clientY: 80 } as React.MouseEvent);
+    });
+
+    expect(el.style.getPropertyValue("--glow-x")).toBe("50px");
+    expect(el.style.getPropertyValue("--glow-y")).toBe("30px");
+    expect(el.style.getPropertyValue("--glow-opacity")).toBe("1");
+  });
+
+  it("sets glow-opacity to 0 on mouse leave", () => {
+    const { result } = renderHook(() => useCursorGlow());
+    const el = document.createElement("div");
+    (result.current.ref as any).current = el;
+
+    act(() => {
+      result.current.onMouseLeave();
+    });
+
+    expect(el.style.getPropertyValue("--glow-opacity")).toBe("0");
+  });
+
+  it("does nothing on mouse leave when ref is null", () => {
+    const { result } = renderHook(() => useCursorGlow());
+    expect(() => {
+      act(() => {
+        result.current.onMouseLeave();
+      });
+    }).not.toThrow();
+  });
+
+  it("does nothing on mouse move when ref is null", () => {
+    const { result } = renderHook(() => useCursorGlow());
+    expect(() => {
+      act(() => {
+        result.current.onMouseMove({ clientX: 0, clientY: 0 } as React.MouseEvent);
+      });
+    }).not.toThrow();
+  });
+
+  it("throttles mouse move via requestAnimationFrame", () => {
+    let rafCallback: FrameRequestCallback | null = null;
+    vi.stubGlobal("requestAnimationFrame", vi.fn((cb: FrameRequestCallback) => {
+      rafCallback = cb;
+      return 1;
+    }));
+
+    const { result } = renderHook(() => useCursorGlow());
+    const el = document.createElement("div");
+    el.getBoundingClientRect = vi.fn(() => ({
+      left: 0, top: 0, right: 100, bottom: 100, width: 100, height: 100, x: 0, y: 0, toJSON: () => {},
+    }));
+    (result.current.ref as any).current = el;
+
+    act(() => {
+      result.current.onMouseMove({ clientX: 10, clientY: 10 } as React.MouseEvent);
+    });
+
+    expect(el.style.getPropertyValue("--glow-x")).toBe("");
+
+    act(() => {
+      rafCallback?.(0);
+    });
+
+    expect(el.style.getPropertyValue("--glow-x")).toBe("10px");
+  });
+});


### PR DESCRIPTION
## Summary
- 10 tests for **LocaleProvider** (locale detection, document lang update, translation with params, locale switching + persistence)
- 11 tests for **ToastProvider** (info/success/error/progress toasts, action buttons, context hook, throws outside provider)
- 6 tests for **useCursorGlow** hook (CSS custom property glow-x/y/opacity, mouse leave reset, null ref safety, RAF throttling)

**27 new tests total across 3 files**

## Test plan
- [x] All new tests pass locally
- [x] No regressions in existing test suite
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)