### PR TITLE
Add axe accessibility audits

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -6,7 +6,21 @@
     "": {
       "name": "helscoop-e2e",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.2",
         "@playwright/test": "^1.52.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -23,6 +37,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/fsevents": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.2",
     "@playwright/test": "^1.52.0"
   }
 }

--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -1,0 +1,137 @@
+import AxeBuilder from "@axe-core/playwright";
+import type { AxeResults, Result as AxeViolation } from "axe-core";
+import { test, expect, type Page } from "@playwright/test";
+import {
+  createProjectViaAPI,
+  registerUser,
+  saveBomViaAPI,
+  setAuthToken,
+} from "./helpers";
+
+const SEVERE_IMPACTS = new Set(["critical", "serious"]);
+
+async function preparePage(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem("helscoop_onboarding_completed", "true");
+  });
+}
+
+async function runWcagAudit(page: Page): Promise<AxeViolation[]> {
+  const results: AxeResults = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa"])
+    .analyze();
+
+  return results.violations.filter((violation) =>
+    SEVERE_IMPACTS.has(violation.impact ?? "")
+  );
+}
+
+function formatViolations(violations: AxeViolation[]): string {
+  if (violations.length === 0) return "No critical or serious accessibility violations";
+
+  return violations
+    .map((violation) => {
+      const targets = violation.nodes
+        .flatMap((node) => node.target)
+        .slice(0, 5)
+        .join(", ");
+      return `${violation.impact}: ${violation.id} - ${violation.help} (${targets})`;
+    })
+    .join("\n");
+}
+
+async function expectNoCriticalOrSeriousViolations(page: Page) {
+  const violations = await runWcagAudit(page);
+  expect(violations, formatViolations(violations)).toEqual([]);
+}
+
+async function createAccessibleProject(page: Page) {
+  const user = await registerUser(page, `a11y-${Date.now()}`);
+  const projectId = await createProjectViaAPI(page, user.token, {
+    name: "Accessibility Audit Project",
+    description: "Project used by the axe accessibility audit",
+    scene_js:
+      'const floor = box(6,0.2,4);\nscene.add(floor, {material: "foundation", color: [0.7,0.7,0.7]});',
+  });
+
+  await saveBomViaAPI(page, user.token, projectId, [
+    { material_id: "pine_48x148_c24", quantity: 12, unit: "jm" },
+    { material_id: "concrete_c25", quantity: 1, unit: "m3" },
+  ]);
+
+  return { user, projectId };
+}
+
+test.describe("Accessibility audits", () => {
+  test("landing page has no critical or serious WCAG violations in light and dark themes", async ({ page }) => {
+    await preparePage(page);
+    await page.goto("/");
+    await expect(page).toHaveTitle(/helscoop/i);
+
+    const addressInput = page.locator('[data-tour="address-input"] input');
+    await expect(addressInput).toBeVisible();
+    await expect(addressInput).toHaveAccessibleName(/address|osoite|search|hae/i);
+
+    await expect(page.locator("#login-email")).toHaveAccessibleName(/email|sähköposti/i);
+    await expect(page.locator("#login-password")).toHaveAccessibleName(/password|salasana/i);
+
+    const themeToggle = page
+      .getByRole("button", { name: /theme|teema|dark|light|tumma|vaalea/i })
+      .first();
+    await expect(themeToggle).toBeVisible();
+
+    await expectNoCriticalOrSeriousViolations(page);
+
+    await themeToggle.click();
+    await page.waitForFunction(() =>
+      document.documentElement.getAttribute("data-theme") === "light" &&
+      !document.documentElement.classList.contains("theme-transitioning")
+    );
+    await expectNoCriticalOrSeriousViolations(page);
+  });
+
+  test("project editor exposes accessible viewport, BOM, chat, icon buttons, and shortcuts dialog", async ({ page }) => {
+    await preparePage(page);
+    const { user, projectId } = await createAccessibleProject(page);
+
+    await setAuthToken(page, user.token);
+    await page.goto(`/project/${projectId}`);
+    await page.waitForLoadState("networkidle");
+    await expect(page.locator("canvas")).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      page.getByRole("application", { name: /3d|viewport|näkymä|malli/i })
+    ).toBeVisible();
+    await expect(page.locator("canvas").first()).toHaveAttribute("aria-hidden", "true");
+    await expect(page.getByRole("grid", { name: /material|materiaali/i })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: /chat|viesti|message/i })).toBeVisible();
+
+    const unlabeledIconButtons = await page.locator("button").evaluateAll((buttons) =>
+      buttons
+        .filter((button) => {
+          const rect = button.getBoundingClientRect();
+          if (rect.width === 0 || rect.height === 0) return false;
+
+          const visibleText = (button.textContent ?? "").replace(/\s+/g, " ").trim();
+          const hasAccessibleName =
+            Boolean(button.getAttribute("aria-label")) ||
+            Boolean(button.getAttribute("aria-labelledby")) ||
+            visibleText.length > 1;
+          const looksIconOnly = Boolean(button.querySelector("svg")) || visibleText.length <= 1;
+
+          return looksIconOnly && !hasAccessibleName;
+        })
+        .map((button) => button.outerHTML.slice(0, 180))
+    );
+    expect(unlabeledIconButtons).toEqual([]);
+
+    await page.keyboard.press("Control+/");
+    const shortcutsDialog = page.getByRole("dialog", { name: /keyboard|shortcuts|pikanäpp/i });
+    await expect(shortcutsDialog).toBeVisible();
+    await expect(shortcutsDialog.getByRole("button", { name: /close|sulje/i })).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(shortcutsDialog).toBeHidden();
+
+    await expectNoCriticalOrSeriousViolations(page);
+  });
+});

