### PR TITLE
feat(editor): inline autocomplete for primitives, transforms, materials

### DIFF
--- a/web/src/__tests__/scene-autocomplete.test.ts
+++ b/web/src/__tests__/scene-autocomplete.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAutocompleteContext,
+  filterCompletions,
+  STATIC_COMPLETIONS,
+} from "@/components/SceneAutocomplete";
+
+describe("getAutocompleteContext", () => {
+  it("detects a word prefix", () => {
+    const ctx = getAutocompleteContext("const w = bo", 12);
+    expect(ctx.prefix).toBe("bo");
+    expect(ctx.startPos).toBe(10);
+    expect(ctx.isMaterialString).toBe(false);
+  });
+
+  it("detects scene.add prefix via dot notation", () => {
+    const ctx = getAutocompleteContext("scene.ad", 8);
+    expect(ctx.prefix).toBe("scene.ad");
+    expect(ctx.startPos).toBe(0);
+    expect(ctx.isMaterialString).toBe(false);
+  });
+
+  it("detects material string context", () => {
+    const ctx = getAutocompleteContext('scene.add(w, { material: "lum', 30);
+    expect(ctx.prefix).toBe("lum");
+    expect(ctx.isMaterialString).toBe(true);
+  });
+
+  it("detects empty material string context", () => {
+    const ctx = getAutocompleteContext('scene.add(w, { material: "', 27);
+    expect(ctx.prefix).toBe("");
+    expect(ctx.isMaterialString).toBe(true);
+  });
+
+  it("returns empty prefix when cursor is after whitespace", () => {
+    const ctx = getAutocompleteContext("const x = ", 10);
+    expect(ctx.prefix).toBe("");
+    expect(ctx.isMaterialString).toBe(false);
+  });
+
+  it("handles cursor at beginning of text", () => {
+    const ctx = getAutocompleteContext("box(", 0);
+    expect(ctx.prefix).toBe("");
+  });
+
+  it("handles multi-line text", () => {
+    const code = "const a = box(1,2,3);\nconst b = cyl";
+    const ctx = getAutocompleteContext(code, code.length);
+    expect(ctx.prefix).toBe("cyl");
+    expect(ctx.startPos).toBe(code.length - 3);
+  });
+});
+
+describe("filterCompletions", () => {
+  it("returns empty for short prefix", () => {
+    const ctx = { prefix: "b", startPos: 0, isMaterialString: false };
+    expect(filterCompletions(ctx)).toEqual([]);
+  });
+
+  it("matches primitives by prefix", () => {
+    const ctx = { prefix: "bo", startPos: 0, isMaterialString: false };
+    const items = filterCompletions(ctx);
+    expect(items.length).toBe(1);
+    expect(items[0].label).toBe("box");
+    expect(items[0].kind).toBe("primitive");
+  });
+
+  it("matches transforms", () => {
+    const ctx = { prefix: "tr", startPos: 0, isMaterialString: false };
+    const items = filterCompletions(ctx);
+    expect(items.length).toBe(1);
+    expect(items[0].label).toBe("translate");
+  });
+
+  it("matches scene.add", () => {
+    const ctx = { prefix: "scene.a", startPos: 0, isMaterialString: false };
+    const items = filterCompletions(ctx);
+    expect(items.length).toBe(1);
+    expect(items[0].label).toBe("scene.add");
+  });
+
+  it("excludes exact matches", () => {
+    const ctx = { prefix: "box", startPos: 0, isMaterialString: false };
+    const items = filterCompletions(ctx);
+    expect(items.length).toBe(0);
+  });
+
+  it("matches multiple items for common prefix", () => {
+    const ctx = { prefix: "sc", startPos: 0, isMaterialString: false };
+    const items = filterCompletions(ctx);
+    const labels = items.map((i) => i.label);
+    expect(labels).toContain("scale");
+    expect(labels).toContain("scene.add");
+  });
+
+  it("filters materials by id in material context", () => {
+    const materials = [
+      { id: "lumber", name: "Sahatavara" },
+      { id: "concrete", name: "Betoni" },
+      { id: "lumber_glulam", name: "Liimapuu" },
+    ];
+    const ctx = { prefix: "lum", startPos: 10, isMaterialString: true };
+    const items = filterCompletions(ctx, materials);
+    expect(items.length).toBe(2);
+    expect(items[0].label).toBe("lumber");
+    expect(items[0].kind).toBe("material");
+    expect(items[1].label).toBe("lumber_glulam");
+  });
+
+  it("filters materials by name in material context", () => {
+    const materials = [
+      { id: "lumber", name: "Sahatavara" },
+      { id: "concrete", name: "Betoni" },
+    ];
+    const ctx = { prefix: "bet", startPos: 10, isMaterialString: true };
+    const items = filterCompletions(ctx, materials);
+    expect(items.length).toBe(1);
+    expect(items[0].label).toBe("concrete");
+    expect(items[0].detail).toBe("Betoni");
+  });
+
+  it("returns all materials for empty prefix in material context", () => {
+    const materials = [
+      { id: "lumber", name: "Sahatavara" },
+      { id: "concrete", name: "Betoni" },
+    ];
+    const ctx = { prefix: "", startPos: 10, isMaterialString: true };
+    const items = filterCompletions(ctx, materials);
+    expect(items.length).toBe(2);
+  });
+
+  it("returns empty for material context with no materials prop", () => {
+    const ctx = { prefix: "lum", startPos: 10, isMaterialString: true };
+    expect(filterCompletions(ctx)).toEqual([]);
+    expect(filterCompletions(ctx, [])).toEqual([]);
+  });
+
+  it("limits material results to 12", () => {
+    const materials = Array.from({ length: 20 }, (_, i) => ({
+      id: `mat_${i}`,
+      name: `Material ${i}`,
+    }));
+    const ctx = { prefix: "", startPos: 10, isMaterialString: true };
+    const items = filterCompletions(ctx, materials);
+    expect(items.length).toBe(12);
+  });
+});
+
+describe("STATIC_COMPLETIONS", () => {
+  it("contains all primitives", () => {
+    const labels = STATIC_COMPLETIONS.map((c) => c.label);
+    expect(labels).toContain("box");
+    expect(labels).toContain("cylinder");
+    expect(labels).toContain("sphere");
+  });
+
+  it("contains all transforms", () => {
+    const labels = STATIC_COMPLETIONS.map((c) => c.label);
+    expect(labels).toContain("translate");
+    expect(labels).toContain("rotate");
+    expect(labels).toContain("scale");
+  });
+
+  it("contains all booleans", () => {
+    const labels = STATIC_COMPLETIONS.map((c) => c.label);
+    expect(labels).toContain("union");
+    expect(labels).toContain("subtract");
+    expect(labels).toContain("intersect");
+  });
+
+  it("all insertText for functions ends with open paren", () => {
+    for (const c of STATIC_COMPLETIONS) {
+      expect(c.insertText).toMatch(/\($/);
+    }
+  });
+});

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -2368,6 +2368,7 @@ export default function ProjectPage() {
                 onChange={handleSceneChange}
                 error={sceneError}
                 errorLine={sceneErrorLine}
+                materials={materials}
               />
             </div>
           )}

