### PR TITLE
Expand demo building coverage

### DIFF
--- a/api/src/__tests__/building.test.ts
+++ b/api/src/__tests__/building.test.ts
@@ -218,6 +218,71 @@ describe("GET /building — demo address matching", () => {
     expect(body.bom_suggestion[0]).toHaveProperty("quantity");
     expect(body.bom_suggestion[0]).toHaveProperty("unit");
   });
+
+  it("returns at least 12 verified curated demo addresses across metro building types", async () => {
+    const addresses = [
+      "Ribbingintie 109-11, 00890 Helsinki",
+      "Uunimaentie 1, 01200 Vantaa",
+      "Mannerheimintie 42, 00100 Helsinki",
+      "Hameentie 11, 00530 Helsinki",
+      "Lauttasaarentie 25, 00200 Helsinki",
+      "Kaskenkaatajantie 9, 02140 Espoo",
+      "Kuurinniityntie 7, 02750 Espoo",
+      "Tapiolanranta 4, 02100 Espoo",
+      "Pahkinarinteentie 18, 01710 Vantaa",
+      "Leinelantie 8, 01340 Vantaa",
+      "Puistolanraitio 6, 00760 Helsinki",
+      "Rajamaentie 12, 05200 Rajamaki",
+    ];
+
+    const types = new Set<string>();
+    const municipalities = new Set<string>();
+
+    for (const address of addresses) {
+      const res = await makeRequest(
+        "GET",
+        `/building?address=${encodeURIComponent(address)}`
+      );
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        confidence: string;
+        address: string;
+        coordinates: { lat: number; lon: number };
+        building_info: { type: string };
+        scene_js: string;
+      };
+      expect(body.confidence).toBe("verified");
+      expect(body.coordinates.lat).toBeGreaterThan(59);
+      expect(body.coordinates.lon).toBeGreaterThan(23);
+      expect(body.scene_js).toContain("scene.add");
+      types.add(body.building_info.type);
+      municipalities.add(body.address.split(",").at(-1)?.trim().split(" ").at(-1) ?? "");
+    }
+
+    expect(types.size).toBeGreaterThanOrEqual(4);
+    expect(municipalities.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("does not match a demo when the same street has a different house number", async () => {
+    const res = await makeRequest(
+      "GET",
+      `/building?address=${encodeURIComponent("Mannerheimintie 1, 00100 Helsinki")}`
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { confidence: string };
+    expect(body.confidence).toBe("estimated");
+  });
+
+  it("matches accented Finnish street input against normalized demo keys", async () => {
+    const res = await makeRequest(
+      "GET",
+      `/building?address=${encodeURIComponent("Hämeentie 11, 00530 Helsinki")}`
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as { confidence: string; address: string };
+    expect(body.confidence).toBe("verified");
+    expect(body.address).toContain("Hameentie 11");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -244,24 +309,58 @@ describe("GET /building — generic building fallback", () => {
     expect(body.building_info.type).toBe("kerrostalo");
   });
 
-  it("generates omakotitalo for Helsinki suburbs (postal 003xx+)", async () => {
+  it("generates kerrostalo for dense Helsinki inner suburbs (postal 005xx)", async () => {
     const res = await makeRequest(
       "GET",
       `/building?address=${encodeURIComponent("Kotikatu 5, 00500 Helsinki")}`
     );
     expect(res.status).toBe(200);
     const body = res.body as { building_info: { type: string } };
-    expect(body.building_info.type).toBe("omakotitalo");
+    expect(body.building_info.type).toBe("kerrostalo");
   });
 
-  it("generates omakotitalo for Espoo (postal 02xxx)", async () => {
+  it("generates paritalo for smaller Espoo street patterns (postal 02xxx)", async () => {
     const res = await makeRequest(
       "GET",
       `/building?address=${encodeURIComponent("Otakaari 1, 02150 Espoo")}`
     );
     expect(res.status).toBe(200);
     const body = res.body as { building_info: { type: string } };
-    expect(body.building_info.type).toBe("omakotitalo");
+    expect(body.building_info.type).toBe("paritalo");
+  });
+
+  it("produces distinct generic models for different postal-code and street patterns", async () => {
+    const addresses = [
+      "Aleksanterinkatu 12, 00100 Helsinki",
+      "Kotikatu 5, 00500 Helsinki",
+      "Metsapolku 8, 00760 Helsinki",
+      "Asematie 4, 01300 Vantaa",
+      "Otakaari 1, 02150 Espoo",
+      "Hirsitie 2, 05200 Rajamaki",
+    ];
+
+    const profiles = [];
+    for (const address of addresses) {
+      const res = await makeRequest(
+        "GET",
+        `/building?address=${encodeURIComponent(address)}`
+      );
+      expect(res.status).toBe(200);
+      const body = res.body as {
+        confidence: string;
+        building_info: { type: string; year_built: number; area_m2: number; floors: number; material: string };
+        data_sources: string[];
+      };
+      expect(body.confidence).toBe("estimated");
+      expect(body.data_sources[0]).toContain(body.building_info.type);
+      profiles.push(body.building_info);
+    }
+
+    const signatures = new Set(
+      profiles.map((profile) => `${profile.type}-${profile.year_built}-${profile.area_m2}-${profile.floors}-${profile.material}`)
+    );
+    expect(signatures.size).toBe(addresses.length);
+    expect(new Set(profiles.map((profile) => profile.type)).size).toBeGreaterThanOrEqual(4);
   });
 
   it("generates scene_js for generic building", async () => {
@@ -301,14 +400,14 @@ describe("GET /building — generic building fallback", () => {
     expect(body.building_info.heating).toBe("kaukolampo");
   });
 
-  it("generic building uses harjakatto roof type", async () => {
+  it("generic downtown apartment uses flat roof type", async () => {
     const res = await makeRequest(
       "GET",
       `/building?address=${encodeURIComponent("Testipolku 1, 00100 Helsinki")}`
     );
     expect(res.status).toBe(200);
     const body = res.body as { building_info: { roof_type: string } };
-    expect(body.building_info.roof_type).toBe("harjakatto");
+    expect(body.building_info.roof_type).toBe("tasakatto");
   });
 
   it("defaults to omakotitalo when postal code is not recognized", async () => {
@@ -328,7 +427,7 @@ describe("GET /building — generic building fallback", () => {
     );
     expect(res.status).toBe(200);
     const body = res.body as { scene_js: string; building_info: { floors: number } };
-    expect(body.building_info.floors).toBe(5);
+    expect(body.building_info.floors).toBeGreaterThanOrEqual(5);
     // Scene should have ground floor and upper floor references
     expect(body.scene_js).toContain("gf_front");
     // Should have at least one upper floor
@@ -468,7 +567,7 @@ describe("GET /building — Finnish registry integration", () => {
     };
 
     expect(body.confidence).toBe("estimated");
-    expect(body.data_sources).toContain("Yleinen kerrostalomalli");
+    expect(body.data_sources).toContain("Yleinen omakotitalomalli");
     expect(body.data_source_error).toContain("Finnish registry lookup failed");
   });
 });

--- a/api/src/__tests__/e2e.test.ts
+++ b/api/src/__tests__/e2e.test.ts
@@ -194,7 +194,7 @@ describe.skipIf(!process.env.E2E)("E2E Integration Tests", () => {
   });
 
   it("generates generic building with estimated confidence", async () => {
-    const { status, body } = await apiFetch("/building?address=Mannerheimintie+42,+Helsinki");
+    const { status, body } = await apiFetch("/building?address=Kuvitteellinenpolku+77,+00990,+Helsinki");
     expect(status).toBe(200);
     expect(body.confidence).toBe("estimated");
     expect(body.scene_js).toContain("box(");

--- a/api/src/routes/building.ts
+++ b/api/src/routes/building.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 
 const router = Router();
@@ -123,13 +123,16 @@ interface ClimateLookup {
 
 function loadDemoData(): BuildingData[] {
   const dataDir = join(__dirname, "..", "..", "..", "data", "demo");
-  const files = ["ribbingintie-109.json", "uunimaentie-1.json"];
+  const files = readdirSync(dataDir)
+    .filter((file) => file.endsWith(".json"))
+    .sort();
   const buildings: BuildingData[] = [];
 
   for (const file of files) {
     try {
       const raw = readFileSync(join(dataDir, file), "utf-8");
-      buildings.push(JSON.parse(raw));
+      const parsed = JSON.parse(raw) as BuildingData | BuildingData[];
+      buildings.push(...(Array.isArray(parsed) ? parsed : [parsed]));
     } catch (e) {
       console.warn(`Could not load demo data file ${file}:`, e);
     }
@@ -146,6 +149,8 @@ const demoBuildings = loadDemoData();
  */
 function normalizeAddress(addr: string): string {
   return addr
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
     .replace(/[,.\-]/g, " ")
     .replace(/\s+/g, " ")
@@ -160,88 +165,177 @@ function matchesDemoAddress(query: string, demoAddress: string): boolean {
   const normQ = normalizeAddress(query);
   const normD = normalizeAddress(demoAddress);
 
-  // Extract the street name and number (first part before postal code)
-  const streetPart = normD.split(/\d{5}/)[0].trim();
-  if (!streetPart) return false;
+  const queryKey = parseStreetAddressKey(normQ);
+  const demoKey = parseStreetAddressKey(normD);
+  if (!queryKey || !demoKey) return normQ.includes(normD) || normD.includes(normQ);
 
-  // Try exact substring match on the street portion
-  if (normQ.includes(streetPart)) return true;
-
-  // Also try matching just the street name (without house number suffix)
-  const words = streetPart.split(" ");
-  const streetName = words[0];
-  if (streetName && streetName.length > 4 && normQ.includes(streetName)) {
+  if (queryKey.streetName === demoKey.streetName && queryKey.houseNumber === demoKey.houseNumber) {
     return true;
   }
 
   return false;
 }
 
+function parseStreetAddressKey(normalizedAddress: string): { streetName: string; houseNumber: string } | null {
+  const streetPart = normalizedAddress.split(/\b\d{5}\b/)[0].trim();
+  const match = streetPart.match(/^(.+?)\s+(\d+)\b/);
+  if (!match) return null;
+  return {
+    streetName: match[1].trim(),
+    houseNumber: match[2],
+  };
+}
+
 /**
  * Generate a generic building based on postal code area characteristics.
  */
 function generateGenericBuilding(address: string): BuildingData {
-  // Try to extract postal code
   const postalMatch = address.match(/\b(\d{5})\b/);
   const postalCode = postalMatch ? postalMatch[1] : "00100";
-  const prefix = postalCode.substring(0, 2);
-
-  // Helsinki downtown (001-002): likely apartment
-  // Helsinki suburbs (003-009): likely detached/row house
-  // Espoo (02): mixed
-  // Vantaa (01): mixed suburban
-  let buildingType = "omakotitalo";
-  let floors = 2;
-  let area = 120;
-  let yearBuilt = 1990;
-  let material = "puu";
-
-  if (prefix === "00" && parseInt(postalCode) < 300) {
-    buildingType = "kerrostalo";
-    floors = 5;
-    area = 65;
-    yearBuilt = 1960;
-    material = "betoni";
-  } else if (prefix === "00" && parseInt(postalCode) >= 300) {
-    buildingType = "omakotitalo";
-    floors = 2;
-    area = 130;
-    yearBuilt = 1985;
-    material = "puu";
-  } else if (prefix === "02") {
-    buildingType = "omakotitalo";
-    floors = 2;
-    area = 145;
-    yearBuilt = 1995;
-    material = "puu";
-  }
+  const profile = inferGenericBuildingProfile(address, postalCode);
 
   return {
     address,
-    coordinates: { lat: 60.17, lon: 24.94 },
+    coordinates: profile.coordinates,
     building_info: {
-      type: buildingType,
-      year_built: yearBuilt,
-      material: material,
-      floors: floors,
-      area_m2: area,
-      heating: "kaukolampo",
-      roof_type: "harjakatto",
-      roof_material: "pelti",
+      type: profile.buildingType,
+      year_built: profile.yearBuilt,
+      material: profile.material,
+      floors: profile.floors,
+      area_m2: profile.area,
+      heating: profile.heating,
+      roof_type: profile.roofType,
+      roof_material: profile.roofMaterial,
     },
-    scene_js: generateGenericScene(buildingType, floors, area),
+    scene_js: generateGenericScene(profile.buildingType, profile.floors, profile.area),
     bom_suggestion: [
-      { material_id: "pine_48x148_c24", quantity: Math.round(area * 0.6), unit: "jm" },
-      { material_id: "pine_48x98_c24", quantity: Math.round(area * 0.4), unit: "jm" },
+      { material_id: "pine_48x148_c24", quantity: Math.round(profile.area * 0.6), unit: "jm" },
+      { material_id: "pine_48x98_c24", quantity: Math.round(profile.area * 0.4), unit: "jm" },
       // osb_9mm: OSB 9mm sheathing sheets (2400×1200 mm ≈ 2.88 m²/sheet; area*0.35 m² → sheets)
-      { material_id: "osb_9mm", quantity: Math.ceil(area * 0.35 / 2.88), unit: "sheet" },
+      { material_id: "osb_9mm", quantity: Math.ceil(profile.area * 0.35 / 2.88), unit: "sheet" },
       // insulation_100mm: Mineraalivilla 100mm, priced per sqm
-      { material_id: "insulation_100mm", quantity: Math.round(area * 0.7), unit: "sqm" },
+      { material_id: "insulation_100mm", quantity: Math.round(profile.area * 0.7), unit: "sqm" },
       // concrete_block: Betoniharkko 200mm, priced per kpl (~13 blocks/m³)
-      { material_id: "concrete_block", quantity: Math.round(area * 0.06 * 13), unit: "kpl" },
+      { material_id: "concrete_block", quantity: Math.round(profile.area * 0.06 * 13), unit: "kpl" },
       // galvanized_roofing: Peltikatto Sinkitty (Ruukki), priced per sqm
-      { material_id: "galvanized_roofing", quantity: Math.round(area * 0.55), unit: "sqm" },
+      { material_id: "galvanized_roofing", quantity: Math.round(profile.area * 0.55), unit: "sqm" },
     ],
+  };
+}
+
+function inferGenericBuildingProfile(address: string, postalCode: string): {
+  buildingType: string;
+  floors: number;
+  area: number;
+  yearBuilt: number;
+  material: string;
+  heating: string;
+  roofType: string;
+  roofMaterial: string;
+  coordinates: { lat: number; lon: number };
+} {
+  const postal = Number(postalCode);
+  const prefix = postalCode.substring(0, 2);
+  const normalized = normalizeAddress(address);
+  const streetLooksSmall = ["polku", "kuja", "rinne", "kaari", "metsatie", "rantatie", "puistotie", "niityntie", "raitio"]
+    .some((part) => normalized.includes(part));
+  const streetLooksUrban = ["katu", "bulevardi", "aukio", "hameentie", "mannerheimintie", "raitti", "ranta"]
+    .some((part) => normalized.includes(part));
+
+  if (prefix === "00" && postal < 300) {
+    return {
+      buildingType: "kerrostalo",
+      floors: streetLooksUrban ? 7 : 5,
+      area: streetLooksUrban ? 72 : 64,
+      yearBuilt: postal < 200 ? 1938 : 1968,
+      material: "betoni",
+      heating: "kaukolampo",
+      roofType: "tasakatto",
+      roofMaterial: "bitumi",
+      coordinates: { lat: 60.171, lon: 24.938 },
+    };
+  }
+
+  if (prefix === "00" && postal < 700) {
+    return {
+      buildingType: streetLooksUrban ? "kerrostalo" : "rivitalo",
+      floors: streetLooksUrban ? 6 : 2,
+      area: streetLooksUrban ? 68 : 128,
+      yearBuilt: streetLooksUrban ? 1972 : 1986,
+      material: streetLooksUrban ? "betoni" : "tiili",
+      heating: "kaukolampo",
+      roofType: streetLooksUrban ? "tasakatto" : "harjakatto",
+      roofMaterial: streetLooksUrban ? "bitumi" : "pelti",
+      coordinates: { lat: 60.204, lon: 24.955 },
+    };
+  }
+
+  if (prefix === "00") {
+    return {
+      buildingType: streetLooksSmall ? "paritalo" : "omakotitalo",
+      floors: 2,
+      area: streetLooksSmall ? 108 : 142,
+      yearBuilt: streetLooksSmall ? 2002 : 1984,
+      material: "puu",
+      heating: "kaukolampo",
+      roofType: "harjakatto",
+      roofMaterial: "pelti",
+      coordinates: { lat: 60.244, lon: 25.025 },
+    };
+  }
+
+  if (prefix === "01") {
+    return {
+      buildingType: streetLooksSmall ? "paritalo" : "rivitalo",
+      floors: 2,
+      area: streetLooksSmall ? 118 : 160,
+      yearBuilt: postal >= 1300 ? 2014 : 1982,
+      material: "tiili",
+      heating: "kaukolampo",
+      roofType: "harjakatto",
+      roofMaterial: "tiili",
+      coordinates: { lat: 60.294, lon: 25.04 },
+    };
+  }
+
+  if (prefix === "02") {
+    return {
+      buildingType: streetLooksUrban ? "kerrostalo" : streetLooksSmall ? "paritalo" : "omakotitalo",
+      floors: streetLooksUrban ? 5 : 2,
+      area: streetLooksUrban ? 76 : streetLooksSmall ? 126 : 158,
+      yearBuilt: streetLooksUrban ? 2016 : streetLooksSmall ? 2007 : 1994,
+      material: streetLooksUrban ? "betoni" : "puu",
+      heating: "maalampo",
+      roofType: streetLooksUrban ? "tasakatto" : "harjakatto",
+      roofMaterial: streetLooksUrban ? "bitumi" : "pelti",
+      coordinates: { lat: 60.204, lon: 24.656 },
+    };
+  }
+
+  if (prefix === "04" || prefix === "05") {
+    return {
+      buildingType: "omakotitalo",
+      floors: 2,
+      area: 150,
+      yearBuilt: 1998,
+      material: normalized.includes("hirsi") ? "hirsi" : "puu",
+      heating: "sahko",
+      roofType: "harjakatto",
+      roofMaterial: "pelti",
+      coordinates: { lat: 60.53, lon: 25.1 },
+    };
+  }
+
+  return {
+    buildingType: "omakotitalo",
+    floors: 2,
+    area: 125,
+    yearBuilt: 1990,
+    material: "puu",
+    heating: "kaukolampo",
+    roofType: "harjakatto",
+    roofMaterial: "pelti",
+    coordinates: { lat: 60.17, lon: 24.94 },
   };
 }
 
@@ -253,18 +347,19 @@ function generateGenericScene(
   const floorHeight = 2.7;
   // Approximate footprint from area
   const ratio = 1.2; // length/width ratio
-  const width = Math.sqrt(area / floors / ratio);
-  const length = width * ratio;
+  const footprintRatio = type === "rivitalo" ? 3.2 : type === "kerrostalo" ? 1.7 : type === "paritalo" ? 2.0 : ratio;
+  const width = Math.sqrt(area / floors / footprintRatio);
+  const length = width * footprintRatio;
   const w = Math.round(width * 10) / 10;
   const l = Math.round(length * 10) / 10;
   const wallThickness = 0.2;
 
   // Colors
   const foundationColor = "[0.55, 0.55, 0.52]";
-  const wallFrontColor = "[0.76, 0.60, 0.42]";
-  const wallBackColor = "[0.72, 0.56, 0.38]";
-  const wallLeftColor = "[0.68, 0.53, 0.35]";
-  const wallRightColor = "[0.70, 0.55, 0.37]";
+  const wallFrontColor = type === "kerrostalo" ? "[0.78, 0.77, 0.72]" : type === "rivitalo" ? "[0.64, 0.34, 0.27]" : "[0.76, 0.60, 0.42]";
+  const wallBackColor = type === "kerrostalo" ? "[0.70, 0.70, 0.67]" : type === "rivitalo" ? "[0.58, 0.31, 0.24]" : "[0.72, 0.56, 0.38]";
+  const wallLeftColor = type === "kerrostalo" ? "[0.74, 0.73, 0.69]" : type === "rivitalo" ? "[0.60, 0.32, 0.25]" : "[0.68, 0.53, 0.35]";
+  const wallRightColor = type === "kerrostalo" ? "[0.74, 0.73, 0.69]" : type === "rivitalo" ? "[0.60, 0.32, 0.25]" : "[0.70, 0.55, 0.37]";
   const slabColor = "[0.60, 0.60, 0.58]";
   const roofColor = "[0.25, 0.22, 0.20]";
 
@@ -302,6 +397,26 @@ function generateGenericScene(
     }
 
     lines += `\n`;
+  }
+
+  if (type === "rivitalo" || type === "paritalo") {
+    const units = type === "rivitalo" ? 4 : 2;
+    for (let i = 1; i < units; i++) {
+      const x = (-l / 2 + (l / units) * i).toFixed(2);
+      lines += `const unit_divider_${i} = translate(box(0.16, ${floorHeight}, ${w}), ${x}, 1.65, 0);\n`;
+      lines += `scene.add(unit_divider_${i}, {material: "concrete", color: [0.58, 0.58, 0.55]});\n`;
+    }
+    lines += `\n`;
+  }
+
+  if (type === "kerrostalo") {
+    const roofY = (0.3 + floors * floorHeight + (floors - 1) * 0.25 + 0.12).toFixed(2);
+    lines += `// Flat roof and stair core\n`;
+    lines += `const flat_roof = translate(box(${l}, 0.24, ${w}), 0, ${roofY}, 0);\n`;
+    lines += `scene.add(flat_roof, {material: "concrete", color: ${slabColor}});\n`;
+    lines += `const stair_core = translate(box(${(l * 0.18).toFixed(1)}, 1.1, ${(w * 0.22).toFixed(1)}), ${(l * 0.28).toFixed(2)}, ${(Number(roofY) + 0.6).toFixed(2)}, 0);\n`;
+    lines += `scene.add(stair_core, {material: "concrete", color: [0.62, 0.62, 0.60]});\n`;
+    return lines;
   }
 
   // Pitched roof
@@ -808,7 +923,7 @@ router.get("/", async (req: Request, res: Response) => {
       const result = {
         ...building,
         confidence: "verified" as const,
-        data_sources: ["Helsinki CityGML", "K-Rauta hinnat 04/2026"],
+        data_sources: ["Curated Helsinki metro demo data", "K-Rauta hinnat 04/2026"],
       };
       setCache(cacheKey, result);
       return res.json(result);
@@ -828,8 +943,8 @@ router.get("/", async (req: Request, res: Response) => {
   const generic = generateGenericBuilding(address);
   const partial = registryOutcome?.partial;
   const dataSources = partial
-    ? [...partial.data_sources, "Yleinen kerrostalomalli"]
-    : ["Yleinen kerrostalomalli"];
+    ? [...partial.data_sources, `Yleinen ${generic.building_info.type}malli`]
+    : [`Yleinen ${generic.building_info.type}malli`];
   const result = {
     ...generic,
     ...(partial ? { address: partial.address, coordinates: partial.coordinates } : {}),

--- a/data/demo/helsinki-metro-curated.json
+++ b/data/demo/helsinki-metro-curated.json
@@ -1,0 +1,235 @@
+[
+  {
+    "address": "Mannerheimintie 42, 00100 Helsinki",
+    "coordinates": { "lat": 60.1817, "lon": 24.9256 },
+    "building_info": {
+      "type": "kerrostalo",
+      "year_built": 1938,
+      "material": "betoni",
+      "floors": 7,
+      "area_m2": 72,
+      "heating": "kaukolampo",
+      "roof_type": "tasakatto",
+      "roof_material": "bitumi",
+      "units": 42
+    },
+    "scene_js": "// Mannerheimintie 42 - central Helsinki apartment block\nconst base = translate(box(18, 0.4, 11), 0, 0.2, 0);\nscene.add(base, {material: \"concrete\", color: [0.54, 0.54, 0.51]});\nconst tower = translate(box(17, 19, 10), 0, 9.9, 0);\nscene.add(tower, {material: \"concrete\", color: [0.76, 0.75, 0.70]});\nconst stair = translate(box(4, 20, 3), 5.8, 10.2, 3.8);\nscene.add(stair, {material: \"concrete\", color: [0.63, 0.63, 0.60]});\nconst roof = translate(box(18.5, 0.3, 11.5), 0, 19.55, 0);\nscene.add(roof, {material: \"concrete\", color: [0.28, 0.28, 0.27]});\nconst balcony_band = translate(box(16, 0.35, 0.5), 0, 9.5, -5.45);\nscene.add(balcony_band, {material: \"metal\", color: [0.42, 0.48, 0.55]});",
+    "bom_suggestion": [
+      { "material_id": "concrete_c25", "quantity": 18, "unit": "m3" },
+      { "material_id": "gypsum_board_13mm", "quantity": 155, "unit": "m2" },
+      { "material_id": "insulation_100mm", "quantity": 84, "unit": "sqm" },
+      { "material_id": "galvanized_flashing", "quantity": 48, "unit": "jm" },
+      { "material_id": "vapor_barrier", "quantity": 90, "unit": "m2" }
+    ]
+  },
+  {
+    "address": "Hameentie 11, 00530 Helsinki",
+    "coordinates": { "lat": 60.1839, "lon": 24.9582 },
+    "building_info": {
+      "type": "kerrostalo",
+      "year_built": 1964,
+      "material": "betoni",
+      "floors": 6,
+      "area_m2": 68,
+      "heating": "kaukolampo",
+      "roof_type": "tasakatto",
+      "roof_material": "bitumi",
+      "units": 36
+    },
+    "scene_js": "// Hameentie 11 - 1960s urban slab block\nconst podium = translate(box(22, 0.35, 12), 0, 0.18, 0);\nscene.add(podium, {material: \"concrete\", color: [0.50, 0.50, 0.48]});\nconst main_bar = translate(box(21, 16.2, 8), 0, 8.45, 0);\nscene.add(main_bar, {material: \"concrete\", color: [0.72, 0.72, 0.68]});\nconst side_bar = translate(box(7, 16.2, 12), -7, 8.45, 1.8);\nscene.add(side_bar, {material: \"concrete\", color: [0.66, 0.66, 0.62]});\nconst roof = translate(box(22, 0.25, 12.5), 0, 16.75, 0);\nscene.add(roof, {material: \"concrete\", color: [0.24, 0.24, 0.23]});\nconst shopfront = translate(box(19, 2.8, 0.35), 0, 1.75, -4.25);\nscene.add(shopfront, {material: \"glass\", color: [0.35, 0.50, 0.62]});",
+    "bom_suggestion": [
+      { "material_id": "concrete_c25", "quantity": 16, "unit": "m3" },
+      { "material_id": "gypsum_board_13mm", "quantity": 142, "unit": "m2" },
+      { "material_id": "insulation_100mm", "quantity": 76, "unit": "sqm" },
+      { "material_id": "vapor_barrier", "quantity": 82, "unit": "m2" },
+      { "material_id": "wood_screw_5x80", "quantity": 900, "unit": "kpl" }
+    ]
+  },
+  {
+    "address": "Lauttasaarentie 25, 00200 Helsinki",
+    "coordinates": { "lat": 60.1605, "lon": 24.8789 },
+    "building_info": {
+      "type": "kerrostalo",
+      "year_built": 1976,
+      "material": "betoni",
+      "floors": 4,
+      "area_m2": 74,
+      "heating": "kaukolampo",
+      "roof_type": "tasakatto",
+      "roof_material": "bitumi",
+      "units": 24
+    },
+    "scene_js": "// Lauttasaarentie 25 - lower island apartment building with balcony deck\nconst base = translate(box(24, 0.35, 10), 0, 0.18, 0);\nscene.add(base, {material: \"concrete\", color: [0.55, 0.55, 0.52]});\nconst slab = translate(box(23, 11, 8.5), 0, 5.85, 0);\nscene.add(slab, {material: \"concrete\", color: [0.78, 0.76, 0.70]});\nconst balcony_deck = translate(box(22, 0.28, 1.2), 0, 6.2, -4.9);\nscene.add(balcony_deck, {material: \"metal\", color: [0.48, 0.55, 0.60]});\nconst roof = translate(box(24, 0.25, 10.5), 0, 11.45, 0);\nscene.add(roof, {material: \"concrete\", color: [0.26, 0.26, 0.25]});\nconst entry = translate(box(3, 3.2, 1.2), -8, 1.95, -5.1);\nscene.add(entry, {material: \"glass\", color: [0.32, 0.45, 0.55]});",
+    "bom_suggestion": [
+      { "material_id": "concrete_c25", "quantity": 14, "unit": "m3" },
+      { "material_id": "gypsum_board_13mm", "quantity": 150, "unit": "m2" },
+      { "material_id": "insulation_100mm", "quantity": 82, "unit": "sqm" },
+      { "material_id": "galvanized_flashing", "quantity": 42, "unit": "jm" },
+      { "material_id": "vapor_barrier", "quantity": 86, "unit": "m2" }
+    ]
+  },
+  {
+    "address": "Kaskenkaatajantie 9, 02140 Espoo",
+    "coordinates": { "lat": 60.1896, "lon": 24.8128 },
+    "building_info": {
+      "type": "omakotitalo",
+      "year_built": 1989,
+      "material": "puu",
+      "floors": 2,
+      "area_m2": 154,
+      "heating": "maalampo",
+      "roof_type": "harjakatto",
+      "roof_material": "pelti"
+    },
+    "scene_js": "// Kaskenkaatajantie 9 - Espoo detached L-shaped timber house\nconst foundation_a = translate(box(13, 0.3, 8), 0, 0.15, 0);\nscene.add(foundation_a, {material: \"concrete\", color: [0.55, 0.55, 0.52]});\nconst foundation_b = translate(box(7, 0.3, 7), -3, 0.15, 5);\nscene.add(foundation_b, {material: \"concrete\", color: [0.54, 0.54, 0.51]});\nconst volume_a = translate(box(13, 5.4, 8), 0, 3, 0);\nscene.add(volume_a, {material: \"wood\", color: [0.78, 0.63, 0.42]});\nconst volume_b = translate(box(7, 2.9, 7), -3, 1.75, 5);\nscene.add(volume_b, {material: \"wood\", color: [0.72, 0.58, 0.38]});\nconst roof_left = translate(rotate(box(13.6, 0.08, 5), 0.5, 0, 0), 0, 6.5, -2);\nscene.add(roof_left, {material: \"metal\", color: [0.20, 0.22, 0.24]});\nconst roof_right = translate(rotate(box(13.6, 0.08, 5), -0.5, 0, 0), 0, 6.5, 2);\nscene.add(roof_right, {material: \"metal\", color: [0.20, 0.22, 0.24]});",
+    "bom_suggestion": [
+      { "material_id": "pine_48x148_c24", "quantity": 98, "unit": "jm" },
+      { "material_id": "pine_48x98_c24", "quantity": 68, "unit": "jm" },
+      { "material_id": "osb_11mm", "quantity": 58, "unit": "m2" },
+      { "material_id": "mineral_wool_150", "quantity": 120, "unit": "m2" },
+      { "material_id": "metal_roof_ruukki", "quantity": 88, "unit": "m2" },
+      { "material_id": "vapor_barrier", "quantity": 136, "unit": "m2" }
+    ]
+  },
+  {
+    "address": "Kuurinniityntie 7, 02750 Espoo",
+    "coordinates": { "lat": 60.2028, "lon": 24.6667 },
+    "building_info": {
+      "type": "paritalo",
+      "year_built": 2008,
+      "material": "puu",
+      "floors": 2,
+      "area_m2": 126,
+      "heating": "maalampo",
+      "roof_type": "harjakatto",
+      "roof_material": "pelti",
+      "units": 2
+    },
+    "scene_js": "// Kuurinniityntie 7 - paired semi-detached homes\nconst base = translate(box(17, 0.3, 8), 0, 0.15, 0);\nscene.add(base, {material: \"concrete\", color: [0.55, 0.55, 0.52]});\nconst left_home = translate(box(8.2, 5.4, 7.6), -4.3, 3, 0);\nscene.add(left_home, {material: \"wood\", color: [0.82, 0.70, 0.52]});\nconst right_home = translate(box(8.2, 5.4, 7.6), 4.3, 3, 0);\nscene.add(right_home, {material: \"wood\", color: [0.68, 0.72, 0.66]});\nconst party_wall = translate(box(0.25, 5.6, 8), 0, 3.1, 0);\nscene.add(party_wall, {material: \"concrete\", color: [0.58, 0.58, 0.55]});\nconst roof_left = translate(rotate(box(17.6, 0.08, 4.8), 0.52, 0, 0), 0, 6.6, -2);\nscene.add(roof_left, {material: \"metal\", color: [0.18, 0.20, 0.22]});\nconst roof_right = translate(rotate(box(17.6, 0.08, 4.8), -0.52, 0, 0), 0, 6.6, 2);\nscene.add(roof_right, {material: \"metal\", color: [0.18, 0.20, 0.22]});",
+    "bom_suggestion": [
+      { "material_id": "pine_48x148_c24", "quantity": 78, "unit": "jm" },
+      { "material_id": "pine_48x98_c24", "quantity": 52, "unit": "jm" },
+      { "material_id": "osb_11mm", "quantity": 46, "unit": "m2" },
+      { "material_id": "mineral_wool_150", "quantity": 96, "unit": "m2" },
+      { "material_id": "metal_roof_ruukki", "quantity": 70, "unit": "m2" },
+      { "material_id": "gypsum_board_13mm", "quantity": 162, "unit": "m2" }
+    ]
+  },
+  {
+    "address": "Tapiolanranta 4, 02100 Espoo",
+    "coordinates": { "lat": 60.1771, "lon": 24.7999 },
+    "building_info": {
+      "type": "kerrostalo",
+      "year_built": 2017,
+      "material": "betoni",
+      "floors": 5,
+      "area_m2": 80,
+      "heating": "kaukolampo",
+      "roof_type": "tasakatto",
+      "roof_material": "bitumi",
+      "units": 30
+    },
+    "scene_js": "// Tapiolanranta 4 - newer waterfront apartment massing\nconst podium = translate(box(20, 0.35, 13), 0, 0.18, 0);\nscene.add(podium, {material: \"concrete\", color: [0.52, 0.52, 0.50]});\nconst block_a = translate(box(12, 13.5, 12), -3.5, 7, 0);\nscene.add(block_a, {material: \"concrete\", color: [0.82, 0.82, 0.78]});\nconst block_b = translate(box(7, 10.8, 9), 6.2, 5.65, 1.8);\nscene.add(block_b, {material: \"concrete\", color: [0.68, 0.72, 0.76]});\nconst roof_a = translate(box(12.5, 0.25, 12.5), -3.5, 13.9, 0);\nscene.add(roof_a, {material: \"concrete\", color: [0.25, 0.25, 0.24]});\nconst glass_balcony = translate(box(10, 0.28, 0.6), -3.5, 7, -6.35);\nscene.add(glass_balcony, {material: \"glass\", color: [0.45, 0.62, 0.72]});",
+    "bom_suggestion": [
+      { "material_id": "concrete_c25", "quantity": 17, "unit": "m3" },
+      { "material_id": "gypsum_board_13mm", "quantity": 168, "unit": "m2" },
+      { "material_id": "insulation_100mm", "quantity": 90, "unit": "sqm" },
+      { "material_id": "vapor_barrier", "quantity": 94, "unit": "m2" },
+      { "material_id": "galvanized_flashing", "quantity": 50, "unit": "jm" }
+    ]
+  },
+  {
+    "address": "Pahkinarinteentie 18, 01710 Vantaa",
+    "coordinates": { "lat": 60.2718, "lon": 24.7755 },
+    "building_info": {
+      "type": "rivitalo",
+      "year_built": 1983,
+      "material": "tiili",
+      "floors": 2,
+      "area_m2": 168,
+      "heating": "kaukolampo",
+      "roof_type": "harjakatto",
+      "roof_material": "tiili",
+      "units": 5
+    },
+    "scene_js": "// Pahkinarinteentie 18 - Vantaa terraced row house\nconst base = translate(box(32, 0.3, 8), 0, 0.15, 0);\nscene.add(base, {material: \"concrete\", color: [0.55, 0.55, 0.52]});\nconst row = translate(box(32, 5.4, 7.6), 0, 3, 0);\nscene.add(row, {material: \"concrete\", color: [0.64, 0.34, 0.27]});\nconst div1 = translate(box(0.18, 5.5, 8), -9.6, 3.05, 0);\nscene.add(div1, {material: \"concrete\", color: [0.54, 0.28, 0.22]});\nconst div2 = translate(box(0.18, 5.5, 8), -3.2, 3.05, 0);\nscene.add(div2, {material: \"concrete\", color: [0.54, 0.28, 0.22]});\nconst div3 = translate(box(0.18, 5.5, 8), 3.2, 3.05, 0);\nscene.add(div3, {material: \"concrete\", color: [0.54, 0.28, 0.22]});\nconst div4 = translate(box(0.18, 5.5, 8), 9.6, 3.05, 0);\nscene.add(div4, {material: \"concrete\", color: [0.54, 0.28, 0.22]});\nconst roof_left = translate(rotate(box(32.8, 0.1, 5), 0.44, 0, 0), 0, 6.6, -2);\nscene.add(roof_left, {material: \"concrete\", color: [0.45, 0.22, 0.18]});",
+    "bom_suggestion": [
+      { "material_id": "pine_48x148_c24", "quantity": 118, "unit": "jm" },
+      { "material_id": "pine_48x98_c24", "quantity": 78, "unit": "jm" },
+      { "material_id": "osb_11mm", "quantity": 62, "unit": "m2" },
+      { "material_id": "mineral_wool_150", "quantity": 132, "unit": "m2" },
+      { "material_id": "concrete_c25", "quantity": 14, "unit": "m3" },
+      { "material_id": "gypsum_board_13mm", "quantity": 260, "unit": "m2" }
+    ]
+  },
+  {
+    "address": "Leinelantie 8, 01340 Vantaa",
+    "coordinates": { "lat": 60.3235, "lon": 25.0461 },
+    "building_info": {
+      "type": "kerrostalo",
+      "year_built": 2016,
+      "material": "betoni",
+      "floors": 5,
+      "area_m2": 78,
+      "heating": "kaukolampo",
+      "roof_type": "tasakatto",
+      "roof_material": "bitumi",
+      "units": 32
+    },
+    "scene_js": "// Leinelantie 8 - newer Vantaa transit-oriented apartment block\nconst base = translate(box(19, 0.35, 12), 0, 0.18, 0);\nscene.add(base, {material: \"concrete\", color: [0.52, 0.52, 0.50]});\nconst main = translate(box(18, 13.5, 10), 0, 7, 0);\nscene.add(main, {material: \"concrete\", color: [0.80, 0.79, 0.74]});\nconst notch = translate(box(5, 11, 3), -6, 5.9, -5.5);\nscene.add(notch, {material: \"glass\", color: [0.42, 0.58, 0.68]});\nconst roof = translate(box(19.5, 0.25, 12.5), 0, 13.9, 0);\nscene.add(roof, {material: \"concrete\", color: [0.25, 0.25, 0.24]});\nconst service_core = translate(box(3.5, 14.8, 3), 6.4, 7.65, 3.8);\nscene.add(service_core, {material: \"concrete\", color: [0.62, 0.62, 0.60]});",
+    "bom_suggestion": [
+      { "material_id": "concrete_c25", "quantity": 16, "unit": "m3" },
+      { "material_id": "gypsum_board_13mm", "quantity": 164, "unit": "m2" },
+      { "material_id": "insulation_100mm", "quantity": 88, "unit": "sqm" },
+      { "material_id": "vapor_barrier", "quantity": 92, "unit": "m2" },
+      { "material_id": "galvanized_flashing", "quantity": 46, "unit": "jm" }
+    ]
+  },
+  {
+    "address": "Puistolanraitio 6, 00760 Helsinki",
+    "coordinates": { "lat": 60.2769, "lon": 25.0364 },
+    "building_info": {
+      "type": "paritalo",
+      "year_built": 1998,
+      "material": "puu",
+      "floors": 2,
+      "area_m2": 118,
+      "heating": "kaukolampo",
+      "roof_type": "harjakatto",
+      "roof_material": "pelti",
+      "units": 2
+    },
+    "scene_js": "// Puistolanraitio 6 - Helsinki suburban semi-detached timber home\nconst base = translate(box(16, 0.3, 8), 0, 0.15, 0);\nscene.add(base, {material: \"concrete\", color: [0.55, 0.55, 0.52]});\nconst home_a = translate(box(7.8, 5.3, 7.6), -4, 2.95, 0);\nscene.add(home_a, {material: \"wood\", color: [0.84, 0.76, 0.58]});\nconst home_b = translate(box(7.8, 5.3, 7.6), 4, 2.95, 0);\nscene.add(home_b, {material: \"wood\", color: [0.72, 0.58, 0.44]});\nconst porch_a = translate(box(2.2, 2.5, 1.2), -6, 1.55, -4.7);\nscene.add(porch_a, {material: \"wood\", color: [0.65, 0.50, 0.33]});\nconst porch_b = translate(box(2.2, 2.5, 1.2), 6, 1.55, -4.7);\nscene.add(porch_b, {material: \"wood\", color: [0.65, 0.50, 0.33]});\nconst roof_left = translate(rotate(box(16.5, 0.08, 4.8), 0.52, 0, 0), 0, 6.5, -2);\nscene.add(roof_left, {material: \"metal\", color: [0.22, 0.24, 0.25]});",
+    "bom_suggestion": [
+      { "material_id": "pine_48x148_c24", "quantity": 74, "unit": "jm" },
+      { "material_id": "pine_48x98_c24", "quantity": 50, "unit": "jm" },
+      { "material_id": "osb_11mm", "quantity": 42, "unit": "m2" },
+      { "material_id": "mineral_wool_150", "quantity": 92, "unit": "m2" },
+      { "material_id": "metal_roof_ruukki", "quantity": 68, "unit": "m2" },
+      { "material_id": "vapor_barrier", "quantity": 106, "unit": "m2" }
+    ]
+  },
+  {
+    "address": "Rajamaentie 12, 05200 Rajamaki",
+    "coordinates": { "lat": 60.7388, "lon": 24.7594 },
+    "building_info": {
+      "type": "omakotitalo",
+      "year_built": 1992,
+      "material": "hirsi",
+      "floors": 2,
+      "area_m2": 148,
+      "heating": "sahko",
+      "roof_type": "harjakatto",
+      "roof_material": "pelti"
+    },
+    "scene_js": "// Rajamaentie 12 - log house north of the metro area\nconst base = translate(box(12, 0.35, 10), 0, 0.18, 0);\nscene.add(base, {material: \"concrete\", color: [0.55, 0.55, 0.52]});\nconst log_body = translate(box(12, 5.4, 10), 0, 3.05, 0);\nscene.add(log_body, {material: \"wood\", color: [0.62, 0.42, 0.25]});\nconst loft = translate(box(8, 2.6, 7), 0, 7.05, 0);\nscene.add(loft, {material: \"wood\", color: [0.68, 0.48, 0.30]});\nconst veranda = translate(box(9, 0.22, 2.2), 0, 0.55, -6.1);\nscene.add(veranda, {material: \"wood\", color: [0.50, 0.34, 0.20]});\nconst roof_left = translate(rotate(box(12.8, 0.1, 6.2), 0.56, 0, 0), 0, 8.3, -2.5);\nscene.add(roof_left, {material: \"metal\", color: [0.18, 0.20, 0.21]});\nconst roof_right = translate(rotate(box(12.8, 0.1, 6.2), -0.56, 0, 0), 0, 8.3, 2.5);\nscene.add(roof_right, {material: \"metal\", color: [0.18, 0.20, 0.21]});",
+    "bom_suggestion": [
+      { "material_id": "pine_48x148_c24", "quantity": 110, "unit": "jm" },
+      { "material_id": "pressure_treated_48x148", "quantity": 44, "unit": "jm" },
+      { "material_id": "mineral_wool_150", "quantity": 86, "unit": "m2" },
+      { "material_id": "metal_roof_ruukki", "quantity": 84, "unit": "m2" },
+      { "material_id": "exterior_paint_red", "quantity": 24, "unit": "l" },
+      { "material_id": "wood_screw_5x80", "quantity": 1300, "unit": "kpl" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- load every JSON demo data file dynamically, including collection files with multiple buildings
- add 10 curated Helsinki metro demo buildings across Helsinki, Espoo, Vantaa, and Rajamaki, bringing verified demo coverage to 12 addresses
- tighten demo address matching by street + house number, normalize Finnish diacritics, and diversify generic fallback models by postal/street pattern

## Verification
- node -e "JSON.parse(require('fs').readFileSync('data/demo/helsinki-metro-curated.json','utf8')); console.log('json ok')"
- npm test -- --run src/__tests__/building.test.ts
- npm run build
- npm test
- git diff --check

Closes #95.