--- a/web/src/__tests__/ui-controls.test.tsx
+++ b/web/src/__tests__/ui-controls.test.tsx
@@ -67,22 +67,26 @@ describe("LanguageSwitcher", () => {
     expect(mockSetLocale).toHaveBeenCalledWith("fi");
   });
 
-  it("highlights active locale (FI full opacity when fi)", () => {
+  it("highlights active locale (FI emphasized when fi)", () => {
     mockLocale = "fi";
     render(<LanguageSwitcher />);
     const fi = screen.getByText("FI");
-    expect(fi.style.opacity).toBe("1");
+    expect(fi.style.color).toBe("var(--text-primary)");
+    expect(fi.style.fontWeight).toBe("700");
     const en = screen.getByText("EN");
-    expect(en.style.opacity).toBe("0.4");
+    expect(en.style.color).toBe("var(--text-secondary)");
+    expect(en.style.fontWeight).toBe("500");
   });
 
-  it("highlights active locale (EN full opacity when en)", () => {
+  it("highlights active locale (EN emphasized when en)", () => {
     mockLocale = "en";
     render(<LanguageSwitcher />);
     const en = screen.getByText("EN");
-    expect(en.style.opacity).toBe("1");
+    expect(en.style.color).toBe("var(--text-primary)");
+    expect(en.style.fontWeight).toBe("700");
     const fi = screen.getByText("FI");
-    expect(fi.style.opacity).toBe("0.4");
+    expect(fi.style.color).toBe("var(--text-secondary)");
+    expect(fi.style.fontWeight).toBe("500");
   });
 });
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -26,7 +26,7 @@
 
   --text-primary: #fafafa;
   --text-secondary: #a1a1aa;
-  --text-muted: #71717a;
+  --text-muted: #94949f;
 
   --amber: #e5a04b;
   --amber-light: #f0b86a;
@@ -2103,6 +2103,10 @@ body::before {
   color: var(--amber);
 }
 
+[data-theme="light"] .lang-switch:hover {
+  color: var(--amber-dim);
+}
+
 @keyframes slideLeft {
   from { opacity: 0; transform: translateX(8px); }
   to { opacity: 1; transform: translateX(0); }
@@ -2226,6 +2230,10 @@ body::before {
   color: #09090b;
   font-weight: 600;
   letter-spacing: 0.02em;
+}
+
+[data-theme="light"] .btn-primary {
+  color: #ffffff;
 }
 
 .btn-primary:hover:not(:disabled) {

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -4,6 +4,11 @@ import { useTranslation } from "@/components/LocaleProvider";
 
 export function LanguageSwitcher() {
   const { locale, setLocale, t } = useTranslation();
+  const languageStyle = (active: boolean) => ({
+    color: active ? "var(--text-primary)" : "var(--text-secondary)",
+    fontWeight: active ? 700 : 500,
+    transition: "color 0.15s ease",
+  });
 
   return (
     <button
@@ -11,9 +16,9 @@ export function LanguageSwitcher() {
       aria-label={t("aria.switchLanguage")}
       onClick={() => setLocale(locale === "fi" ? "en" : "fi")}
     >
-      <span style={{ opacity: locale === "fi" ? 1 : 0.4, transition: "opacity 0.15s ease" }}>FI</span>
-      <span style={{ opacity: 0.3 }}>|</span>
-      <span style={{ opacity: locale === "en" ? 1 : 0.4, transition: "opacity 0.15s ease" }}>EN</span>
+      <span style={languageStyle(locale === "fi")}>FI</span>
+      <span style={{ color: "var(--text-secondary)" }}>|</span>
+      <span style={languageStyle(locale === "en")}>EN</span>
     </button>
   );
 }

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -48,7 +48,7 @@ export function ThemeToggle() {
           <line x1="12" y1="17" x2="12" y2="21" />
         </svg>
       )}
-      <span style={{ fontSize: 10, opacity: 0.8 }}>{label.toUpperCase()}</span>
+      <span style={{ fontSize: 10, fontWeight: 700 }}>{label.toUpperCase()}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- add @axe-core/playwright and E2E accessibility audits for the landing page and authenticated editor
- assert no critical/serious WCAG 2 A/AA violations plus explicit accessible labels and keyboard checks
- fix contrast regressions in theme/language controls, primary CTA, and muted text

## Verification
- npx playwright test tests/accessibility.spec.ts:66 --reporter=line
- npx playwright test tests/accessibility.spec.ts --list
- npx playwright test tests/accessibility.spec.ts:93 --list
- npx tsc --noEmit
- npm test -- --run src/__tests__/ui-controls.test.tsx
- npm test
- npm run build
- git diff --check

Editor audit was not run end-to-end locally because localhost:5433 Postgres is unavailable: pg_isready reported no response.

Closes #280.