--- a/web/src/components/SceneAutocomplete.tsx
+++ b/web/src/components/SceneAutocomplete.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+
+export interface AutocompleteItem {
+  label: string;
+  insertText: string;
+  detail?: string;
+  kind: "primitive" | "transform" | "boolean" | "scene" | "material" | "snippet";
+}
+
+const KIND_COLORS: Record<AutocompleteItem["kind"], string> = {
+  primitive: "var(--syntax-primitive, #e5a04b)",
+  transform: "var(--syntax-transform, #7ab3e0)",
+  boolean: "var(--syntax-boolean, #8bc48b)",
+  scene: "var(--syntax-scene-add, #f0b86a)",
+  material: "var(--syntax-string, #c4a06e)",
+  snippet: "var(--syntax-keyword, #e5a04b)",
+};
+
+export const STATIC_COMPLETIONS: AutocompleteItem[] = [
+  { label: "box", insertText: "box(", detail: "(width, height, depth)", kind: "primitive" },
+  { label: "cylinder", insertText: "cylinder(", detail: "(radius, height)", kind: "primitive" },
+  { label: "sphere", insertText: "sphere(", detail: "(radius)", kind: "primitive" },
+  { label: "translate", insertText: "translate(", detail: "(shape, x, y, z)", kind: "transform" },
+  { label: "rotate", insertText: "rotate(", detail: "(shape, rx, ry, rz)", kind: "transform" },
+  { label: "scale", insertText: "scale(", detail: "(shape, sx, sy, sz)", kind: "transform" },
+  { label: "union", insertText: "union(", detail: "(a, b)", kind: "boolean" },
+  { label: "subtract", insertText: "subtract(", detail: "(a, b)", kind: "boolean" },
+  { label: "intersect", insertText: "intersect(", detail: "(a, b)", kind: "boolean" },
+  { label: "scene.add", insertText: "scene.add(", detail: '(shape, { material: "..." })', kind: "scene" },
+];
+
+export interface AutocompleteContext {
+  prefix: string;
+  startPos: number;
+  isMaterialString: boolean;
+}
+
+export function getAutocompleteContext(text: string, cursorPos: number): AutocompleteContext {
+  const before = text.slice(0, cursorPos);
+  const materialMatch = before.match(/material:\s*"([^"]*)$/);
+  if (materialMatch) {
+    return {
+      prefix: materialMatch[1],
+      startPos: cursorPos - materialMatch[1].length,
+      isMaterialString: true,
+    };
+  }
+  const wordMatch = before.match(/([a-zA-Z_][\w.]*)$/);
+  if (wordMatch) {
+    return {
+      prefix: wordMatch[1],
+      startPos: cursorPos - wordMatch[1].length,
+      isMaterialString: false,
+    };
+  }
+  return { prefix: "", startPos: cursorPos, isMaterialString: false };
+}
+
+export function filterCompletions(
+  ctx: AutocompleteContext,
+  materials?: { id: string; name: string }[],
+): AutocompleteItem[] {
+  if (ctx.prefix.length < 2 && !ctx.isMaterialString) return [];
+
+  if (ctx.isMaterialString) {
+    if (!materials?.length) return [];
+    const lower = ctx.prefix.toLowerCase();
+    return materials
+      .filter((m) => m.id.toLowerCase().includes(lower) || m.name.toLowerCase().includes(lower))
+      .slice(0, 12)
+      .map((m) => ({
+        label: m.id,
+        insertText: m.id,
+        detail: m.name,
+        kind: "material" as const,
+      }));
+  }
+
+  const lower = ctx.prefix.toLowerCase();
+  return STATIC_COMPLETIONS.filter(
+    (c) => c.label.toLowerCase().startsWith(lower) && c.label !== ctx.prefix,
+  );
+}
+
+export default function SceneAutocomplete({
+  items,
+  selectedIndex,
+  position,
+  onSelect,
+}: {
+  items: AutocompleteItem[];
+  selectedIndex: number;
+  position: { top: number; left: number };
+  onSelect: (item: AutocompleteItem) => void;
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const el = list.children[selectedIndex] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      ref={listRef}
+      role="listbox"
+      aria-label="Autocomplete suggestions"
+      style={{
+        position: "absolute",
+        top: position.top,
+        left: Math.min(position.left, 280),
+        zIndex: 10,
+        background: "var(--bg-secondary, #1a1a24)",
+        border: "1px solid var(--border, #2a2a3a)",
+        borderRadius: "var(--radius-sm, 4px)",
+        boxShadow: "0 4px 16px rgba(0,0,0,0.4)",
+        maxHeight: 200,
+        overflowY: "auto",
+        minWidth: 220,
+        maxWidth: 380,
+        fontSize: 12,
+        fontFamily: "var(--font-mono)",
+      }}
+    >
+      {items.map((item, i) => (
+        <div
+          key={item.label + item.kind}
+          role="option"
+          aria-selected={i === selectedIndex}
+          onMouseDown={(e) => {
+            e.preventDefault();
+            onSelect(item);
+          }}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "5px 10px",
+            cursor: "pointer",
+            background: i === selectedIndex ? "rgba(255,255,255,0.08)" : "transparent",
+            borderLeft: `2px solid ${i === selectedIndex ? KIND_COLORS[item.kind] : "transparent"}`,
+          }}
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: KIND_COLORS[item.kind],
+              flexShrink: 0,
+            }}
+          />
+          <span style={{ color: "var(--text-primary)", flexShrink: 0 }}>
+            {item.label}
+          </span>
+          {item.detail && (
+            <span
+              style={{
+                color: "var(--text-muted)",
+                fontSize: 11,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {item.detail}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/SceneEditor.tsx
+++ b/web/src/components/SceneEditor.tsx
@@ -2,6 +2,11 @@
 
 import { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
+import SceneAutocomplete, {
+  type AutocompleteItem,
+  getAutocompleteContext,
+  filterCompletions,
+} from "@/components/SceneAutocomplete";
 
 /* ── Find / Replace helpers ──────────────────────────────────────── */
 interface FindMatch {
@@ -113,6 +118,7 @@ export default function SceneEditor({
   onChange,
   error,
   errorLine,
+  materials,
 }: {
   sceneJs: string;
   onChange: (code: string) => void;
@@ -120,6 +126,7 @@ export default function SceneEditor({
   error?: string | null;
   /** 1-based line number of the error in the script, or null. */
   errorLine?: number | null;
+  materials?: { id: string; name: string }[];
 }) {
   const { t } = useTranslation();
 
@@ -137,6 +144,58 @@ export default function SceneEditor({
   const [findQuery, setFindQuery] = useState("");
   const [replaceValue, setReplaceValue] = useState("");
   const [currentMatchIdx, setCurrentMatchIdx] = useState(0);
+
+  /* ── Autocomplete state ──────────────────────────────────────── */
+  const [acItems, setAcItems] = useState<AutocompleteItem[]>([]);
+  const [acIndex, setAcIndex] = useState(0);
+  const [acPosition, setAcPosition] = useState({ top: 0, left: 0 });
+  const acVisible = acItems.length > 0;
+
+  const dismissAutocomplete = useCallback(() => {
+    setAcItems([]);
+    setAcIndex(0);
+  }, []);
+
+  const updateAutocomplete = useCallback(() => {
+    const ta = textareaRef.current;
+    if (!ta || !document.activeElement || document.activeElement !== ta) {
+      dismissAutocomplete();
+      return;
+    }
+    const cursor = ta.selectionStart;
+    const ctx = getAutocompleteContext(ta.value, cursor);
+    const items = filterCompletions(ctx, materials);
+    if (items.length === 0) {
+      dismissAutocomplete();
+      return;
+    }
+    const before = ta.value.slice(0, cursor);
+    const linesBefore = before.split("\n");
+    const line = linesBefore.length - 1;
+    const col = linesBefore[linesBefore.length - 1].length;
+    const charWidth = 7.8;
+    setAcPosition({
+      top: (line + 1) * EDITOR_LINE_HEIGHT + EDITOR_PADDING_TOP - ta.scrollTop,
+      left: col * charWidth + 20,
+    });
+    setAcItems(items);
+    setAcIndex((prev) => Math.min(prev, items.length - 1));
+  }, [materials, dismissAutocomplete]);
+
+  const acceptCompletion = useCallback((item: AutocompleteItem) => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    const cursor = ta.selectionStart;
+    const ctx = getAutocompleteContext(ta.value, cursor);
+    const newValue = ta.value.slice(0, ctx.startPos) + item.insertText + ta.value.slice(cursor);
+    onChange(newValue);
+    const newCursor = ctx.startPos + item.insertText.length;
+    dismissAutocomplete();
+    setTimeout(() => {
+      ta.selectionStart = ta.selectionEnd = newCursor;
+      ta.focus();
+    }, 0);
+  }, [onChange, dismissAutocomplete]);
 
   const findMatches = useMemo(() => findAllMatches(sceneJs, findQuery), [sceneJs, findQuery]);
 
@@ -692,12 +751,16 @@ export default function SceneEditor({
             onChange={(e) => {
               onChange(e.target.value);
               updateCursorLine();
+              setTimeout(updateAutocomplete, 0);
             }}
             onScroll={syncScroll}
             onKeyUp={updateCursorLine}
             onMouseUp={updateCursorLine}
             onFocus={startCursorTracking}
-            onBlur={stopCursorTracking}
+            onBlur={() => {
+              stopCursorTracking();
+              dismissAutocomplete();
+            }}
             spellCheck={false}
             aria-label={t("editor.scene")}
             style={{
@@ -720,6 +783,28 @@ export default function SceneEditor({
                 e.preventDefault();
                 openFindReplace();
                 return;
+              }
+              if (acVisible) {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  setAcIndex((prev) => (prev + 1) % acItems.length);
+                  return;
+                }
+                if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  setAcIndex((prev) => (prev - 1 + acItems.length) % acItems.length);
+                  return;
+                }
+                if (e.key === "Tab" || e.key === "Enter") {
+                  e.preventDefault();
+                  acceptCompletion(acItems[acIndex]);
+                  return;
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  dismissAutocomplete();
+                  return;
+                }
               }
               if (e.key === "Tab") {
                 e.preventDefault();
@@ -787,6 +872,14 @@ export default function SceneEditor({
               </div>
             </div>
           )}
+
+          {/* Autocomplete popup */}
+          <SceneAutocomplete
+            items={acItems}
+            selectedIndex={acIndex}
+            position={acPosition}
+            onSelect={acceptCompletion}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds trigger-based autocomplete popup to SceneEditor — suggests `box`, `cylinder`, `sphere`, transforms (`translate`, `rotate`, `scale`), booleans (`union`, `subtract`, `intersect`), and `scene.add` when typing 2+ character prefixes
- Inside `material: "..."` strings, autocomplete suggests material IDs from the project's loaded material catalog, filtered by both ID and localized name
- Standard keyboard controls: Arrow Up/Down to navigate, Tab/Enter to accept, Escape to dismiss
- New `SceneAutocomplete.tsx` component with styled popup matching editor theme
- 22 unit tests covering context detection, filtering, material matching, and static completion catalog

## Test plan
- [x] 22 unit tests pass (`npx vitest run src/__tests__/scene-autocomplete.test.ts`)
- [x] 13 existing SceneEditor tests pass (no regressions)
- [x] TypeScript compiles cleanly
- [ ] Manual: type `bo` in editor → see `box(width, height, depth)` suggestion
- [ ] Manual: type `material: "lu` → see material suggestions from catalog
- [ ] Manual: Tab/Enter accepts, Escape dismisses, arrow keys navigate

Fixes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)