### PR TITLE
Add StatFin renovation cost index integration

### DIFF
--- a/api/src/__tests__/statfin-cost-index.test.ts
+++ b/api/src/__tests__/statfin-cost-index.test.ts
@@ -1,0 +1,253 @@
+process.env.NODE_ENV = "test";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import jwt from "jsonwebtoken";
+import http from "http";
+import type { AddressInfo } from "net";
+import {
+  clearRenovationCostIndexCache,
+  estimateRenovationCost,
+  FINNISH_VAT_RATE,
+  getRenovationCostIndexCatalog,
+  parseStatFinCostIndex,
+  RENOVATION_BASE_COSTS,
+  STATFIN_COST_INDEX_ATTRIBUTION,
+} from "../statfin-cost-index";
+
+const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [], command: "", rowCount: 0, oid: 0, fields: [] }),
+  pool: { query: vi.fn() },
+}));
+
+vi.mock("../email", () => ({
+  sendEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendPriceAlertEmail: vi.fn(),
+}));
+
+import app from "../index";
+
+function authToken(userId = "user-1", role = "user") {
+  return jwt.sign(
+    { id: userId, email: "test@test.com", role },
+    JWT_SECRET,
+    { expiresIn: "7d" },
+  );
+}
+
+function makeRequest(
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const bodyStr = opts.body ? JSON.stringify(opts.body) : undefined;
+      const reqOpts: http.RequestOptions = {
+        hostname: "127.0.0.1",
+        port,
+        path,
+        method: method.toUpperCase(),
+        headers: {
+          "Content-Type": "application/json",
+          ...opts.headers,
+        },
+      };
+
+      const req = http.request(reqOpts, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          server.close();
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = data;
+          }
+          resolve({ status: res.statusCode || 0, body: parsed });
+        });
+      });
+
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+
+      if (bodyStr) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+const metadata = {
+  title: "Building cost index by type of cost, monthly data",
+  variables: [
+    { code: "Kuukausi", text: "Month", values: ["2026M01", "2026M02", "2026M03"], time: true },
+    { code: "Perusvuosi", text: "Base year", values: ["2021_100"] },
+    {
+      code: "Indeksi",
+      text: "Index",
+      values: ["Kokonaisindeksi", "Työpanokset", "Tarvikepanokset", "Palvelut"],
+    },
+    { code: "Tiedot", text: "Information", values: ["pisteluku"] },
+  ],
+};
+
+const jsonStatDataset = {
+  version: "2.0",
+  class: "dataset",
+  source: "Statistics Finland, building cost index",
+  updated: "2026-04-15T05:00:00Z",
+  id: ["Kuukausi", "Perusvuosi", "Indeksi", "Tiedot"],
+  size: [1, 1, 4, 1],
+  dimension: {
+    Kuukausi: { category: { index: { "2026M03": 0 }, label: { "2026M03": "2026M03" } } },
+    Perusvuosi: { category: { index: { "2021_100": 0 }, label: { "2021_100": "2021=100" } } },
+    Indeksi: {
+      category: {
+        index: { Kokonaisindeksi: 0, "Työpanokset": 1, "Tarvikepanokset": 2, Palvelut: 3 },
+        label: {
+          Kokonaisindeksi: "0 Total index",
+          "Työpanokset": "01 Labour",
+          "Tarvikepanokset": "02 Materials",
+          Palvelut: "03 Services",
+        },
+      },
+    },
+    Tiedot: { category: { index: { pisteluku: 0 }, label: { pisteluku: "Index figure" } } },
+  },
+  value: [110, 120, 130, 100],
+};
+
+function stubStatFinFetch() {
+  const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => ({
+    ok: true,
+    status: 200,
+    json: async () => (init?.method === "POST" ? jsonStatDataset : metadata),
+  } as Response));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  clearRenovationCostIndexCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clearRenovationCostIndexCache();
+});
+
+describe("StatFin renovation cost index", () => {
+  it("parses the latest JSON-stat RKI values into multipliers", () => {
+    const parsed = parseStatFinCostIndex(jsonStatDataset, "2026M03");
+
+    expect(parsed.period).toBe("2026M03");
+    expect(parsed.values).toEqual({
+      total: 110,
+      labour: 120,
+      materials: 130,
+      services: 100,
+    });
+    expect(parsed.multipliers).toEqual({
+      total: 1.1,
+      labour: 1.2,
+      materials: 1.3,
+      services: 1,
+    });
+  });
+
+  it("keeps at least eight homeowner renovation base-cost categories", () => {
+    expect(RENOVATION_BASE_COSTS.length).toBeGreaterThanOrEqual(8);
+    expect(RENOVATION_BASE_COSTS.map((category) => category.id)).toContain("window_replacement");
+    expect(RENOVATION_BASE_COSTS.map((category) => category.id)).toContain("bathroom_renovation");
+  });
+
+  it("fetches StatFin metadata and data once, then serves the 24h cache", async () => {
+    const fetchMock = stubStatFinFetch();
+
+    const first = await getRenovationCostIndexCatalog({
+      now: new Date("2026-04-23T08:00:00.000Z"),
+    });
+    const second = await getRenovationCostIndexCatalog({
+      now: new Date("2026-04-23T09:00:00.000Z"),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(first.cache.hit).toBe(false);
+    expect(first.cache.ttlHours).toBe(24);
+    expect(second.cache.hit).toBe(true);
+    expect(second.source.latestPeriod).toBe("2026M03");
+    expect(second.source.status).toBe("live");
+  });
+
+  it("calculates estimates with indexed base cost and 25.5% ALV", async () => {
+    stubStatFinFetch();
+    const catalog = await getRenovationCostIndexCatalog({
+      now: new Date("2026-04-23T08:00:00.000Z"),
+    });
+
+    const estimate = estimateRenovationCost(catalog, "bathroom_renovation", 2);
+
+    expect(estimate.vatRate).toBe(FINNISH_VAT_RATE);
+    expect(estimate.category.statfinMultiplier).toBe(1.232);
+    expect(estimate.subtotalExVat).toBe(3498.88);
+    expect(estimate.vatAmount).toBe(892.21);
+    expect(estimate.totalInclVat).toBe(4391.09);
+    expect(estimate.source.attribution).toBe(STATFIN_COST_INDEX_ATTRIBUTION);
+  });
+});
+
+describe("StatFin pricing routes", () => {
+  it("returns the indexed renovation cost catalog with source attribution", async () => {
+    stubStatFinFetch();
+
+    const res = await makeRequest("GET", "/pricing/renovation-cost-index", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      source: { attribution: string; latestPeriod: string; status: string };
+      categories: unknown[];
+      vatRate: number;
+    };
+    expect(body.source.attribution).toBe(STATFIN_COST_INDEX_ATTRIBUTION);
+    expect(body.source.latestPeriod).toBe("2026M03");
+    expect(body.source.status).toBe("live");
+    expect(body.vatRate).toBe(0.255);
+    expect(body.categories.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("returns a single quantity estimate from the StatFin-indexed catalog", async () => {
+    stubStatFinFetch();
+
+    const res = await makeRequest("POST", "/pricing/renovation-cost-estimate", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { categoryId: "window_replacement", quantity: 3 },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { category: { id: string }; quantity: number; totalInclVat: number; formula: string };
+    expect(body.category.id).toBe("window_replacement");
+    expect(body.quantity).toBe(3);
+    expect(body.totalInclVat).toBeGreaterThan(0);
+    expect(body.formula).toContain("ALV 25.5%");
+  });
+
+  it("rejects invalid estimate input", async () => {
+    stubStatFinFetch();
+
+    const res = await makeRequest("POST", "/pricing/renovation-cost-estimate", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { categoryId: "unknown", quantity: 0 },
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/api/src/routes/pricing.ts
+++ b/api/src/routes/pricing.ts
@@ -4,6 +4,11 @@ import { requireAuth } from "../auth";
 import { normalizeRole, requirePermission } from "../permissions";
 import { buildMaterialTrend, buildProjectTrendSummary, type PriceHistoryInput } from "../material-trends";
 import { notifyPriceWatchers } from "../price-alerts";
+import {
+  estimateRenovationCost,
+  getRenovationCostIndexCatalog,
+  isRenovationCostCategoryId,
+} from "../statfin-cost-index";
 
 const router = Router();
 
@@ -157,6 +162,29 @@ router.get("/trends/project/:projectId", requireAuth, requirePermission("pricing
     dataSources: Array.from(new Set(items.map((item) => item.source))),
     ...buildProjectTrendSummary(items),
   });
+});
+
+// GET /pricing/renovation-cost-index — StatFin-indexed detached-house renovation baselines
+router.get("/renovation-cost-index", requireAuth, requirePermission("pricing:read"), async (_req, res) => {
+  const catalog = await getRenovationCostIndexCatalog();
+  res.json(catalog);
+});
+
+// POST /pricing/renovation-cost-estimate — base_cost x quantity x StatFin multiplier x ALV
+router.post("/renovation-cost-estimate", requireAuth, requirePermission("pricing:read"), async (req, res) => {
+  const { categoryId, quantity } = req.body as { categoryId?: unknown; quantity?: unknown };
+  const numericQuantity = Number(quantity);
+
+  if (!isRenovationCostCategoryId(categoryId)) {
+    return res.status(400).json({ error: "Unknown renovation cost category" });
+  }
+
+  if (!Number.isFinite(numericQuantity) || numericQuantity <= 0) {
+    return res.status(400).json({ error: "quantity must be a positive number" });
+  }
+
+  const catalog = await getRenovationCostIndexCatalog();
+  res.json(estimateRenovationCost(catalog, categoryId, numericQuantity));
 });
 
 // PUT /pricing/:materialId/:supplierId — update pricing (admin or partner with pricing:update)

--- a/api/src/statfin-cost-index.ts
+++ b/api/src/statfin-cost-index.ts
@@ -1,0 +1,580 @@
+export const FINNISH_VAT_RATE = 0.255;
+export const STATFIN_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FALLBACK_CACHE_TTL_MS = 30 * 60 * 1000;
+const STATFIN_BASE_YEAR_CODE = "2021_100";
+const STATFIN_BASE_YEAR_LABEL = "2021=100";
+const STATFIN_TABLE_ID = "statfin_rki_pxt_118p";
+const STATFIN_BROWSER_URL =
+  "https://pxdata.stat.fi/PxWeb/pxweb/en/StatFin/StatFin__rki/statfin_rki_pxt_118p.px/";
+const DEFAULT_STATFIN_API_URL =
+  "https://pxdata.stat.fi/PxWeb/api/v1/en/StatFin/rki/statfin_rki_pxt_118p.px";
+
+const INDEX_CODES = {
+  total: "Kokonaisindeksi",
+  labour: "Työpanokset",
+  materials: "Tarvikepanokset",
+  services: "Palvelut",
+} as const;
+
+export const STATFIN_COST_INDEX_ATTRIBUTION = "Lähde: Tilastokeskus, Rakennuskustannusindeksi";
+
+export type RenovationCostUnit = "m2" | "m" | "unit" | "project";
+export type StatFinIndexSourceStatus = "live" | "fallback";
+
+export interface RenovationBaseCost {
+  id: string;
+  labelFi: string;
+  labelEn: string;
+  unit: RenovationCostUnit;
+  baseCostExVat: number;
+  materialShare: number;
+  labourShare: number;
+  serviceShare: number;
+  notes: string;
+}
+
+export interface StatFinCostIndex {
+  period: string;
+  updatedAt: string | null;
+  baseYear: string;
+  values: {
+    total: number;
+    labour: number;
+    materials: number;
+    services: number;
+  };
+  multipliers: {
+    total: number;
+    labour: number;
+    materials: number;
+    services: number;
+  };
+}
+
+export interface RenovationCostCategory extends RenovationBaseCost {
+  statfinMultiplier: number;
+  currentCostExVat: number;
+  currentCostInclVat: number;
+}
+
+export interface RenovationCostIndexCatalog {
+  generatedAt: string;
+  source: {
+    name: "Tilastokeskus";
+    statistic: "Rakennuskustannusindeksi";
+    attribution: string;
+    tableId: string;
+    apiUrl: string;
+    url: string;
+    status: StatFinIndexSourceStatus;
+    latestPeriod: string;
+    updatedAt: string | null;
+    error?: string;
+  };
+  cache: {
+    hit: boolean;
+    ttlHours: number;
+    expiresAt: string;
+  };
+  vatRate: number;
+  baseYear: string;
+  index: StatFinCostIndex;
+  categories: RenovationCostCategory[];
+}
+
+export interface RenovationCostEstimate {
+  generatedAt: string;
+  category: RenovationCostCategory;
+  quantity: number;
+  unit: RenovationCostUnit;
+  subtotalExVat: number;
+  vatRate: number;
+  vatAmount: number;
+  totalInclVat: number;
+  formula: string;
+  source: RenovationCostIndexCatalog["source"];
+}
+
+interface PxWebVariable {
+  code: string;
+  values: string[];
+  valueTexts?: string[];
+  time?: boolean;
+}
+
+interface PxWebMetadata {
+  title?: string;
+  variables: PxWebVariable[];
+}
+
+interface JsonStatCategory {
+  index?: Record<string, number> | string[];
+  label?: Record<string, string>;
+}
+
+interface JsonStatDataset {
+  source?: string;
+  updated?: string;
+  id?: string[];
+  size?: number[];
+  dimension?: Record<string, { category?: JsonStatCategory }>;
+  value?: number[] | Record<string, number | null> | null;
+}
+
+interface CacheEntry {
+  index: StatFinCostIndex;
+  status: StatFinIndexSourceStatus;
+  error?: string;
+  expiresAtMs: number;
+  ttlMs: number;
+}
+
+export const RENOVATION_BASE_COSTS: RenovationBaseCost[] = [
+  {
+    id: "facade_cladding",
+    labelFi: "Julkisivulaudoituksen uusinta",
+    labelEn: "Facade cladding renewal",
+    unit: "m2",
+    baseCostExVat: 155,
+    materialShare: 0.48,
+    labourShare: 0.45,
+    serviceShare: 0.07,
+    notes: "Planning baseline for detached-house exterior cladding renewal.",
+  },
+  {
+    id: "roof_sheet_metal",
+    labelFi: "Peltikaton uusinta",
+    labelEn: "Sheet-metal roof renewal",
+    unit: "m2",
+    baseCostExVat: 135,
+    materialShare: 0.58,
+    labourShare: 0.36,
+    serviceShare: 0.06,
+    notes: "Roof covering, battens, flashings, and normal installation labour.",
+  },
+  {
+    id: "roof_tile",
+    labelFi: "Tiilikaton uusinta",
+    labelEn: "Tile roof renewal",
+    unit: "m2",
+    baseCostExVat: 175,
+    materialShare: 0.55,
+    labourShare: 0.39,
+    serviceShare: 0.06,
+    notes: "Heavier roof-covering renewal where structure is otherwise reusable.",
+  },
+  {
+    id: "window_replacement",
+    labelFi: "Ikkunoiden vaihto",
+    labelEn: "Window replacement",
+    unit: "unit",
+    baseCostExVat: 760,
+    materialShare: 0.62,
+    labourShare: 0.33,
+    serviceShare: 0.05,
+    notes: "One installed standard window, excluding unusual facade repairs.",
+  },
+  {
+    id: "exterior_door_replacement",
+    labelFi: "Ulko-oven vaihto",
+    labelEn: "Exterior door replacement",
+    unit: "unit",
+    baseCostExVat: 1180,
+    materialShare: 0.58,
+    labourShare: 0.36,
+    serviceShare: 0.06,
+    notes: "One installed exterior door with normal trim work.",
+  },
+  {
+    id: "attic_insulation",
+    labelFi: "Yläpohjan lisäeristys",
+    labelEn: "Attic insulation upgrade",
+    unit: "m2",
+    baseCostExVat: 52,
+    materialShare: 0.50,
+    labourShare: 0.42,
+    serviceShare: 0.08,
+    notes: "Added insulation for an accessible detached-house attic.",
+  },
+  {
+    id: "bathroom_renovation",
+    labelFi: "Kylpyhuoneremontti",
+    labelEn: "Bathroom renovation",
+    unit: "m2",
+    baseCostExVat: 1420,
+    materialShare: 0.46,
+    labourShare: 0.47,
+    serviceShare: 0.07,
+    notes: "Wet-room surfaces, waterproofing, fixtures, and installation labour.",
+  },
+  {
+    id: "kitchen_renovation",
+    labelFi: "Keittiöremontti",
+    labelEn: "Kitchen renovation",
+    unit: "m2",
+    baseCostExVat: 1180,
+    materialShare: 0.60,
+    labourShare: 0.34,
+    serviceShare: 0.06,
+    notes: "Cabinetry-led renovation baseline excluding premium appliances.",
+  },
+  {
+    id: "air_to_water_heat_pump",
+    labelFi: "Ilma-vesilämpöpumppu",
+    labelEn: "Air-to-water heat pump",
+    unit: "project",
+    baseCostExVat: 13800,
+    materialShare: 0.68,
+    labourShare: 0.26,
+    serviceShare: 0.06,
+    notes: "Installed system baseline for a detached-house heating upgrade.",
+  },
+  {
+    id: "geothermal_heating",
+    labelFi: "Maalämpöjärjestelmä",
+    labelEn: "Geothermal heating system",
+    unit: "project",
+    baseCostExVat: 23800,
+    materialShare: 0.52,
+    labourShare: 0.32,
+    serviceShare: 0.16,
+    notes: "Heat pump, borehole/service work, and installation baseline.",
+  },
+  {
+    id: "electrical_upgrade",
+    labelFi: "Sähköjärjestelmän päivitys",
+    labelEn: "Electrical system upgrade",
+    unit: "m2",
+    baseCostExVat: 86,
+    materialShare: 0.34,
+    labourShare: 0.58,
+    serviceShare: 0.08,
+    notes: "Planning baseline for wiring and distribution-board upgrade.",
+  },
+  {
+    id: "foundation_drainage",
+    labelFi: "Salaojaremontti",
+    labelEn: "Foundation drainage renewal",
+    unit: "m",
+    baseCostExVat: 420,
+    materialShare: 0.38,
+    labourShare: 0.42,
+    serviceShare: 0.20,
+    notes: "Perimeter drainage renewal with excavation-heavy service share.",
+  },
+];
+
+const FALLBACK_INDEX: StatFinCostIndex = {
+  period: "2026M03",
+  updatedAt: "2026-04-15T05:00:00Z",
+  baseYear: STATFIN_BASE_YEAR_LABEL,
+  values: {
+    total: 112.7,
+    labour: 113.5,
+    materials: 113.8,
+    services: 103,
+  },
+  multipliers: {
+    total: 1.127,
+    labour: 1.135,
+    materials: 1.138,
+    services: 1.03,
+  },
+};
+
+let cache: CacheEntry | null = null;
+let inFlight: Promise<CacheEntry> | null = null;
+
+function statfinApiUrl(): string {
+  return process.env.STATFIN_RKI_API_URL || DEFAULT_STATFIN_API_URL;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function roundMultiplier(value: number): number {
+  return Math.round(value * 10_000) / 10_000;
+}
+
+function normalizeShare(value: number): number {
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return value;
+}
+
+function weightedMultiplier(baseCost: RenovationBaseCost, index: StatFinCostIndex): number {
+  const materialShare = normalizeShare(baseCost.materialShare);
+  const labourShare = normalizeShare(baseCost.labourShare);
+  const serviceShare = normalizeShare(baseCost.serviceShare);
+  const totalShare = materialShare + labourShare + serviceShare;
+
+  if (totalShare <= 0) return index.multipliers.total;
+
+  return roundMultiplier(
+    ((materialShare / totalShare) * index.multipliers.materials) +
+      ((labourShare / totalShare) * index.multipliers.labour) +
+      ((serviceShare / totalShare) * index.multipliers.services),
+  );
+}
+
+function buildCategories(index: StatFinCostIndex): RenovationCostCategory[] {
+  return RENOVATION_BASE_COSTS.map((baseCost) => {
+    const statfinMultiplier = weightedMultiplier(baseCost, index);
+    const currentCostExVat = roundMoney(baseCost.baseCostExVat * statfinMultiplier);
+    return {
+      ...baseCost,
+      statfinMultiplier,
+      currentCostExVat,
+      currentCostInclVat: roundMoney(currentCostExVat * (1 + FINNISH_VAT_RATE)),
+    };
+  });
+}
+
+function latestMonthFromMetadata(metadata: PxWebMetadata): string {
+  const monthVariable = metadata.variables.find((variable) => variable.code === "Kuukausi" || variable.time);
+  const latestMonth = monthVariable?.values.at(-1);
+  if (!latestMonth) {
+    throw new Error("StatFin RKI metadata did not include a latest month");
+  }
+  return latestMonth;
+}
+
+function buildStatFinQuery(month: string) {
+  return {
+    query: [
+      { code: "Kuukausi", selection: { filter: "item", values: [month] } },
+      { code: "Perusvuosi", selection: { filter: "item", values: [STATFIN_BASE_YEAR_CODE] } },
+      {
+        code: "Indeksi",
+        selection: {
+          filter: "item",
+          values: [
+            INDEX_CODES.total,
+            INDEX_CODES.labour,
+            INDEX_CODES.materials,
+            INDEX_CODES.services,
+          ],
+        },
+      },
+      { code: "Tiedot", selection: { filter: "item", values: ["pisteluku"] } },
+    ],
+    response: { format: "json-stat2" },
+  };
+}
+
+function jsonStatIndexPosition(dataset: JsonStatDataset, dimensionId: string, code: string): number | null {
+  const categoryIndex = dataset.dimension?.[dimensionId]?.category?.index;
+  if (!categoryIndex) return null;
+
+  if (Array.isArray(categoryIndex)) {
+    const index = categoryIndex.indexOf(code);
+    return index >= 0 ? index : null;
+  }
+
+  const index = categoryIndex[code];
+  return Number.isInteger(index) ? index : null;
+}
+
+function readJsonStatValue(dataset: JsonStatDataset, coordinates: Record<string, string>): number {
+  const ids = dataset.id;
+  const sizes = dataset.size;
+  const values = dataset.value;
+
+  if (!ids || !sizes || !values) {
+    throw new Error("StatFin RKI response is missing JSON-stat dimensions or values");
+  }
+
+  let offset = 0;
+  let stride = 1;
+
+  for (let index = ids.length - 1; index >= 0; index -= 1) {
+    const id = ids[index];
+    const size = sizes[index] ?? 1;
+    const code = coordinates[id];
+    const dimensionIndex = code ? jsonStatIndexPosition(dataset, id, code) : 0;
+
+    if (dimensionIndex == null) {
+      throw new Error(`StatFin RKI response is missing ${id}=${code}`);
+    }
+
+    offset += dimensionIndex * stride;
+    stride *= size;
+  }
+
+  const rawValue = Array.isArray(values) ? values[offset] : values[String(offset)];
+  const value = Number(rawValue);
+  if (!Number.isFinite(value)) {
+    throw new Error(`StatFin RKI value at offset ${offset} is not numeric`);
+  }
+
+  return value;
+}
+
+export function parseStatFinCostIndex(dataset: JsonStatDataset, period: string): StatFinCostIndex {
+  const coordinates = {
+    Kuukausi: period,
+    Perusvuosi: STATFIN_BASE_YEAR_CODE,
+    Tiedot: "pisteluku",
+  };
+
+  const total = readJsonStatValue(dataset, { ...coordinates, Indeksi: INDEX_CODES.total });
+  const labour = readJsonStatValue(dataset, { ...coordinates, Indeksi: INDEX_CODES.labour });
+  const materials = readJsonStatValue(dataset, { ...coordinates, Indeksi: INDEX_CODES.materials });
+  const services = readJsonStatValue(dataset, { ...coordinates, Indeksi: INDEX_CODES.services });
+
+  return {
+    period,
+    updatedAt: dataset.updated ?? null,
+    baseYear: STATFIN_BASE_YEAR_LABEL,
+    values: { total, labour, materials, services },
+    multipliers: {
+      total: roundMultiplier(total / 100),
+      labour: roundMultiplier(labour / 100),
+      materials: roundMultiplier(materials / 100),
+      services: roundMultiplier(services / 100),
+    },
+  };
+}
+
+async function fetchJson<T>(
+  fetchImpl: typeof fetch,
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetchImpl(url, init);
+  if (!response.ok) {
+    throw new Error(`StatFin RKI request failed with ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function fetchCurrentStatFinCostIndex(fetchImpl: typeof fetch = globalThis.fetch): Promise<StatFinCostIndex> {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("fetch is not available for StatFin RKI client");
+  }
+
+  const apiUrl = statfinApiUrl();
+  const metadata = await fetchJson<PxWebMetadata>(fetchImpl, apiUrl);
+  const latestMonth = latestMonthFromMetadata(metadata);
+  const dataset = await fetchJson<JsonStatDataset>(fetchImpl, apiUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(buildStatFinQuery(latestMonth)),
+  });
+
+  return parseStatFinCostIndex(dataset, latestMonth);
+}
+
+async function refreshCache(nowMs: number, fetchImpl: typeof fetch): Promise<CacheEntry> {
+  try {
+    const index = await fetchCurrentStatFinCostIndex(fetchImpl);
+    const entry: CacheEntry = {
+      index,
+      status: "live",
+      expiresAtMs: nowMs + STATFIN_CACHE_TTL_MS,
+      ttlMs: STATFIN_CACHE_TTL_MS,
+    };
+    cache = entry;
+    return entry;
+  } catch (error) {
+    const entry: CacheEntry = {
+      index: FALLBACK_INDEX,
+      status: "fallback",
+      error: error instanceof Error ? error.message : "Unknown StatFin RKI fetch error",
+      expiresAtMs: nowMs + FALLBACK_CACHE_TTL_MS,
+      ttlMs: FALLBACK_CACHE_TTL_MS,
+    };
+    cache = entry;
+    return entry;
+  }
+}
+
+export async function getRenovationCostIndexCatalog(options: {
+  now?: Date;
+  fetchImpl?: typeof fetch;
+  forceRefresh?: boolean;
+} = {}): Promise<RenovationCostIndexCatalog> {
+  const now = options.now ?? new Date();
+  const nowMs = now.getTime();
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  let cacheHit = false;
+
+  if (!options.forceRefresh && cache && cache.expiresAtMs > nowMs) {
+    cacheHit = true;
+  } else {
+    inFlight ??= refreshCache(nowMs, fetchImpl).finally(() => {
+      inFlight = null;
+    });
+    cache = await inFlight;
+  }
+
+  const entry = cache;
+  if (!entry) {
+    throw new Error("StatFin RKI cache was not initialized");
+  }
+
+  return {
+    generatedAt: now.toISOString(),
+    source: {
+      name: "Tilastokeskus",
+      statistic: "Rakennuskustannusindeksi",
+      attribution: STATFIN_COST_INDEX_ATTRIBUTION,
+      tableId: STATFIN_TABLE_ID,
+      apiUrl: statfinApiUrl(),
+      url: STATFIN_BROWSER_URL,
+      status: entry.status,
+      latestPeriod: entry.index.period,
+      updatedAt: entry.index.updatedAt,
+      ...(entry.error ? { error: entry.error } : {}),
+    },
+    cache: {
+      hit: cacheHit,
+      ttlHours: entry.ttlMs / (60 * 60 * 1000),
+      expiresAt: new Date(entry.expiresAtMs).toISOString(),
+    },
+    vatRate: FINNISH_VAT_RATE,
+    baseYear: entry.index.baseYear,
+    index: entry.index,
+    categories: buildCategories(entry.index),
+  };
+}
+
+export function estimateRenovationCost(
+  catalog: RenovationCostIndexCatalog,
+  categoryId: string,
+  quantity: number,
+): RenovationCostEstimate {
+  const category = catalog.categories.find((item) => item.id === categoryId);
+  if (!category) {
+    throw new Error(`Unknown renovation cost category: ${categoryId}`);
+  }
+
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    throw new Error("Quantity must be a positive number");
+  }
+
+  const subtotalExVat = roundMoney(category.currentCostExVat * quantity);
+  const vatAmount = roundMoney(subtotalExVat * FINNISH_VAT_RATE);
+
+  return {
+    generatedAt: catalog.generatedAt,
+    category,
+    quantity,
+    unit: category.unit,
+    subtotalExVat,
+    vatRate: FINNISH_VAT_RATE,
+    vatAmount,
+    totalInclVat: roundMoney(subtotalExVat + vatAmount),
+    formula: "base_cost x quantity x tilastokeskus_index_multiplier x (1 + ALV 25.5%)",
+    source: catalog.source,
+  };
+}
+
+export function isRenovationCostCategoryId(value: unknown): value is string {
+  return typeof value === "string" && RENOVATION_BASE_COSTS.some((category) => category.id === value);
+}
+
+export function clearRenovationCostIndexCache(): void {
+  cache = null;
+  inFlight = null;
+}

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -13,6 +13,7 @@ import BomSavingsPanel, { type BomPriceOverride } from "@/components/BomSavingsP
 import QuoteRequestModal from "@/components/QuoteRequestModal";
 import HouseholdDeductionPanel from "@/components/HouseholdDeductionPanel";
 import RenovationRoiPanel from "@/components/RenovationRoiPanel";
+import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
 import PhotoEstimatePanel from "@/components/PhotoEstimatePanel";
 import PermitCheckerPanel from "@/components/PermitCheckerPanel";
@@ -2636,6 +2637,9 @@ export default function BomPanel({
         )}
         {bom.length > 0 && (
           <QuoteSummary bom={bom} materials={materials} />
+        )}
+        {bom.length > 0 && (
+          <RenovationCostIndexPanel />
         )}
         {bom.length > 0 && (
           <HouseholdDeductionPanel

--- a/web/src/components/RenovationCostIndexPanel.tsx
+++ b/web/src/components/RenovationCostIndexPanel.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { api } from "@/lib/api";
+import type { RenovationCostIndexResponse, RenovationCostUnit } from "@/types";
+
+function formatEur(value: number, locale: string): string {
+  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} €`;
+}
+
+function formatPeriod(period: string): string {
+  const match = /^(\d{4})M(\d{2})$/.exec(period);
+  if (!match) return period;
+  return `${match[2]}/${match[1]}`;
+}
+
+function localizeUnit(unit: RenovationCostUnit, locale: string): string {
+  if (unit === "m2") return "m²";
+  if (unit === "m") return locale === "fi" ? "jm" : "m";
+  if (unit === "unit") return locale === "fi" ? "kpl" : "unit";
+  return locale === "fi" ? "projekti" : "project";
+}
+
+export default function RenovationCostIndexPanel() {
+  const { t, locale } = useTranslation();
+  const [data, setData] = useState<RenovationCostIndexResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    api.getRenovationCostIndex()
+      .then((response) => {
+        if (!active) return;
+        setData(response);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if (!active) return;
+        setError(err instanceof Error ? err.message : t("renovationCostIndex.loadFailed"));
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [t]);
+
+  if (error) {
+    return (
+      <section
+        aria-label={t("renovationCostIndex.title")}
+        style={{
+          marginTop: 12,
+          padding: 12,
+          borderRadius: "var(--radius-md)",
+          border: "1px solid var(--border)",
+          background: "var(--bg-secondary)",
+          color: "var(--text-muted)",
+          fontSize: 11,
+        }}
+      >
+        {t("renovationCostIndex.loadFailed")}
+      </section>
+    );
+  }
+
+  if (!data) {
+    return (
+      <section
+        aria-label={t("renovationCostIndex.title")}
+        style={{
+          marginTop: 12,
+          padding: 12,
+          borderRadius: "var(--radius-md)",
+          border: "1px solid var(--border)",
+          background: "var(--bg-secondary)",
+          color: "var(--text-muted)",
+          fontSize: 11,
+        }}
+      >
+        {t("renovationCostIndex.loading")}
+      </section>
+    );
+  }
+
+  const categories = data.categories.slice(0, 4);
+  const vatPct = Math.round(data.vatRate * 1000) / 10;
+
+  return (
+    <section
+      aria-label={t("renovationCostIndex.title")}
+      style={{
+        marginTop: 12,
+        padding: 14,
+        borderRadius: "var(--radius-md)",
+        border: "1px solid rgba(74,124,89,0.22)",
+        background: "linear-gradient(135deg, rgba(74,124,89,0.12), rgba(229,160,75,0.07))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <div className="label-mono" style={{ color: "var(--forest)", fontSize: 10, marginBottom: 4 }}>
+            {t("renovationCostIndex.eyebrow")}
+          </div>
+          <h4 style={{ margin: 0, fontSize: 15, color: "var(--text-primary)" }}>
+            {t("renovationCostIndex.title")}
+          </h4>
+        </div>
+        <span
+          style={{
+            borderRadius: 999,
+            padding: "4px 7px",
+            border: "1px solid rgba(74,124,89,0.28)",
+            background: "rgba(74,124,89,0.12)",
+            color: "var(--forest)",
+            fontSize: 10,
+            fontWeight: 700,
+            textTransform: "uppercase",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {formatPeriod(data.source.latestPeriod)}
+        </span>
+      </div>
+
+      <p style={{ margin: "8px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+        {t("renovationCostIndex.summary", {
+          multiplier: data.index.multipliers.total.toFixed(3),
+          vat: vatPct.toFixed(1),
+        })}
+      </p>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 12 }}>
+        {categories.map((category) => (
+          <div
+            key={category.id}
+            style={{
+              padding: "8px 9px",
+              borderRadius: "var(--radius-sm)",
+              background: "var(--bg-tertiary)",
+              border: "1px solid var(--border)",
+              minWidth: 0,
+            }}
+          >
+            <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-primary)", marginBottom: 4 }}>
+              {locale === "fi" ? category.labelFi : category.labelEn}
+            </div>
+            <div style={{ fontSize: 10, color: "var(--text-muted)" }}>
+              {formatEur(category.currentCostInclVat, locale)} / {localizeUnit(category.unit, locale)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <p style={{ margin: "9px 0 0", color: "var(--text-muted)", fontSize: 10, lineHeight: 1.45 }}>
+        {data.source.attribution}. {t("renovationCostIndex.updated", { period: formatPeriod(data.source.latestPeriod) })}
+        {data.source.status === "fallback" ? ` ${t("renovationCostIndex.fallback")}` : ""}
+      </p>
+    </section>
+  );
+}

--- a/web/src/components/__tests__/RenovationCostIndexPanel.test.tsx
+++ b/web/src/components/__tests__/RenovationCostIndexPanel.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
+import type { RenovationCostIndexResponse } from "@/types";
+
+const mocks = vi.hoisted(() => ({
+  getRenovationCostIndex: vi.fn(),
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "fi",
+    setLocale: vi.fn(),
+    t: (key: string, params?: Record<string, string | number>) => {
+      if (key === "renovationCostIndex.summary") return `summary ${params?.multiplier} ${params?.vat}`;
+      if (key === "renovationCostIndex.updated") return `updated ${params?.period}`;
+      return key;
+    },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getRenovationCostIndex: mocks.getRenovationCostIndex,
+  },
+}));
+
+const response: RenovationCostIndexResponse = {
+  generatedAt: "2026-04-23T08:00:00.000Z",
+  source: {
+    name: "Tilastokeskus",
+    statistic: "Rakennuskustannusindeksi",
+    attribution: "Lähde: Tilastokeskus, Rakennuskustannusindeksi",
+    tableId: "statfin_rki_pxt_118p",
+    apiUrl: "https://pxdata.stat.fi/PxWeb/api/v1/en/StatFin/rki/statfin_rki_pxt_118p.px",
+    url: "https://pxdata.stat.fi/PxWeb/pxweb/en/StatFin/StatFin__rki/statfin_rki_pxt_118p.px/",
+    status: "live",
+    latestPeriod: "2026M03",
+    updatedAt: "2026-04-15T05:00:00Z",
+  },
+  cache: {
+    hit: false,
+    ttlHours: 24,
+    expiresAt: "2026-04-24T08:00:00.000Z",
+  },
+  vatRate: 0.255,
+  baseYear: "2021=100",
+  index: {
+    period: "2026M03",
+    updatedAt: "2026-04-15T05:00:00Z",
+    baseYear: "2021=100",
+    values: {
+      total: 112.7,
+      labour: 113.5,
+      materials: 113.8,
+      services: 103,
+    },
+    multipliers: {
+      total: 1.127,
+      labour: 1.135,
+      materials: 1.138,
+      services: 1.03,
+    },
+  },
+  categories: [
+    {
+      id: "facade_cladding",
+      labelFi: "Julkisivulaudoituksen uusinta",
+      labelEn: "Facade cladding renewal",
+      unit: "m2",
+      baseCostExVat: 155,
+      materialShare: 0.48,
+      labourShare: 0.45,
+      serviceShare: 0.07,
+      notes: "Planning baseline",
+      statfinMultiplier: 1.13,
+      currentCostExVat: 175.15,
+      currentCostInclVat: 219.81,
+    },
+  ],
+};
+
+describe("RenovationCostIndexPanel", () => {
+  beforeEach(() => {
+    mocks.getRenovationCostIndex.mockReset();
+  });
+
+  it("shows Statistics Finland attribution and indexed category costs", async () => {
+    mocks.getRenovationCostIndex.mockResolvedValue(response);
+
+    render(<RenovationCostIndexPanel />);
+
+    expect(screen.getByText("renovationCostIndex.loading")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Julkisivulaudoituksen uusinta")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Lähde: Tilastokeskus, Rakennuskustannusindeksi/)).toBeInTheDocument();
+    expect(screen.getByText("summary 1.127 25.5")).toBeInTheDocument();
+    expect(screen.getByText(/220 €/)).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -689,6 +689,10 @@ describe("exhaustive i18n key parity", () => {
     "renovationRoi.category.energy", "renovationRoi.category.roof", "renovationRoi.category.kitchen",
     "renovationRoi.category.bathroom", "renovationRoi.category.facade", "renovationRoi.category.windows",
     "renovationRoi.category.outdoor", "renovationRoi.category.general",
+    // renovation cost index
+    "renovationCostIndex.eyebrow", "renovationCostIndex.title", "renovationCostIndex.loading",
+    "renovationCostIndex.loadFailed", "renovationCostIndex.summary",
+    "renovationCostIndex.updated", "renovationCostIndex.fallback",
     // BOM savings
     "bomSavings.eyebrow", "bomSavings.title", "bomSavings.totalAvailable",
     "bomSavings.noSavings", "bomSavings.supplier_switch", "bomSavings.material_substitution",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -18,6 +18,9 @@ import type {
   PhotoEstimateUpload,
   ProjectMaterialTrendResponse,
   QuoteRequestPayload,
+  RenovationCostEstimateRequest,
+  RenovationCostEstimateResponse,
+  RenovationCostIndexResponse,
   RyhtiPermitMetadata,
 } from "@/types";
 
@@ -383,6 +386,13 @@ export const api = {
     apiFetch(`/pricing/history/${materialId}`),
   getProjectMaterialTrends: (projectId: string): Promise<ProjectMaterialTrendResponse> =>
     apiFetch(`/pricing/trends/project/${encodeURIComponent(projectId)}`),
+  getRenovationCostIndex: (): Promise<RenovationCostIndexResponse> =>
+    apiFetch("/pricing/renovation-cost-index"),
+  estimateRenovationCost: (data: RenovationCostEstimateRequest): Promise<RenovationCostEstimateResponse> =>
+    apiFetch("/pricing/renovation-cost-estimate", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
   getNotifications: (limit = 20): Promise<AppNotification[]> =>
     apiFetch(`/notifications?limit=${encodeURIComponent(String(limit))}`),
   getUnreadNotificationCount: (): Promise<{ unread: number }> =>

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1214,6 +1214,15 @@ const translations = {
         general: 'Yleinen',
       },
     },
+    renovationCostIndex: {
+      eyebrow: 'TILASTOKESKUS',
+      title: 'Kuukausittainen kustannusindeksi',
+      loading: 'Haetaan Tilastokeskuksen kustannusindeksiä...',
+      loadFailed: 'Tilastokeskuksen kustannusindeksiä ei voitu hakea.',
+      summary: 'Perushinnat indeksoitu kertoimella {{multiplier}} ja näytetään ALV {{vat}} % sisältyen.',
+      updated: 'Päivitetty jaksolle {{period}}.',
+      fallback: 'Näytetään viimeisin varasisäinen indeksipiste.',
+    },
     bomSavings: {
       eyebrow: 'SÄÄSTÖT',
       title: 'Kustannusoptimointi',
@@ -2704,6 +2713,15 @@ const translations = {
         general: 'General',
       },
     },
+    renovationCostIndex: {
+      eyebrow: 'STATISTICS FINLAND',
+      title: 'Monthly cost index',
+      loading: 'Loading Statistics Finland cost index...',
+      loadFailed: 'Could not load the Statistics Finland cost index.',
+      summary: 'Base prices are indexed by {{multiplier}} and shown including {{vat}}% VAT.',
+      updated: 'Updated for period {{period}}.',
+      fallback: 'Showing the latest internal fallback index point.',
+    },
     bomSavings: {
       eyebrow: 'SAVINGS',
       title: 'Cost optimization',
@@ -4102,6 +4120,15 @@ const translations = {
         outdoor: 'Utomhus',
         general: 'Allmänt',
       },
+    },
+    renovationCostIndex: {
+      eyebrow: 'STATISTIKCENTRALEN',
+      title: 'Månatligt kostnadsindex',
+      loading: 'Hämtar Statistikcentralens kostnadsindex...',
+      loadFailed: 'Kunde inte hämta Statistikcentralens kostnadsindex.',
+      summary: 'Baspriserna indexeras med {{multiplier}} och visas inklusive {{vat}} % moms.',
+      updated: 'Uppdaterad för perioden {{period}}.',
+      fallback: 'Visar den senaste interna reservindexpunkten.',
     },
     bomSavings: {
       eyebrow: 'BESPARINGAR',

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -700,6 +700,85 @@ export interface ProjectMaterialTrendResponse {
   items: MaterialTrendItem[];
 }
 
+export type RenovationCostUnit = "m2" | "m" | "unit" | "project";
+export type RenovationCostSourceStatus = "live" | "fallback";
+
+export interface RenovationCostSource {
+  name: "Tilastokeskus";
+  statistic: "Rakennuskustannusindeksi";
+  attribution: string;
+  tableId: string;
+  apiUrl: string;
+  url: string;
+  status: RenovationCostSourceStatus;
+  latestPeriod: string;
+  updatedAt: string | null;
+  error?: string;
+}
+
+export interface RenovationCostCategory {
+  id: string;
+  labelFi: string;
+  labelEn: string;
+  unit: RenovationCostUnit;
+  baseCostExVat: number;
+  materialShare: number;
+  labourShare: number;
+  serviceShare: number;
+  notes: string;
+  statfinMultiplier: number;
+  currentCostExVat: number;
+  currentCostInclVat: number;
+}
+
+export interface RenovationCostIndexResponse {
+  generatedAt: string;
+  source: RenovationCostSource;
+  cache: {
+    hit: boolean;
+    ttlHours: number;
+    expiresAt: string;
+  };
+  vatRate: number;
+  baseYear: string;
+  index: {
+    period: string;
+    updatedAt: string | null;
+    baseYear: string;
+    values: {
+      total: number;
+      labour: number;
+      materials: number;
+      services: number;
+    };
+    multipliers: {
+      total: number;
+      labour: number;
+      materials: number;
+      services: number;
+    };
+  };
+  categories: RenovationCostCategory[];
+}
+
+export interface RenovationCostEstimateRequest {
+  categoryId: string;
+  quantity: number;
+}
+
+export interface RenovationCostEstimateResponse {
+  generatedAt: string;
+  category: RenovationCostCategory;
+  quantity: number;
+  unit: RenovationCostUnit;
+  subtotalExVat: number;
+  vatRate: number;
+  vatAmount: number;
+  totalInclVat: number;
+  formula: string;
+  source: RenovationCostSource;
+}
+
 export type PriceAlertEmailFrequency = "off" | "daily" | "weekly";
 
 export interface AppNotification {


### PR DESCRIPTION
## Summary
- add a StatFin PxWeb RKI client with 24h live cache, latest-month metadata lookup, JSON-stat parsing, and fallback snapshot
- expose authenticated renovation cost-index and cost-estimate pricing endpoints with 25.5% ALV included
- add BOM-side cost-index attribution panel plus frontend API/types and locale coverage

Closes #103

## Verification
- api: npm run build
- api: npm test -- --run src/__tests__/statfin-cost-index.test.ts
- api: npm test -- --run src/__tests__/pricing.test.ts src/__tests__/statfin-cost-index.test.ts
- api: npm test -- --run
- web: npx tsc --noEmit
- web: npm test -- --run src/components/__tests__/RenovationCostIndexPanel.test.tsx src/lib/__tests__/i18n.test.ts
- web: npm test -- --run src/components/__tests__/RenovationCostIndexPanel.test.tsx src/components/__tests__/BomPanel.test.ts src/lib/__tests__/i18n.test.ts src/lib/__tests__/quote-engine.test.ts
- web: npm run build
- web: npm test -- --run
- git diff --check