### PR TITLE
feat: update BOM quantities from scene geometry

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -19,6 +19,12 @@ import SceneApiReference from "@/components/SceneApiReference";
 import SharePresentationPanel from "@/components/SharePresentationPanel";
 import ProjectVersionPanel from "@/components/ProjectVersionPanel";
 import { parseSceneParams, applyParamToScript } from "@/lib/scene-interpreter";
+import {
+  analyzeSceneGeometry,
+  suggestGeometryBomUpdates,
+  type GeometryBomSuggestion,
+  type SceneGeometryMetrics,
+} from "@/lib/scene-geometry-bom";
 import { replaceSceneMaterialReferences } from "@/lib/scene-materials";
 import type { BomImportMode } from "@/lib/bom-import";
 import { estimateRenovationRoi } from "@/lib/renovation-roi";
@@ -122,6 +128,14 @@ const MOBILE_EDITOR_QUERY = "(max-width: 768px)";
 type MobileEditorPanel = "viewport" | "chat" | "bom" | "code" | "params" | "docs";
 type MobilePanelSize = "normal" | "expanded" | "minimized";
 
+interface GeometryBomUpdateState {
+  sceneJs: string;
+  metrics: SceneGeometryMetrics;
+  previousMetrics: SceneGeometryMetrics | null;
+  suggestions: GeometryBomSuggestion[];
+  skippedManual: GeometryBomSuggestion[];
+}
+
 function getBomWidthBounds(): { min: number; max: number } {
   if (typeof window === "undefined") return { min: 260, max: 600 };
   const isTabletOrNarrow = window.innerWidth <= 1024;
@@ -200,6 +214,24 @@ function hydrateSnapshotBom(snapshot: ProjectVersionSnapshot, materials: Materia
   });
 }
 
