### PR TITLE
feat(landing): interactive 3D house preview in hero

### DIFF
--- a/web/src/components/HeroViewport.tsx
+++ b/web/src/components/HeroViewport.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+
+function buildHouseGeometry(): THREE.Group {
+  const group = new THREE.Group();
+  const mat = new THREE.MeshStandardMaterial({
+    color: 0xd4a574,
+    roughness: 0.85,
+    metalness: 0.05,
+  });
+  const roofMat = new THREE.MeshStandardMaterial({
+    color: 0x8b4513,
+    roughness: 0.7,
+    metalness: 0.1,
+  });
+  const glassMat = new THREE.MeshStandardMaterial({
+    color: 0x87ceeb,
+    roughness: 0.1,
+    metalness: 0.3,
+    transparent: true,
+    opacity: 0.6,
+  });
+
+  const body = new THREE.Mesh(new THREE.BoxGeometry(10, 5, 8), mat);
+  body.position.set(0, 2.5, 0);
+  group.add(body);
+
+  const roofGeo = new THREE.ConeGeometry(7.5, 3.5, 4);
+  const roof = new THREE.Mesh(roofGeo, roofMat);
+  roof.position.set(0, 6.75, 0);
+  roof.rotation.y = Math.PI / 4;
+  group.add(roof);
+
+  const doorGeo = new THREE.BoxGeometry(1.2, 2.4, 0.3);
+  const doorMat = new THREE.MeshStandardMaterial({ color: 0x5c3a1e, roughness: 0.9 });
+  const door = new THREE.Mesh(doorGeo, doorMat);
+  door.position.set(0, 1.2, 4.15);
+  group.add(door);
+
+  const winGeo = new THREE.BoxGeometry(1.4, 1.2, 0.15);
+  const winL = new THREE.Mesh(winGeo, glassMat);
+  winL.position.set(-3, 3.1, 4.05);
+  group.add(winL);
+  const winR = new THREE.Mesh(winGeo, glassMat);
+  winR.position.set(3, 3.1, 4.05);
+  group.add(winR);
+
+  const chimneyGeo = new THREE.BoxGeometry(1, 2.5, 1);
+  const chimney = new THREE.Mesh(chimneyGeo, mat.clone());
+  chimney.material.color.set(0xb8b8b8);
+  chimney.position.set(3, 7.25, -1);
+  group.add(chimney);
+
+  return group;
+}
+
+export default function HeroViewport() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scene = new THREE.Scene();
+
+    const camera = new THREE.PerspectiveCamera(35, container.clientWidth / container.clientHeight, 0.1, 200);
+    camera.position.set(18, 12, 18);
+    camera.lookAt(0, 3, 0);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(container.clientWidth, container.clientHeight);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 0.9;
+    container.appendChild(renderer.domElement);
+
+    const ambientLight = new THREE.AmbientLight(0xfff5e6, 0.6);
+    scene.add(ambientLight);
+
+    const dirLight = new THREE.DirectionalLight(0xfff0db, 1.2);
+    dirLight.position.set(10, 15, 8);
+    dirLight.castShadow = false;
+    scene.add(dirLight);
+
+    const rimLight = new THREE.PointLight(0xe5a04b, 0.4, 50);
+    rimLight.position.set(-8, 6, -8);
+    scene.add(rimLight);
+
+    const house = buildHouseGeometry();
+    scene.add(house);
+
+    const radius = 24;
+    let angle = 0;
+    let frameId = 0;
+
+    const reducedMotion = typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    const speed = reducedMotion ? 0 : 0.003;
+
+    function animate() {
+      angle += speed;
+      camera.position.x = Math.cos(angle) * radius;
+      camera.position.z = Math.sin(angle) * radius;
+      camera.position.y = 12;
+      camera.lookAt(0, 3, 0);
+      renderer.render(scene, camera);
+      frameId = requestAnimationFrame(animate);
+    }
+    animate();
+
+    setVisible(true);
+
+    const handleResize = () => {
+      if (!container) return;
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+      renderer.setSize(w, h);
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      cancelAnimationFrame(frameId);
+      renderer.dispose();
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        width: "100%",
+        height: 200,
+        borderRadius: "var(--radius-lg)",
+        overflow: "hidden",
+        border: "1px solid rgba(229,160,75,0.15)",
+        boxShadow: "0 0 32px rgba(229,160,75,0.06)",
+        background: "transparent",
+        opacity: visible ? 1 : 0,
+        transition: "opacity 0.6s ease",
+        pointerEvents: "none",
+      }}
+      aria-hidden="true"
+    />
+  );
+}

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, type ReactNode } from "react";
+import dynamic from "next/dynamic";
 import { api, setToken } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
 import { useAnalytics } from "@/hooks/useAnalytics";
@@ -10,6 +11,18 @@ import HeroIllustration from "@/components/HeroIllustration";
 import TrustLayer from "@/components/TrustLayer";
 import ScrollReveal from "@/components/ScrollReveal";
 import type { BuildingResult } from "@/types";
+
+const HeroViewport = dynamic(() => import("@/components/HeroViewport"), {
+  ssr: false,
+  loading: () => (
+    <div style={{
+      width: "100%",
+      height: 200,
+      borderRadius: "var(--radius-lg)",
+      background: "var(--bg-secondary)",
+    }} />
+  ),
+});
 
 type GoogleIdentity = {
   accounts: {
@@ -212,6 +225,12 @@ export default function LoginForm({
               </div>
             </ScrollReveal>
           )}
+
+          <ScrollReveal delay={0.15}>
+            <div style={{ marginBottom: 28 }}>
+              <HeroViewport />
+            </div>
+          </ScrollReveal>
 
           <div style={{ display: "flex", flexDirection: "column", marginBottom: 36 }}>
             {features.map((item, i) => (


### PR DESCRIPTION
## Summary
- Adds a lightweight auto-rotating 3D house model to the login/landing page hero section
- Uses standalone Three.js geometry (no manifold worker dependency) for fast loading
- Dynamically imported with Next.js `dynamic()` for code splitting
- Respects `prefers-reduced-motion` (disables rotation)
- Decorative only (`aria-hidden`, `pointerEvents: none`)

Fixes #215

## Test plan
- [ ] Visit the login page — 3D house model should appear between address search and features
- [ ] House should slowly auto-rotate with warm amber-tinted lighting
- [ ] Verify no interaction (click/drag) on the preview — it's view-only
- [ ] Check that the page loads without delay (Three.js is lazy-loaded)
- [ ] Enable reduced motion in OS settings — rotation should stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)