### PR TITLE
fix(test): correct localStorage key in preferences E2E test (Fixes #279)

### DIFF
--- a/e2e/tests/preferences.spec.ts
+++ b/e2e/tests/preferences.spec.ts
@@ -20,7 +20,7 @@ test.describe("Theme toggle persistence", () => {
       expect(toggledTheme).not.toBe(initialTheme);
 
       const storedTheme = await page.evaluate(() =>
-        localStorage.getItem("helscoop_theme")
+        localStorage.getItem("helscoop-theme")
       );
       expect(storedTheme).toBeTruthy();
 


### PR DESCRIPTION
## Summary
- Fixes localStorage key in preferences E2E test: `helscoop_theme` (underscore) → `helscoop-theme` (hyphen)
- The ThemeProvider uses `helscoop-theme` as the storage key, so the test assertion was checking the wrong key

## Test plan
- [x] Key matches `ThemeProvider.tsx` `STORAGE_KEY = "helscoop-theme"`

Fixes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)