### PR TITLE
feat(editor): sticky price summary bar with real-time BOM total

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -2954,6 +2954,46 @@ select:focus {
   background: var(--bg-base);
 }
 
+.price-summary-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+  padding: 0 16px;
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+  background: var(--bg-tertiary);
+}
+
+.price-delta-badge {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  animation: priceDeltaFade 1.5s ease forwards;
+}
+
+@keyframes priceDeltaFade {
+  0% { opacity: 1; transform: translateY(0); }
+  70% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-6px); }
+}
+
+.price-summary-link {
+  background: none;
+  border: none;
+  color: var(--amber);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  transition: background var(--transition-fast);
+}
+
+.price-summary-link:hover {
+  background: rgba(229, 160, 75, 0.08);
+}
+
 .resize-handle-v {
   /* Visible hit-zone: 5px wide, touch pseudo-element expands to 44px (WCAG 2.5.5) */
   width: 5px;

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -46,6 +46,7 @@ import type { Material, BomItem, Project, ProjectVersionSnapshot } from "@/types
 import type { ViewportMaterialSelection, ViewportPresentationApi } from "@/components/Viewport3D";
 import { shortcutLabel } from "@/lib/shortcut-label";
 import ConfidenceBadge from "@/components/ConfidenceBadge";
+import PriceSummaryBar from "@/components/PriceSummaryBar";
 import type { DataProvenance } from "@/lib/confidence";
 
 /** Parse a validation warning key like "validation.typoDetected:scene" into
@@ -2447,6 +2448,13 @@ export default function ProjectPage() {
             buildingInfo={project?.building_info ?? undefined}
             renovationRoiSummary={renovationRoi?.summary}
             onMessageCountChange={setChatMessageCount}
+          />
+          <PriceSummaryBar
+            bom={bom}
+            onViewBom={showBom ? undefined : () => {
+              const el = document.querySelector(".editor-bom-panel");
+              if (el) el.scrollIntoView({ behavior: "smooth" });
+            }}
           />
         </div>
 

--- a/web/src/components/PriceSummaryBar.tsx
+++ b/web/src/components/PriceSummaryBar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import type { BomItem } from "@/types";
+
+interface PriceSummaryBarProps {
+  bom: BomItem[];
+  onViewBom?: () => void;
+}
+
+export default function PriceSummaryBar({ bom, onViewBom }: PriceSummaryBarProps) {
+  const { t, locale } = useTranslation();
+  const total = bom.reduce((sum, item) => sum + (item.total || (item.unit_price || 0) * item.quantity), 0);
+  const prevTotalRef = useRef(total);
+  const [delta, setDelta] = useState<number | null>(null);
+  const [flash, setFlash] = useState(false);
+
+  useEffect(() => {
+    const prev = prevTotalRef.current;
+    if (prev !== total && prev > 0) {
+      setDelta(total - prev);
+      setFlash(true);
+      const timer = setTimeout(() => {
+        setDelta(null);
+        setFlash(false);
+      }, 1500);
+      prevTotalRef.current = total;
+      return () => clearTimeout(timer);
+    }
+    prevTotalRef.current = total;
+  }, [total]);
+
+  if (bom.length === 0) return null;
+
+  const fmtLocale = locale === "fi" ? "fi-FI" : "en-GB";
+
+  return (
+    <div className="price-summary-bar">
+      <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+        <span style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 15,
+          fontWeight: 600,
+          color: flash ? "var(--amber)" : "var(--text-primary)",
+          transition: "color 0.3s ease",
+        }}>
+          {total.toLocaleString(fmtLocale, { maximumFractionDigits: 0 })}
+          <span style={{ fontSize: 12, color: "var(--text-muted)", marginLeft: 4, fontWeight: 400 }}>EUR</span>
+        </span>
+        {delta !== null && (
+          <span
+            className="price-delta-badge"
+            style={{
+              color: delta < 0 ? "var(--success)" : "var(--amber)",
+            }}
+          >
+            {delta > 0 ? "+" : ""}{delta.toLocaleString(fmtLocale, { maximumFractionDigits: 0 })}
+          </span>
+        )}
+        <span style={{
+          fontSize: 11,
+          color: "var(--text-muted)",
+          fontFamily: "var(--font-mono)",
+        }}>
+          {bom.length} {locale === "fi" ? "kpl" : "items"}
+        </span>
+      </div>
+      {onViewBom && (
+        <button
+          className="price-summary-link"
+          onClick={onViewBom}
+        >
+          {t("editor.viewBom")} →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -345,6 +345,7 @@ const translations = {
       toBuy: 'Osta',
       paramSliderLabel: '{{name}} — liukusäädin',
       computing: 'Laskee\u2026',
+      viewBom: 'Näytä materiaaliluettelo',
     },
     share: {
       title: 'Jaa projekti',
@@ -1720,6 +1721,7 @@ const translations = {
       toBuy: 'Buy',
       paramSliderLabel: '{{name}} slider',
       computing: 'Computing\u2026',
+      viewBom: 'View BOM',
     },
     share: {
       title: 'Share project',


### PR DESCRIPTION
## Summary
- Adds a 40px sticky bar at the bottom of the viewport area showing estimated BOM total
- Price changes trigger an amber flash and floating delta badge (+/- animation)
- Shows item count and a "View BOM" link (amber, mono font)
- Hidden when BOM is empty
- i18n strings added for Finnish and English

Fixes #157

## Test plan
- [ ] Open a project with BOM items — price bar should appear at bottom of viewport
- [ ] Add/remove/change BOM items — total should update with amber flash + delta badge
- [ ] Click "View BOM" link — should scroll to BOM panel
- [ ] Empty BOM — bar should not render
- [ ] Check Finnish and English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)