### PR TITLE
test: stabilize project name autosave e2e

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,6 +3,8 @@ import { defineConfig, devices } from "@playwright/test";
 const API_PORT = 3051;
 const WEB_PORT = 3052;
 
+process.env.TEST_API_URL ??= `http://localhost:${API_PORT}`;
+
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: false,

--- a/e2e/tests/project-crud.spec.ts
+++ b/e2e/tests/project-crud.spec.ts
@@ -145,12 +145,18 @@ scene.add(wall, { material: "lumber", color: [0.85, 0.75, 0.55] });
     const nameInput = page.locator('input[value="Original Name"]');
     await expect(nameInput).toBeVisible({ timeout: 10_000 });
 
-    await nameInput.fill("Renamed Project");
+    const saveResponse = page.waitForResponse((response) => {
+      return response.url().includes(`/projects/${project.id}`)
+        && response.request().method() === "PUT"
+        && response.ok();
+    }, { timeout: 15_000 });
 
-    // Wait for auto-save
-    await expect(
-      page.getByText(/tallennettu|saved/i)
-    ).toBeVisible({ timeout: 15_000 });
+    await nameInput.fill("Renamed Project");
+    await saveResponse;
+
+    const saveStatus = page.locator(".save-status-pill");
+    await expect(saveStatus).toHaveAttribute("data-status", "saved", { timeout: 15_000 });
+    await expect(saveStatus).toContainText(/tallennettu|saved/i);
   });
 
   test("deletes a project", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Set `TEST_API_URL` from the Playwright API port so E2E helpers and browser code use the same API server.
- Make the project-name autosave assertion wait for the actual successful `PUT /projects/:id` response before checking UI state.
- Check the save indicator by its explicit `data-status="saved"` state, then verify the localized saved label.

## Verification

- `e2e`: `npx playwright test tests/project-crud.spec.ts:131 --list`
- `git diff --check`

Blocked locally: the full exact repro reaches `POST http://localhost:3051/auth/register`, but this machine's Postgres on `localhost:5433` accepts TCP and then does not complete the PostgreSQL handshake, so the request times out before the autosave step. The Playwright test/config syntax is validated, and the CI suite does not currently run this Playwright job.

Closes #299
