### PR TITLE
style(editor): per-surface noise texture layers for panel depth

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -509,13 +509,17 @@ body::before {
 }
 
 /* Disable noise overlay in light theme */
-[data-theme="light"] body::before {
+[data-theme="light"] body::before,
+[data-theme="light"] .scene-params-panel::before,
+[data-theme="light"] .editor-bom-panel::before {
   display: none;
 }
 
 /* Disable noise overlay for users who prefer reduced motion/effects */
 @media (prefers-reduced-motion: reduce) {
-  body::before {
+  body::before,
+  .scene-params-panel::before,
+  .editor-bom-panel::before {
     display: none;
   }
 }
@@ -561,6 +565,7 @@ body::before {
   height: 100%;
   display: flex;
   flex-direction: column;
+  position: relative;
   background: var(--glass-ground);
   backdrop-filter: var(--glass-ground-blur);
   -webkit-backdrop-filter: var(--glass-ground-blur);
@@ -568,6 +573,17 @@ body::before {
   box-shadow: var(--shadow-depth-1), inset 0 1px 2px rgba(255,255,255,0.02);
   overflow: hidden;
   transition: background var(--transition-normal);
+}
+
+.scene-params-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.025;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n2'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n2)'/%3E%3C/svg%3E");
+  border-radius: inherit;
 }
 
 .scene-params-panel:focus-within {
@@ -3003,12 +3019,24 @@ select:focus {
   border-left: 1px solid var(--glass-mid-border);
   display: flex;
   flex-direction: column;
+  position: relative;
   background: var(--glass-mid);
   backdrop-filter: var(--glass-mid-blur);
   -webkit-backdrop-filter: var(--glass-mid-blur);
   box-shadow: var(--shadow-depth-2), inset 0 1px 2px rgba(255,255,255,0.02);
   flex-shrink: 0;
   transition: background var(--transition-normal);
+}
+
+.editor-bom-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.02;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n3'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n3)'/%3E%3C/svg%3E");
+  border-radius: inherit;
 }
 
 .editor-bom-panel:focus-within {


### PR DESCRIPTION
## Summary
- Adds per-surface SVG `feTurbulence` noise overlays to the scene params panel and BOM panel
- Uses different `baseFrequency` per panel (0.75 vs 0.85) to create subtle material differentiation
- Panels now have `position: relative` for the `::before` pseudo-element
- Noise layers suppressed in light theme and `prefers-reduced-motion`

Partially addresses #674 — the remaining items (resize handles, focus-within inset, viewport gradient mesh) were already implemented.

## Test plan
- [ ] Open the editor in dark theme — panels should have subtle grain texture
- [ ] Compare params panel grain vs BOM panel grain — slightly different density
- [ ] Switch to light theme — noise overlays should disappear
- [ ] Enable reduced motion in OS — noise overlays should disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)