### PR TITLE
Fix editor PDF export download E2E

### DIFF
--- a/e2e/tests/pdf-export.spec.ts
+++ b/e2e/tests/pdf-export.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { registerUser, loginViaUI } from "./helpers";
+import { apiUrl, createProjectViaAPI, loginViaUI, registerUser, saveBomViaAPI } from "./helpers";
 
 test.describe("PDF Export", () => {
   let user: { email: string; password: string; name: string; token: string };
@@ -9,38 +9,23 @@ test.describe("PDF Export", () => {
     const page = await browser.newPage();
     user = await registerUser(page, `pdf-${Date.now()}`);
 
-    // Create project with BOM
-    const res = await page.request.post("http://localhost:3001/projects", {
-      headers: { Authorization: `Bearer ${user.token}` },
-      data: {
-        name: "PDF Export Test",
-        description: "Testing PDF generation",
-        scene_js:
-          'const f = box(6,0.2,4);\nscene.add(f, {material: "foundation", color: [0.7,0.7,0.7]});',
-      },
+    projectId = await createProjectViaAPI(page, user.token, {
+      name: "PDF Export Test",
+      description: "Testing PDF generation",
+      scene_js:
+        'const f = box(6,0.2,4);\nscene.add(f, {material: "foundation", color: [0.7,0.7,0.7]});',
     });
-    const body = await res.json();
-    projectId = body.id;
 
-    // Add BOM items
-    await page.request.put(
-      `http://localhost:3001/projects/${projectId}/bom`,
-      {
-        headers: { Authorization: `Bearer ${user.token}` },
-        data: {
-          items: [
-            { material_id: "pine_48x148_c24", quantity: 42, unit: "jm" },
-            { material_id: "concrete_c25", quantity: 1.2, unit: "m3" },
-          ],
-        },
-      }
-    );
+    await saveBomViaAPI(page, user.token, projectId, [
+      { material_id: "pine_48x148_c24", quantity: 42, unit: "jm" },
+      { material_id: "concrete_c25", quantity: 1.2, unit: "m3" },
+    ]);
     await page.close();
   });
 
   test("API returns valid PDF", async ({ page }) => {
     const res = await page.request.get(
-      `http://localhost:3001/projects/${projectId}/pdf?lang=fi`,
+      apiUrl(`/projects/${projectId}/pdf?lang=fi`),
       {
         headers: { Authorization: `Bearer ${user.token}` },
       }
@@ -60,21 +45,28 @@ test.describe("PDF Export", () => {
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15000 });
     await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
     await page.waitForLoadState("networkidle");
     await expect(page.locator("canvas")).toBeVisible({ timeout: 15_000 });
 
-    // Set up download listener
+    const exportTrigger = page.locator('[data-tour="export-btn"] button').first();
+    await expect(exportTrigger).toBeEnabled({ timeout: 15_000 });
+    await exportTrigger.click();
+
+    const pdfBtn = page.getByRole("menuitem", { name: /^PDF$/i });
+    await expect(pdfBtn).toBeVisible({ timeout: 5_000 });
+
+    const pdfResponsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/projects/${projectId}/pdf`) &&
+        response.status() === 200,
+      { timeout: 15_000 }
+    );
     const downloadPromise = page.waitForEvent("download", { timeout: 15_000 });
 
-    // Open export dropdown then click PDF
-    const exportTrigger = page.locator('[data-tour="export-btn"] button').first();
-    await exportTrigger.click();
-    await page.waitForTimeout(300);
-    const pdfBtn = page.getByRole("button", { name: /^PDF$/i });
     await pdfBtn.click();
 
-    const download = await downloadPromise;
+    const [pdfResponse, download] = await Promise.all([pdfResponsePromise, downloadPromise]);
+    expect(pdfResponse.headers()["content-type"]).toContain("application/pdf");
     expect(download.suggestedFilename()).toContain(".pdf");
   });
 });

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -26,7 +26,7 @@ import CommandPalette from "@/components/CommandPalette";
 import type { Command } from "@/components/CommandPalette";
 import OnboardingTour from "@/components/OnboardingTour";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
-import { generateAraGrantPdf, generateQuotePdf } from "@/lib/pdf";
+import { generateAraGrantPdf } from "@/lib/pdf";
 import { useTheme } from "@/components/ThemeProvider";
 import Link from "next/link";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -884,6 +884,21 @@ export default function ProjectPage() {
     [locale]
   );
 
+  const exportQuotePdf = useCallback(async () => {
+    setShowExportMenu(false);
+    setExportingFormat("pdf");
+    try {
+      await save();
+      track("bom_exported", { format: "pdf" });
+      await api.exportPdf(projectId, projectName, locale);
+      toast(t("toast.bomExported"), "success");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : t("toast.bomExportFailed"), "error");
+    } finally {
+      setExportingFormat(null);
+    }
+  }, [locale, projectId, projectName, save, t, toast, track]);
+
   const exportAraGrantPackage = useCallback(() => {
     setShowAraChecklist(false);
     setShowExportMenu(false);
@@ -993,15 +1008,7 @@ export default function ProjectPage() {
             <polyline points="14 2 14 8 20 8" />
           </svg>
         ),
-        action: () => {
-          try {
-            track("bom_exported", { format: "pdf" });
-            generateQuotePdf({ projectName, projectDescription: projectDesc, bom, locale });
-            toast(t("toast.bomExported"), "success");
-          } catch (err) {
-            toast(err instanceof Error ? err.message : t("toast.bomExportFailed"), "error");
-          }
-        },
+        action: () => { void exportQuotePdf(); },
       },
       {
         id: "export-ara-grant",
@@ -1170,7 +1177,7 @@ export default function ProjectPage() {
         isActive: showDocs,
       },
     ];
-  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, toggleCodePanel, wireframe, showBom, showDocs, resolvedTheme, exportIfcPermitModel]);
+  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, toggleCodePanel, wireframe, showBom, showDocs, resolvedTheme, exportIfcPermitModel, exportQuotePdf]);
 
   const handleViewportReset = useCallback(() => {
     setSceneJs(DEFAULT_SCENE);
@@ -1731,19 +1738,7 @@ export default function ProjectPage() {
                   role="menuitem"
                   className="btn btn-ghost"
                   disabled={exportingFormat !== null}
-                  onClick={async () => {
-                    setShowExportMenu(false);
-                    setExportingFormat("pdf");
-                    try {
-                      track("bom_exported", { format: "pdf" });
-                      generateQuotePdf({ projectName, projectDescription: projectDesc, bom, locale });
-                      toast(t('toast.bomExported'), "success");
-                    } catch (err) {
-                      toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
-                    } finally {
-                      setExportingFormat(null);
-                    }
-                  }}
+                  onClick={() => { void exportQuotePdf(); }}
                   style={{ width: "100%", justifyContent: "flex-start", gap: 8, padding: "8px 12px", fontSize: 12, border: "none", opacity: exportingFormat && exportingFormat !== "pdf" ? 0.4 : 1 }}
                 >
                   {exportingFormat === "pdf" ? (

--- a/web/src/lib/__tests__/api-client.test.ts
+++ b/web/src/lib/__tests__/api-client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ApiError, setToken, getToken, stopRefreshTimer } from "@/lib/api";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { api, ApiError, setToken, getToken, stopRefreshTimer } from "@/lib/api";
 
 describe("ApiError", () => {
   it("sets name, status, and statusText", () => {
@@ -59,5 +59,73 @@ describe("setToken / getToken", () => {
     setToken(null);
     localStorage.setItem("helscoop_token", "fallback-token");
     expect(getToken()).toBe("fallback-token");
+  });
+});
+
+describe("blob-backed downloads", () => {
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    localStorage.clear();
+    setToken("download-token");
+    stopRefreshTimer();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: originalCreateObjectUrl,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: originalRevokeObjectUrl,
+    });
+    document.body.innerHTML = "";
+    setToken(null);
+    stopRefreshTimer();
+  });
+
+  it("downloads exported PDFs via an attached anchor before revoking the blob URL", async () => {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:pdf-download"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      blob: async () => new Blob(["%PDF-test"], { type: "application/pdf" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    let clickedAnchor: HTMLAnchorElement | null = null;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (this: HTMLAnchorElement) {
+      clickedAnchor = this;
+    });
+
+    await api.exportPdf("project-1", "My Project", "fi");
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:3001/projects/project-1/pdf?lang=fi", {
+      headers: { Authorization: "Bearer download-token" },
+    });
+    expect(clickedAnchor).not.toBeNull();
+    const anchor = clickedAnchor as unknown as HTMLAnchorElement;
+    expect(anchor.download).toBe("helscoop_My_Project.pdf");
+    expect(anchor.href).toBe("blob:pdf-download");
+    expect(document.querySelector("a[download]")).toBeNull();
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(30_000);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:pdf-download");
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,21 @@ export function getToken(): string | null {
   return token;
 }
 
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.style.display = "none";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+
+  // Keep the object URL alive long enough for browser download managers and
+  // Playwright's download observer to resolve the blob-backed navigation.
+  window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
+}
+
 export class ApiError extends Error {
   status: number;
   statusText: string;
@@ -397,12 +412,7 @@ export const api = {
       );
     }
     const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `helscoop_${projectName.replace(/\s+/g, '_')}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `helscoop_${projectName.replace(/\s+/g, '_')}.csv`);
   },
   exportIFC: async (projectId: string, projectName: string) => {
     const t = getToken();
@@ -417,12 +427,7 @@ export const api = {
       );
     }
     const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `helscoop_permit_${projectName.replace(/\s+/g, '_')}.ifc`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `helscoop_permit_${projectName.replace(/\s+/g, '_')}.ifc`);
   },
   exportPdf: async (projectId: string, projectName: string, lang: string) => {
     const t = getToken();
@@ -437,12 +442,7 @@ export const api = {
       );
     }
     const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `helscoop_${projectName.replace(/\s+/g, '_')}.pdf`;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, `helscoop_${projectName.replace(/\s+/g, '_')}.pdf`);
   },
   saveBOM: (projectId: string, items: { material_id: string; quantity: number; unit: string }[]) =>
     apiFetch(`/projects/${projectId}/bom`, {


### PR DESCRIPTION
## Summary
- route editor/command-palette PDF export through the backend PDF endpoint
- make blob downloads deterministic by attaching the anchor and delaying URL revocation
- tighten the PDF export Playwright spec to use configured API helpers and wait for both PDF response and download
- add API client coverage for blob-backed PDF downloads

Closes #298.

## Verification
- npm test -- --run src/lib/__tests__/api-client.test.ts
- npx tsc --noEmit
- npm test
- npm run build
- npx playwright test tests/pdf-export.spec.ts --list
- npx playwright test tests/pdf-export.spec.ts:44 --reporter=line (blocked locally: beforeAll timed out waiting for POST http://localhost:3051/auth/register; pg_isready localhost:5433 reports no response)