### PR TITLE
test: add MaterialPicker and SceneEditor unit tests

### DIFF
--- a/web/src/__tests__/material-picker.test.tsx
+++ b/web/src/__tests__/material-picker.test.tsx
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import type { Material, BomItem } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/hooks/useFocusTrap", () => ({
+  useFocusTrap: vi.fn(),
+}));
+
+vi.mock("@/lib/material-affiliate", () => ({
+  buildAffiliateRetailerUrl: vi.fn((link: string | null) => link ? `aff:${link}` : null),
+}));
+
+import MaterialPicker from "@/components/MaterialPicker";
+
+const baseMaterial: Material = {
+  id: "m1",
+  name: "Pine Board 22x100",
+  name_fi: "Mäntylankku 22x100",
+  name_en: "Pine Board 22x100",
+  category_name: "lumber",
+  category_name_fi: "Sahatavara",
+  image_url: null,
+  pricing: [
+    { unit_price: 4.5, unit: "jm", supplier_name: "K-Rauta", is_primary: true, link: "https://k-rauta.fi/123" },
+  ],
+  thermal_conductivity: 0.13,
+  thermal_thickness: null,
+  fire_rating: null,
+  tags: ["wood", "pine"],
+  visual_albedo: [0.6, 0.45, 0.3],
+};
+
+const cheapMaterial: Material = {
+  ...baseMaterial,
+  id: "m2",
+  name: "Spruce Board 22x100",
+  name_fi: "Kuusilankku 22x100",
+  name_en: "Spruce Board 22x100",
+  pricing: [
+    { unit_price: 3.0, unit: "jm", supplier_name: "Stark", is_primary: true, link: null },
+  ],
+  thermal_conductivity: 0.12,
+};
+
+const insulationMaterial: Material = {
+  ...baseMaterial,
+  id: "m3",
+  name: "Rockwool 100mm",
+  name_fi: "Kivivilla 100mm",
+  name_en: "Rockwool 100mm",
+  category_name: "insulation",
+  category_name_fi: "Eristeet",
+  pricing: [
+    { unit_price: 8.5, unit: "m2", supplier_name: "K-Rauta", is_primary: true, link: null },
+  ],
+  thermal_conductivity: 0.035,
+  fire_rating: "A1",
+  tags: ["mineral", "rockwool"],
+};
+
+const bomItem: BomItem = {
+  material_id: "m1",
+  quantity: 20,
+  unit: "jm",
+};
+
+const materials = [baseMaterial, cheapMaterial, insulationMaterial];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("MaterialPicker", () => {
+  it("renders dialog with title", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("materialPicker.title")).toBeInTheDocument();
+  });
+
+  it("renders subtitle", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.subtitle")).toBeInTheDocument();
+  });
+
+  it("renders close button", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("dialog.close")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={onClose}
+        onSelect={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("dialog.close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows current material info", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.current")).toBeInTheDocument();
+    expect(screen.getAllByText("Pine Board 22x100").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders search input", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.search")).toBeInTheDocument();
+  });
+
+  it("renders sort dropdown with options", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.sortPriceAsc")).toBeInTheDocument();
+    expect(screen.getByText("materialPicker.sortPriceDesc")).toBeInTheDocument();
+    expect(screen.getByText("materialPicker.sortThermal")).toBeInTheDocument();
+    expect(screen.getByText("materialPicker.sortAvailability")).toBeInTheDocument();
+  });
+
+  it("renders category tabs", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.allMaterials")).toBeInTheDocument();
+  });
+
+  it("renders affiliate disclosure", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.affiliateDisclosure")).toBeInTheDocument();
+  });
+
+  it("has aria-modal on dialog", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("renders eyebrow label", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("materialPicker.eyebrow")).toBeInTheDocument();
+  });
+
+  it("renders price and conductivity sliders", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/materialPicker\.maxPrice/)).toBeInTheDocument();
+    expect(screen.getByText(/materialPicker\.maxConductivity/)).toBeInTheDocument();
+  });
+
+  it("closes when overlay is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={onClose}
+        onSelect={vi.fn()}
+      />,
+    );
+    const overlay = screen.getByRole("presentation");
+    fireEvent.mouseDown(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders tablist for categories", () => {
+    render(
+      <MaterialPicker
+        currentMaterialId="m1"
+        bomItem={bomItem}
+        materials={materials}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/scene-editor.test.tsx
+++ b/web/src/__tests__/scene-editor.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+import SceneEditor from "@/components/SceneEditor";
+
+const sampleCode = `const w = 10;
+const h = 5;
+const d = 3;
+scene.add(box(w, h, d));`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SceneEditor", () => {
+  it("renders textarea with code", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue(sampleCode);
+  });
+
+  it("calls onChange when text is edited", () => {
+    const onChange = vi.fn();
+    render(<SceneEditor sceneJs={sampleCode} onChange={onChange} />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "box(1,1,1)" } });
+    expect(onChange).toHaveBeenCalledWith("box(1,1,1)");
+  });
+
+  it("renders line number gutter", () => {
+    const { container } = render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    const gutter = container.querySelector("[class*='gutter'], [style*='gutter']")
+      || container.querySelector("div > div > div");
+    expect(gutter).toBeInTheDocument();
+    const lines = sampleCode.split("\n");
+    expect(lines.length).toBe(4);
+  });
+
+  it("renders error message when error prop provided", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} error="Syntax error" />);
+    expect(screen.getByText("Syntax error")).toBeInTheDocument();
+  });
+
+  it("renders scene status indicator", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    expect(screen.getByLabelText("editor.sceneValid")).toBeInTheDocument();
+  });
+
+  it("renders error status when error present", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} error="Error" />);
+    expect(screen.getByLabelText("editor.sceneError")).toBeInTheDocument();
+  });
+
+  it("renders scene label", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    expect(screen.getByText("editor.scene")).toBeInTheDocument();
+  });
+
+  it("renders syntax highlighted overlay", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    const pre = document.querySelector("pre");
+    expect(pre).toBeInTheDocument();
+    expect(pre!.innerHTML).toContain("const");
+  });
+
+  it("highlights syntax keywords with colors", () => {
+    render(<SceneEditor sceneJs="const x = 42;" onChange={vi.fn()} />);
+    const pre = document.querySelector("pre");
+    expect(pre!.innerHTML).toContain("color:");
+  });
+
+  it("opens find bar with Ctrl+F", () => {
+    const { container } = render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    const wrapper = container.firstChild as HTMLElement;
+    fireEvent.keyDown(wrapper, { key: "f", ctrlKey: true });
+    expect(screen.getByRole("search")).toBeInTheDocument();
+  });
+
+  it("renders with aria-label on textarea", () => {
+    render(<SceneEditor sceneJs={sampleCode} onChange={vi.fn()} />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveAttribute("aria-label");
+  });
+
+  it("handles empty code", () => {
+    render(<SceneEditor sceneJs="" onChange={vi.fn()} />);
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveValue("");
+  });
+
+  it("handles Tab key for indentation", () => {
+    const onChange = vi.fn();
+    render(<SceneEditor sceneJs="hello" onChange={onChange} />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    textarea.selectionStart = 5;
+    textarea.selectionEnd = 5;
+    fireEvent.keyDown(textarea, { key: "Tab" });
+    expect(onChange).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 27 new unit tests across 2 test files
- **MaterialPicker** (14 tests): dialog rendering, close/overlay dismiss, current material display, search/sort/filter controls, category tabs, affiliate disclosure, aria-modal, sliders
- **SceneEditor** (13 tests): textarea rendering, onChange callback, syntax highlighting with colors, error/status indicators, find bar (Ctrl+F), Tab indentation, empty code handling

## Test plan
- [x] All 27 tests pass locally with `vitest run`
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>