### PR TITLE
feat(sound): wire exportDone and cameraSnap ambient sounds (Fixes #262)

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -897,6 +897,7 @@ export default function ProjectPage() {
       track("bom_exported", { format: "pdf" });
       await api.exportPdf(projectId, projectName, locale);
       toast(t("toast.bomExported"), "success");
+      playSound("exportDone");
     } catch (err) {
       toast(err instanceof Error ? err.message : t("toast.bomExportFailed"), "error");
     } finally {
@@ -921,6 +922,7 @@ export default function ProjectPage() {
         manualChecklist: araChecklistItems,
       });
       toast(locale === "fi" ? "ARA-avustuspaketti viety" : "ARA grant package exported", "success");
+      playSound("exportDone");
     } catch (err) {
       toast(err instanceof Error ? err.message : t("toast.bomExportFailed"), "error");
     } finally {
@@ -935,6 +937,7 @@ export default function ProjectPage() {
       track("project_exported", { format: "ifc4x3_permit" });
       await api.exportIFC(projectId, projectName);
       toast(t("ifcExport.generated"), "success");
+      playSound("exportDone");
     } catch (err) {
       toast(err instanceof Error ? err.message : t("ifcExport.generateFailed"), "error");
     } finally {
@@ -1082,6 +1085,7 @@ export default function ProjectPage() {
             a.click();
             URL.revokeObjectURL(url);
             toast(t("toast.projectExported"), "success");
+            playSound("exportDone");
           } catch (err) {
             toast(err instanceof Error ? err.message : t("toast.projectExportFailed"), "error");
           }
@@ -1846,6 +1850,7 @@ export default function ProjectPage() {
                       track("bom_exported", { format: "csv" });
                       await api.exportBOMCsv(projectId, projectName);
                       toast(t('toast.bomExported'), "success");
+                      playSound("exportDone");
                     } catch (err) {
                       toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
                     } finally {
@@ -1886,6 +1891,7 @@ export default function ProjectPage() {
                       a.click();
                       URL.revokeObjectURL(url);
                       toast(t('toast.bomExported'), "success");
+                      playSound("exportDone");
                     } catch (err) {
                       toast(err instanceof Error ? err.message : t('toast.bomExportFailed'), "error");
                     } finally {
@@ -1942,6 +1948,7 @@ export default function ProjectPage() {
                       a.click();
                       URL.revokeObjectURL(url);
                       toast(t('toast.projectExported'), "success");
+                      playSound("exportDone");
                     } catch (err) {
                       toast(err instanceof Error ? err.message : t('toast.projectExportFailed'), "error");
                     }

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -10,6 +10,7 @@ import ViewportContextMenu, { type ContextMenuItem } from "@/components/Viewport
 import ScreenshotPopover from "@/components/ScreenshotPopover";
 import { shortcutLabel } from "@/lib/shortcut-label";
 import { getPresentationPreset, type PresentationPresetId } from "@/lib/presentation-export";
+import { useAmbientSound } from "@/hooks/useAmbientSound";
 
 export interface ViewportPresentationApi {
   captureFrame: (options?: {
@@ -292,6 +293,7 @@ function CameraToolbar({
   onCycleMeasurementUnit: () => void;
 }) {
   const { t } = useTranslation();
+  const { play: playSfx } = useAmbientSound();
   const [activePreset, setActivePreset] = useState(3);
   const [screenshotDataUrl, setScreenshotDataUrl] = useState<string | null>(null);
 
@@ -303,8 +305,9 @@ function CameraToolbar({
       setActivePreset(index);
       const presets = computePresets(sceneBoundsRef.current);
       animateCamera(camera, controls, presets[index].position, presets[index].target);
+      playSfx("cameraSnap");
     },
-    [cameraRef, controlsRef, sceneBoundsRef]
+    [cameraRef, controlsRef, sceneBoundsRef, playSfx]
   );
 
   const handleScreenshot = useCallback(() => {


### PR DESCRIPTION
## Summary
- Wires `exportDone` sound to all 6 export success paths (PDF, CSV, JSON, IFC, ARA grant package, project export)
- Wires `cameraSnap` sound to viewport camera preset clicks
- Both sounds were already synthesized in `sounds.ts` but not connected to UI events

## Test plan
- [x] Type-check passes (`tsc --noEmit`)
- [x] All 11 ambient-sound tests pass
- [ ] Manual: enable sound in Settings, verify audio on export and camera snap

Fixes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)