+function formatGeometryNumber(value: number, unit: string, locale: string): string {
+  return `${value.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB", {
+    maximumFractionDigits: value >= 10 ? 1 : 2,
+  })} ${unit}`;
+}
+
+function formatGeometryMetricChange(update: GeometryBomUpdateState, locale: string): string {
+  const previous = update.previousMetrics;
+  if (!previous) {
+    return locale === "fi"
+      ? `Seinäalaa ${formatGeometryNumber(update.metrics.wallAreaM2, "m²", locale)}, kattoa ${formatGeometryNumber(update.metrics.roofAreaM2, "m²", locale)}`
+      : `Wall area ${formatGeometryNumber(update.metrics.wallAreaM2, "m²", locale)}, roof ${formatGeometryNumber(update.metrics.roofAreaM2, "m²", locale)}`;
+  }
+  return locale === "fi"
+    ? `Seinäala ${formatGeometryNumber(previous.wallAreaM2, "m²", locale)} → ${formatGeometryNumber(update.metrics.wallAreaM2, "m²", locale)}, katto ${formatGeometryNumber(previous.roofAreaM2, "m²", locale)} → ${formatGeometryNumber(update.metrics.roofAreaM2, "m²", locale)}`
+    : `Wall area ${formatGeometryNumber(previous.wallAreaM2, "m²", locale)} → ${formatGeometryNumber(update.metrics.wallAreaM2, "m²", locale)}, roof ${formatGeometryNumber(previous.roofAreaM2, "m²", locale)} → ${formatGeometryNumber(update.metrics.roofAreaM2, "m²", locale)}`;
+}
+
 export default function ProjectPage() {
   const params = useParams();
   const router = useRouter();
@@ -215,6 +247,8 @@ export default function ProjectPage() {
   const [project, setProject] = useState<Project | null>(null);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [bom, setBom] = useState<BomItem[]>([]);
+  const [manualBomOverrideIds, setManualBomOverrideIds] = useState<Set<string>>(() => new Set());
+  const [geometryBomUpdate, setGeometryBomUpdate] = useState<GeometryBomUpdateState | null>(null);
   const [surfacePickerMaterialId, setSurfacePickerMaterialId] = useState<string | null>(null);
   const [sceneJs, setSceneJs] = useState("");
   const [savedScript, setSavedScript] = useState("");
@@ -278,6 +312,8 @@ export default function ProjectPage() {
   const presentationRef = useRef<ViewportPresentationApi | null>(null);
   const resizingRef = useRef(false);
   const activeVersionBranchRef = useRef<string | null>(null);
+  const geometryBaselineRef = useRef<{ sceneJs: string; metrics: SceneGeometryMetrics } | null>(null);
+  const dismissedGeometrySceneRef = useRef<string | null>(null);
 
   const pushHistory = useCallback((code: string) => {
     const history = historyRef.current;
@@ -332,6 +368,8 @@ export default function ProjectPage() {
         const initialScene = proj.scene_js || DEFAULT_SCENE;
         setSceneJs(initialScene);
         setSavedScript(initialScene);
+        geometryBaselineRef.current = { sceneJs: initialScene, metrics: analyzeSceneGeometry(initialScene) };
+        dismissedGeometrySceneRef.current = null;
         historyRef.current = [initialScene];
         historyIndexRef.current = 0;
         setMaterials(mats);
@@ -342,6 +380,8 @@ export default function ProjectPage() {
             }))
           : [];
         setBom(initialBom);
+        setManualBomOverrideIds(new Set());
+        setGeometryBomUpdate(null);
         // Set the auto-save baseline to match what the server has
         setSavedSnapshot({
           name: proj.name,
@@ -610,6 +650,42 @@ export default function ProjectPage() {
     () => estimateRenovationRoi(bom, materials, project?.building_info ?? null, { coupleMode: householdDeductionJoint }),
     [bom, householdDeductionJoint, materials, project?.building_info],
   );
+  const manualOverrideKey = useMemo(
+    () => Array.from(manualBomOverrideIds).sort().join("|"),
+    [manualBomOverrideIds],
+  );
+
+  useEffect(() => {
+    if (!initialLoadDone) return;
+    if (dismissedGeometrySceneRef.current === sceneJs) return;
+
+    const timer = window.setTimeout(() => {
+      const baseline = geometryBaselineRef.current;
+      if (!baseline || baseline.sceneJs === sceneJs) {
+        if (!baseline) {
+          geometryBaselineRef.current = { sceneJs, metrics: analyzeSceneGeometry(sceneJs) };
+        }
+        return;
+      }
+
+      const result = suggestGeometryBomUpdates(sceneJs, bom, materials, manualBomOverrideIds);
+      if (result.suggestions.length === 0 && result.skippedManual.length === 0) {
+        geometryBaselineRef.current = { sceneJs, metrics: result.metrics };
+        setGeometryBomUpdate(null);
+        return;
+      }
+
+      setGeometryBomUpdate({
+        sceneJs,
+        metrics: result.metrics,
+        previousMetrics: baseline.metrics,
+        suggestions: result.suggestions,
+        skippedManual: result.skippedManual,
+      });
+    }, 1200);
+
+    return () => window.clearTimeout(timer);
+  }, [bom, initialLoadDone, manualBomOverrideIds, manualOverrideKey, materials, sceneJs]);
 
   const handleParamChange = useCallback(
     (name: string, value: number) => {
@@ -756,6 +832,13 @@ export default function ProjectPage() {
       setSceneJs(snapshot.scene_js || DEFAULT_SCENE);
       setSavedScript(snapshot.scene_js || DEFAULT_SCENE);
       setBom(restoredBom);
+      geometryBaselineRef.current = {
+        sceneJs: snapshot.scene_js || DEFAULT_SCENE,
+        metrics: analyzeSceneGeometry(snapshot.scene_js || DEFAULT_SCENE),
+      };
+      dismissedGeometrySceneRef.current = null;
+      setManualBomOverrideIds(new Set());
+      setGeometryBomUpdate(null);
       setProject((prev) => prev ? {
         ...prev,
         name: snapshot.name,
@@ -1541,6 +1624,61 @@ export default function ProjectPage() {
     [bom, t, toast, track],
   );
 
+  const dismissGeometryBomUpdate = useCallback(() => {
+    if (geometryBomUpdate) {
+      geometryBaselineRef.current = {
+        sceneJs: geometryBomUpdate.sceneJs,
+        metrics: geometryBomUpdate.metrics,
+      };
+      dismissedGeometrySceneRef.current = geometryBomUpdate.sceneJs;
+    }
+    setGeometryBomUpdate(null);
+  }, [geometryBomUpdate]);
+
+  const applyGeometryBomUpdate = useCallback((includeManualOverrides: boolean) => {
+    if (!geometryBomUpdate) return;
+    const selected = includeManualOverrides
+      ? [...geometryBomUpdate.suggestions, ...geometryBomUpdate.skippedManual]
+      : geometryBomUpdate.suggestions;
+    if (selected.length === 0) return;
+
+    const selectedById = new Map(selected.map((suggestion) => [suggestion.materialId, suggestion]));
+    setBom((prev) =>
+      prev.map((item) => {
+        const suggestion = selectedById.get(item.material_id);
+        if (!suggestion) return item;
+        return {
+          ...item,
+          quantity: suggestion.suggestedQuantity,
+          total: (item.unit_price || 0) * suggestion.suggestedQuantity,
+          manual_override: includeManualOverrides ? false : item.manual_override,
+          geometry_driven: true,
+        };
+      }),
+    );
+
+    if (includeManualOverrides) {
+      setManualBomOverrideIds((prev) => {
+        const next = new Set(prev);
+        for (const suggestion of selected) next.delete(suggestion.materialId);
+        return next;
+      });
+    }
+
+    geometryBaselineRef.current = {
+      sceneJs: geometryBomUpdate.sceneJs,
+      metrics: geometryBomUpdate.metrics,
+    };
+    dismissedGeometrySceneRef.current = null;
+    setGeometryBomUpdate(null);
+    toast(
+      locale === "fi"
+        ? `Päivitettiin ${selected.length} materiaalimäärää geometriasta`
+        : `Updated ${selected.length} material quantities from geometry`,
+      "success",
+    );
+  }, [geometryBomUpdate, locale, toast]);
+
   const removeBomItem = useCallback((materialId: string) => {
     let removedItem: BomItem | undefined;
     setBom((prev) => {
@@ -1567,10 +1705,11 @@ export default function ProjectPage() {
   }, [track, toast, t, playSound]);
 
   const updateBomQty = useCallback((materialId: string, qty: number) => {
+    setManualBomOverrideIds((prev) => new Set(prev).add(materialId));
     setBom((prev) =>
       prev.map((b) =>
         b.material_id === materialId
-          ? { ...b, quantity: qty, total: (b.unit_price || 0) * qty }
+          ? { ...b, quantity: qty, total: (b.unit_price || 0) * qty, manual_override: true, geometry_driven: false }
           : b
       )
     );
@@ -2550,6 +2689,107 @@ export default function ProjectPage() {
               if (el) el.scrollIntoView({ behavior: "smooth" });
             }}
           />
+          {geometryBomUpdate && (
+            <div
+              role="status"
+              aria-live="polite"
+              style={{
+                position: "absolute",
+                left: 18,
+                bottom: priceChangeSummary?.show ? 184 : 76,
+                zIndex: 12,
+                width: "min(520px, calc(100% - 36px))",
+                border: "1px solid var(--border-strong)",
+                borderRadius: 16,
+                padding: "14px 16px",
+                background: "color-mix(in srgb, var(--bg-elevated) 92%, transparent)",
+                color: "var(--text-primary)",
+                boxShadow: "0 22px 70px rgba(0,0,0,0.30)",
+                backdropFilter: "blur(16px)",
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+                <div>
+                  <div className="label-mono" style={{ color: "var(--amber)", marginBottom: 5 }}>
+                    {locale === "fi" ? "Geometria muutti materiaalimääriä" : "Geometry changed BOM quantities"}
+                  </div>
+                  <strong style={{ fontSize: 15 }}>
+                    {locale === "fi"
+                      ? `${geometryBomUpdate.suggestions.length} päivitysehdotusta`
+                      : `${geometryBomUpdate.suggestions.length} update suggestion${geometryBomUpdate.suggestions.length === 1 ? "" : "s"}`}
+                  </strong>
+                  <div style={{ marginTop: 5, color: "var(--text-secondary)", fontSize: 12, lineHeight: 1.45 }}>
+                    {formatGeometryMetricChange(geometryBomUpdate, locale)}
+                  </div>
+                </div>
+                <button
+                  className="btn btn-ghost"
+                  onClick={dismissGeometryBomUpdate}
+                  aria-label={locale === "fi" ? "Sulje geometriapäivitys" : "Dismiss geometry update"}
+                  style={{ padding: "4px 7px", border: "none" }}
+                >
+                  ×
+                </button>
+              </div>
+
+              <div style={{ display: "grid", gap: 6, marginTop: 12 }}>
+                {[...geometryBomUpdate.suggestions, ...geometryBomUpdate.skippedManual].slice(0, 4).map((suggestion) => (
+                  <div
+                    key={suggestion.materialId}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr auto",
+                      gap: 10,
+                      padding: "8px 10px",
+                      borderRadius: 10,
+                      background: "var(--bg-secondary)",
+                      border: "1px solid var(--border)",
+                      fontSize: 12,
+                    }}
+                  >
+                    <div>
+                      <strong>{suggestion.materialName}</strong>
+                      {manualBomOverrideIds.has(suggestion.materialId) && (
+                        <span style={{ color: "var(--amber)", marginLeft: 8 }}>
+                          {locale === "fi" ? "manuaalinen" : "manual"}
+                        </span>
+                      )}
+                      <div style={{ color: "var(--text-muted)", marginTop: 2 }}>{suggestion.reason}</div>
+                    </div>
+                    <div style={{ textAlign: "right", whiteSpace: "nowrap" }}>
+                      {formatGeometryNumber(suggestion.currentQuantity, suggestion.unit, locale)}
+                      {" -> "}
+                      <strong>{formatGeometryNumber(suggestion.suggestedQuantity, suggestion.unit, locale)}</strong>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {geometryBomUpdate.skippedManual.length > 0 && (
+                <div style={{ marginTop: 10, color: "var(--text-muted)", fontSize: 12 }}>
+                  {locale === "fi"
+                    ? `${geometryBomUpdate.skippedManual.length} manuaalisesti muokattua riviä jätetään ennalleen, ellet valitse uudelleenlaskentaa.`
+                    : `${geometryBomUpdate.skippedManual.length} manually edited row${geometryBomUpdate.skippedManual.length === 1 ? "" : "s"} will stay unchanged unless you recalculate all.`}
+                </div>
+              )}
+
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end", flexWrap: "wrap", marginTop: 14 }}>
+                <button className="btn btn-ghost" onClick={dismissGeometryBomUpdate} style={{ padding: "7px 11px", fontSize: 12 }}>
+                  {locale === "fi" ? "Pidä nykyiset" : "Keep current"}
+                </button>
+                {geometryBomUpdate.suggestions.length > 0 && (
+                  <button className="btn btn-primary" onClick={() => applyGeometryBomUpdate(false)} style={{ padding: "7px 11px", fontSize: 12 }}>
+                    {locale === "fi" ? "Päivitä ehdotetut" : "Update suggested"}
+                  </button>
+                )}
+                {geometryBomUpdate.skippedManual.length > 0 && (
+                  <button className="btn btn-secondary" onClick={() => applyGeometryBomUpdate(true)} style={{ padding: "7px 11px", fontSize: 12 }}>
+                    {locale === "fi" ? "Laske kaikki uudelleen" : "Recalculate all"}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
           {priceChangeSummary?.show && (
             <div
               role="status"

--- a/web/src/lib/__tests__/scene-geometry-bom.test.ts
+++ b/web/src/lib/__tests__/scene-geometry-bom.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeSceneGeometry,
+  parseSceneGeometryBoxes,
+  suggestGeometryBomUpdates,
+} from "../scene-geometry-bom";
+import type { BomItem, Material } from "@/types";
+
+function material(id: string, name: string, category = "Lumber", tags: string[] = []): Material {
+  return {
+    id,
+    name,
+    name_fi: null,
+    name_en: null,
+    category_name: category,
+    category_name_fi: null,
+    image_url: null,
+    pricing: null,
+    tags,
+  };
+}
+
+const baseScene = `
+const floor = box(4, 0.2, 3);
+const wall_back = translate(box(4, 2.4, 0.12), 0, 1.3, -1.44);
+const wall_front = translate(box(4, 2.4, 0.12), 0, 1.3, 1.44);
+const wall_left = translate(box(0.12, 2.4, 3), -1.94, 1.3, 0);
+const wall_right = translate(box(0.12, 2.4, 3), 1.94, 1.3, 0);
+const roof = translate(rotate(box(4.5, 0.08, 3.5), 0, 0, 0.2), 0, 2.8, 0);
+const door = translate(box(0.9, 2.0, 0.12), 0, 1.0, 1.44);
+scene.add(floor, { material: "foundation" });
+scene.add(wall_back, { material: "lumber" });
+scene.add(wall_front, { material: "lumber" });
+scene.add(wall_left, { material: "lumber" });
+scene.add(wall_right, { material: "lumber" });
+scene.add(roof, { material: "roofing" });
+scene.add(door, { material: "door" });
+`;
+
+describe("scene geometry BOM analyzer", () => {
+  it("extracts box geometry from scene.add calls", () => {
+    const boxes = parseSceneGeometryBoxes(baseScene);
+
+    expect(boxes).toHaveLength(7);
+    expect(boxes.find((box) => box.name === "roof")?.type).toBe("roof");
+    expect(boxes.find((box) => box.name === "door")?.type).toBe("opening");
+  });
+
+  it("calculates floor, roof, wall, and opening metrics", () => {
+    const metrics = analyzeSceneGeometry(baseScene);
+
+    expect(metrics.floorAreaM2).toBeCloseTo(12, 1);
+    expect(metrics.roofAreaM2).toBeCloseTo(15.8, 1);
+    expect(metrics.wallAreaM2).toBeGreaterThan(30);
+    expect(metrics.openingCount).toBe(1);
+    expect(metrics.wallPerimeterM).toBeGreaterThan(13);
+  });
+
+  it("suggests material quantity updates from geometry", () => {
+    const bom: BomItem[] = [
+      { material_id: "insulation_100mm", material_name: "Insulation", quantity: 8, unit: "m2", unit_price: 5, total: 40 },
+      { material_id: "pine_48x148_c24", material_name: "48x148 C24", quantity: 20, unit: "jm", unit_price: 3, total: 60 },
+      { material_id: "galvanized_roofing", material_name: "Roofing", quantity: 6, unit: "m2", unit_price: 9, total: 54 },
+    ];
+    const materials = [
+      material("insulation_100mm", "Mineraalivilla 100mm", "Insulation", ["insulation"]),
+      material("pine_48x148_c24", "48x148 Runkopuu C24", "Lumber", ["structural"]),
+      material("galvanized_roofing", "Peltikatto", "Roofing", ["roofing"]),
+    ];
+
+    const result = suggestGeometryBomUpdates(baseScene, bom, materials);
+
+    expect(result.suggestions.map((suggestion) => suggestion.materialId)).toEqual(
+      expect.arrayContaining(["insulation_100mm", "pine_48x148_c24", "galvanized_roofing"]),
+    );
+    expect(result.suggestions.find((suggestion) => suggestion.materialId === "insulation_100mm")?.suggestedQuantity)
+      .toBeGreaterThan(30);
+  });
+
+  it("preserves manual overrides by moving them to skippedManual", () => {
+    const bom: BomItem[] = [
+      { material_id: "insulation_100mm", material_name: "Insulation", quantity: 8, unit: "m2" },
+      { material_id: "galvanized_roofing", material_name: "Roofing", quantity: 6, unit: "m2" },
+    ];
+    const materials = [
+      material("insulation_100mm", "Mineraalivilla 100mm", "Insulation", ["insulation"]),
+      material("galvanized_roofing", "Peltikatto", "Roofing", ["roofing"]),
+    ];
+
+    const result = suggestGeometryBomUpdates(baseScene, bom, materials, new Set(["insulation_100mm"]));
+
+    expect(result.suggestions.map((suggestion) => suggestion.materialId)).toContain("galvanized_roofing");
+    expect(result.suggestions.map((suggestion) => suggestion.materialId)).not.toContain("insulation_100mm");
+    expect(result.skippedManual.map((suggestion) => suggestion.materialId)).toContain("insulation_100mm");
+  });
+
+  it("keeps quantity units compatible for kpl foundation materials", () => {
+    const bom: BomItem[] = [
+      { material_id: "concrete_block", material_name: "Betoniharkko", quantity: 4, unit: "kpl" },
+    ];
+    const materials = [material("concrete_block", "Betoniharkko 200mm", "Masonry", ["foundation"])];
+
+    const result = suggestGeometryBomUpdates(baseScene, bom, materials);
+
+    expect(result.suggestions[0]?.materialId).toBe("concrete_block");
+    expect(result.suggestions[0]?.unit).toBe("kpl");
+  });
+});

--- a/web/src/lib/scene-geometry-bom.ts
+++ b/web/src/lib/scene-geometry-bom.ts
@@ -1,0 +1,374 @@
+import type { BomItem, Material } from "@/types";
+
+export interface SceneGeometryBox {
+  name: string;
+  material?: string;
+  type: "wall" | "floor" | "roof" | "opening" | "generic";
+  dimensions: { x: number; y: number; z: number };
+  position: { x: number; y: number; z: number };
+}
+
+export interface SceneGeometryMetrics {
+  wallAreaM2: number;
+  floorAreaM2: number;
+  roofAreaM2: number;
+  wallPerimeterM: number;
+  openingCount: number;
+  openingAreaM2: number;
+  objectCount: number;
+  bounds: {
+    widthM: number;
+    depthM: number;
+    heightM: number;
+  };
+}
+
+export interface GeometryBomSuggestion {
+  materialId: string;
+  materialName: string;
+  unit: string;
+  currentQuantity: number;
+  suggestedQuantity: number;
+  delta: number;
+  percentChange: number;
+  reason: string;
+  metric: keyof Pick<SceneGeometryMetrics, "wallAreaM2" | "floorAreaM2" | "roofAreaM2" | "wallPerimeterM" | "openingCount">;
+}
+
+export interface GeometryBomSuggestionResult {
+  metrics: SceneGeometryMetrics;
+  suggestions: GeometryBomSuggestion[];
+  skippedManual: GeometryBomSuggestion[];
+}
+
+const MIN_DELTA = 0.25;
+const MIN_PERCENT_CHANGE = 0.05;
+const MAX_REASONABLE_METERS = 80;
+
+function cleanNumber(value: string | undefined): number | null {
+  if (!value) return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function maybeMeters(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.abs(value) > MAX_REASONABLE_METERS ? value / 1000 : value;
+}
+
+function roundQuantity(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  if (value >= 100) return Math.round(value);
+  if (value >= 10) return Math.round(value * 10) / 10;
+  return Math.round(value * 100) / 100;
+}
+
+function normalizeText(value: string | undefined | null): string {
+  return (value || "").toLowerCase();
+}
+
+function normalizeUnit(value: string): string {
+  const unit = value.toLowerCase().replace("²", "2");
+  if (["m2", "sqm", "sq m"].includes(unit)) return "m2";
+  if (["jm", "m", "meter", "metre"].includes(unit)) return "jm";
+  if (["kpl", "pcs", "pc", "piece", "pieces"].includes(unit)) return "kpl";
+  return unit;
+}
+
+function classifyBox(name: string, material?: string): SceneGeometryBox["type"] {
+  const haystack = `${name} ${material || ""}`.toLowerCase();
+  if (/window|ikkuna|door|ovi|gate|portti|opening/.test(haystack)) return "opening";
+  if (/roof|katto|kate|galvanized_roofing|roofing/.test(haystack)) return "roof";
+  if (/floor|slab|deck|lattia|laatta|foundation|perustus/.test(haystack)) return "floor";
+  if (/wall|sein|stud|runko|cladding/.test(haystack)) return "wall";
+  return "generic";
+}
+
+function parseBoxAssignments(sceneJs: string) {
+  const assignments = new Map<string, {
+    dimensions: { x: number; y: number; z: number };
+    position: { x: number; y: number; z: number };
+  }>();
+
+  for (const rawLine of sceneJs.split("\n")) {
+    const line = rawLine.trim();
+    const translated = line.match(
+      /const\s+(\w+)\s*=\s*translate\s*\((?:rotate\s*\()?box\s*\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)(?:\s*,\s*[\d.,\s-]+\s*\))?\s*,\s*([\d.-]+)\s*,\s*([\d.-]+)\s*,\s*([\d.-]+)\s*\)/
+    );
+    if (translated) {
+      assignments.set(translated[1], {
+        dimensions: {
+          x: maybeMeters(cleanNumber(translated[2]) ?? 0),
+          y: maybeMeters(cleanNumber(translated[3]) ?? 0),
+          z: maybeMeters(cleanNumber(translated[4]) ?? 0),
+        },
+        position: {
+          x: maybeMeters(cleanNumber(translated[5]) ?? 0),
+          y: maybeMeters(cleanNumber(translated[6]) ?? 0),
+          z: maybeMeters(cleanNumber(translated[7]) ?? 0),
+        },
+      });
+      continue;
+    }
+
+    const box = line.match(/const\s+(\w+)\s*=\s*box\s*\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*\)/);
+    if (box) {
+      assignments.set(box[1], {
+        dimensions: {
+          x: maybeMeters(cleanNumber(box[2]) ?? 0),
+          y: maybeMeters(cleanNumber(box[3]) ?? 0),
+          z: maybeMeters(cleanNumber(box[4]) ?? 0),
+        },
+        position: { x: 0, y: 0, z: 0 },
+      });
+    }
+  }
+
+  return assignments;
+}
+
+export function parseSceneGeometryBoxes(sceneJs: string): SceneGeometryBox[] {
+  const assignments = parseBoxAssignments(sceneJs);
+  const boxes: SceneGeometryBox[] = [];
+  const addRegex = /scene\.add\s*\(\s*(\w+)\s*(?:,\s*\{([^}]*)\})?\s*\)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = addRegex.exec(sceneJs)) !== null) {
+    const name = match[1];
+    const assigned = assignments.get(name);
+    if (!assigned) continue;
+    const material = match[2]?.match(/material\s*:\s*["']([^"']+)["']/)?.[1];
+    boxes.push({
+      name,
+      material,
+      type: classifyBox(name, material),
+      dimensions: assigned.dimensions,
+      position: assigned.position,
+    });
+  }
+
+  return boxes;
+}
+
+function largestVerticalFaceArea(box: SceneGeometryBox): number {
+  const { x, y, z } = box.dimensions;
+  return Math.max(x * y, z * y);
+}
+
+function horizontalArea(box: SceneGeometryBox): number {
+  return box.dimensions.x * box.dimensions.z;
+}
+
+export function analyzeSceneGeometry(sceneJs: string): SceneGeometryMetrics {
+  const boxes = parseSceneGeometryBoxes(sceneJs);
+  const structuralBoxes = boxes.filter((box) => box.type !== "opening");
+  const minX = structuralBoxes.length
+    ? Math.min(...structuralBoxes.map((box) => box.position.x - box.dimensions.x / 2))
+    : 0;
+  const maxX = structuralBoxes.length
+    ? Math.max(...structuralBoxes.map((box) => box.position.x + box.dimensions.x / 2))
+    : 0;
+  const minZ = structuralBoxes.length
+    ? Math.min(...structuralBoxes.map((box) => box.position.z - box.dimensions.z / 2))
+    : 0;
+  const maxZ = structuralBoxes.length
+    ? Math.max(...structuralBoxes.map((box) => box.position.z + box.dimensions.z / 2))
+    : 0;
+  const maxY = structuralBoxes.length
+    ? Math.max(...structuralBoxes.map((box) => box.position.y + box.dimensions.y / 2))
+    : 0;
+
+  let wallAreaM2 = 0;
+  let floorAreaM2 = 0;
+  let roofAreaM2 = 0;
+  let openingAreaM2 = 0;
+  let openingCount = 0;
+
+  for (const box of boxes) {
+    if (box.type === "opening") {
+      openingCount += 1;
+      openingAreaM2 += largestVerticalFaceArea(box);
+      continue;
+    }
+    if (box.type === "roof") {
+      roofAreaM2 += horizontalArea(box);
+      continue;
+    }
+    if (box.type === "floor") {
+      floorAreaM2 += horizontalArea(box);
+      continue;
+    }
+    if (box.type === "wall") {
+      wallAreaM2 += largestVerticalFaceArea(box);
+    }
+  }
+
+  const widthM = Math.max(0, maxX - minX);
+  const depthM = Math.max(0, maxZ - minZ);
+  const fallbackWallPerimeter = widthM > 0 && depthM > 0 ? 2 * (widthM + depthM) : 0;
+  const explicitWallLength = boxes
+    .filter((box) => box.type === "wall")
+    .reduce((sum, box) => sum + Math.max(box.dimensions.x, box.dimensions.z), 0);
+
+  return {
+    wallAreaM2: roundQuantity(Math.max(0, wallAreaM2 - openingAreaM2)),
+    floorAreaM2: roundQuantity(floorAreaM2),
+    roofAreaM2: roundQuantity(roofAreaM2 || floorAreaM2),
+    wallPerimeterM: roundQuantity(explicitWallLength || fallbackWallPerimeter),
+    openingCount,
+    openingAreaM2: roundQuantity(openingAreaM2),
+    objectCount: boxes.length,
+    bounds: {
+      widthM: roundQuantity(widthM),
+      depthM: roundQuantity(depthM),
+      heightM: roundQuantity(maxY),
+    },
+  };
+}
+
+function materialLookup(materials: Material[]): Map<string, Material> {
+  return new Map(materials.map((material) => [material.id, material]));
+}
+
+function materialText(item: BomItem, material: Material | undefined): string {
+  return [
+    item.material_id,
+    item.material_name,
+    item.category_name,
+    material?.name,
+    material?.category_name,
+    ...(material?.tags ?? []),
+  ].map((value) => normalizeText(value)).join(" ");
+}
+
+function estimateQuantity(item: BomItem, material: Material | undefined, metrics: SceneGeometryMetrics): {
+  quantity: number;
+  reason: string;
+  metric: GeometryBomSuggestion["metric"];
+} | null {
+  const id = item.material_id;
+  const text = materialText(item, material);
+
+  if (/screws?|ruuvi|fastener/.test(text)) {
+    return {
+      quantity: (metrics.wallAreaM2 + metrics.floorAreaM2 + metrics.roofAreaM2) * 18,
+      reason: "fasteners from total sheathed area",
+      metric: "wallAreaM2",
+    };
+  }
+
+  if (/concrete_block|betoniharkko|foundation|perustus/.test(text)) {
+    return {
+      quantity: Math.max(4, Math.ceil(metrics.wallPerimeterM * 2)),
+      reason: "foundation blocks from building perimeter",
+      metric: "wallPerimeterM",
+    };
+  }
+
+  if (/galvanized_roofing|roofing|katto|kate/.test(text)) {
+    return {
+      quantity: metrics.roofAreaM2 * 1.1,
+      reason: "roofing area plus 10% waste",
+      metric: "roofAreaM2",
+    };
+  }
+
+  if (/insulation|mineraalivilla|villa/.test(text)) {
+    return {
+      quantity: metrics.wallAreaM2 * 1.05,
+      reason: "wall insulation area plus 5% waste",
+      metric: "wallAreaM2",
+    };
+  }
+
+  if (/osb_18|floor|lattia/.test(text) && /osb|sheet|levy|sheathing/.test(text)) {
+    return {
+      quantity: metrics.floorAreaM2 * 1.08,
+      reason: "floor sheathing area plus 8% waste",
+      metric: "floorAreaM2",
+    };
+  }
+
+  if (/osb|sheet|levy|sheathing|cladding|ulkoverhous/.test(text)) {
+    return {
+      quantity: metrics.wallAreaM2 * 1.08,
+      reason: "wall sheathing/cladding area plus 8% waste",
+      metric: "wallAreaM2",
+    };
+  }
+
+  if (id === "pine_48x98_c24" || /48x98|rafter|koolaus/.test(text)) {
+    return {
+      quantity: metrics.wallPerimeterM * 1.8 + metrics.roofAreaM2 * 2.2,
+      reason: "secondary framing from perimeter and roof area",
+      metric: "wallPerimeterM",
+    };
+  }
+
+  if (id === "pine_48x148_c24" || /48x148|stud|joist|lattiavasa/.test(text)) {
+    const height = Math.max(metrics.bounds.heightM || 2.4, 2.1);
+    return {
+      quantity: (metrics.wallPerimeterM / 0.6) * height + metrics.wallPerimeterM * 2,
+      reason: "studs at 600mm centres plus top/bottom plates",
+      metric: "wallPerimeterM",
+    };
+  }
+
+  return null;
+}
+
+function isUnitCompatible(itemUnit: string, estimate: ReturnType<typeof estimateQuantity>): boolean {
+  if (!estimate) return false;
+  const unit = normalizeUnit(itemUnit);
+  if (estimate.reason.startsWith("foundation blocks")) return unit === "kpl";
+  if (estimate.reason.startsWith("fasteners")) return unit === "kpl";
+  if (estimate.metric === "wallPerimeterM") return unit === "jm";
+  if (estimate.metric === "openingCount") return unit === "kpl";
+  return unit === "m2";
+}
+
+export function suggestGeometryBomUpdates(
+  sceneJs: string,
+  bom: BomItem[],
+  materials: Material[],
+  manualOverrideIds: Set<string> = new Set(),
+): GeometryBomSuggestionResult {
+  const metrics = analyzeSceneGeometry(sceneJs);
+  const materialById = materialLookup(materials);
+  const suggestions: GeometryBomSuggestion[] = [];
+  const skippedManual: GeometryBomSuggestion[] = [];
+
+  for (const item of bom) {
+    const material = materialById.get(item.material_id);
+    const estimate = estimateQuantity(item, material, metrics);
+    if (!estimate || !isUnitCompatible(item.unit, estimate)) continue;
+
+    const suggestedQuantity = roundQuantity(estimate.quantity);
+    const currentQuantity = Number(item.quantity) || 0;
+    const delta = roundQuantity(suggestedQuantity - currentQuantity);
+    const denominator = Math.max(Math.abs(currentQuantity), 1);
+    const percentChange = Math.abs(delta) / denominator;
+
+    if (Math.abs(delta) < MIN_DELTA || percentChange < MIN_PERCENT_CHANGE) continue;
+
+    const suggestion: GeometryBomSuggestion = {
+      materialId: item.material_id,
+      materialName: item.material_name || material?.name || item.material_id,
+      unit: item.unit,
+      currentQuantity,
+      suggestedQuantity,
+      delta,
+      percentChange,
+      reason: estimate.reason,
+      metric: estimate.metric,
+    };
+
+    if (manualOverrideIds.has(item.material_id)) {
+      skippedManual.push(suggestion);
+    } else {
+      suggestions.push(suggestion);
+    }
+  }
+
+  return { metrics, suggestions, skippedManual };
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -297,6 +297,8 @@ export interface BomItem {
   store_location?: string | null;
   stock_last_checked_at?: string | null;
   note?: string;
+  manual_override?: boolean;
+  geometry_driven?: boolean;
 }
 
 export interface QuoteRequestPayload {


### PR DESCRIPTION
Closes #144.\n\n## Summary\n- adds a scene geometry analyzer for box-based wall, floor, roof, perimeter, and opening metrics\n- maps geometry metrics to BOM quantity suggestions for framing, insulation, sheathing, roofing, fasteners, and foundation blocks\n- adds an editor diff prompt that updates BOM totals after accepting changes while preserving manually edited rows unless the user explicitly recalculates all\n\n## Verification\n- web: npx tsc --noEmit\n- web: npm test -- --run src/lib/__tests__/scene-geometry-bom.test.ts src/lib/__tests__/i18n.test.ts\n- web: npm test -- --run\n- web: npm run build\n- git diff --check