### PR TITLE
feat: supplier-grouped shopping list export

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3854,6 +3854,199 @@ select:focus {
   .viewport-thermal-legend { display: none; }
 }
 
+/* Shopping list modal */
+.shopping-list-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.shopping-list-modal {
+  width: 90%;
+  max-width: 560px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-float);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+}
+
+.shopping-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.shopping-list-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.shopping-list-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.shopping-list-action-btn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.shopping-list-action-btn:hover {
+  background: var(--bg-active);
+  color: var(--text-primary);
+}
+
+.shopping-list-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.shopping-list-close-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.shopping-list-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.shopping-list-project-name {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.shopping-list-supplier-group {
+  margin-bottom: 16px;
+}
+
+.shopping-list-supplier-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 4px;
+}
+
+.shopping-list-supplier-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.shopping-list-supplier-subtotal {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.shopping-list-items {
+  display: flex;
+  flex-direction: column;
+}
+
+.shopping-list-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: baseline;
+  padding: 4px 0;
+  font-size: 12px;
+}
+
+.shopping-list-item-name {
+  color: var(--text-primary);
+}
+
+.shopping-list-item-name a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.shopping-list-item-name a:hover {
+  text-decoration: underline;
+}
+
+.shopping-list-item-qty {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.shopping-list-item-price {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.shopping-list-grand-total {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 0 4px;
+  border-top: 2px solid var(--border);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+@media print {
+  .shopping-list-overlay {
+    position: static;
+    background: none;
+    backdrop-filter: none;
+  }
+  .shopping-list-modal {
+    max-height: none;
+    border: none;
+    box-shadow: none;
+    width: 100%;
+    max-width: 100%;
+  }
+  .shopping-list-actions {
+    display: none;
+  }
+}
+
 /* Dashboard layout */
 .dash-empty {
   padding: 48px 28px;

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -17,6 +17,7 @@ import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
 import PhotoEstimatePanel from "@/components/PhotoEstimatePanel";
 import PermitCheckerPanel from "@/components/PermitCheckerPanel";
+import ShoppingListModal from "@/components/ShoppingListModal";
 import { api } from "@/lib/api";
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { interpretScene, extractSceneMaterials } from "@/lib/scene-interpreter";
@@ -1902,6 +1903,7 @@ export default function BomPanel({
   const [searchFocused, setSearchFocused] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const [activePackage, setActivePackage] = useState<PackageTierId>("standard");
+  const [showShoppingList, setShowShoppingList] = useState(false);
   const [packageDelta, setPackageDelta] = useState<number | null>(null);
   const [packageFlashKey, setPackageFlashKey] = useState(0);
   const [lockedPackageMaterials, setLockedPackageMaterials] = useState<Set<string>>(() => new Set());
@@ -2745,7 +2747,55 @@ export default function BomPanel({
             {t('bom.exportCsv')}
           </button>
         )}
+        {bom.length > 0 && (
+          <button
+            onClick={() => setShowShoppingList(true)}
+            aria-label={t('shoppingList.title')}
+            style={{
+              marginTop: 6,
+              width: "100%",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 6,
+              padding: "8px 12px",
+              fontSize: 12,
+              fontWeight: 500,
+              fontFamily: "var(--font-body)",
+              color: "var(--text-secondary)",
+              background: "var(--bg-tertiary)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--radius-sm)",
+              cursor: "pointer",
+              transition: "all 0.15s ease",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = "var(--bg-secondary)";
+              e.currentTarget.style.color = "var(--text-primary)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = "var(--bg-tertiary)";
+              e.currentTarget.style.color = "var(--text-secondary)";
+            }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="9" cy="21" r="1" />
+              <circle cx="20" cy="21" r="1" />
+              <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6" />
+            </svg>
+            {t('shoppingList.title')}
+          </button>
+        )}
       </div>
+
+      {showShoppingList && (
+        <ShoppingListModal
+          bom={bom}
+          materials={materials}
+          projectName={projectName}
+          onClose={() => setShowShoppingList(false)}
+        />
+      )}
 
       {/* Scene material sync banner */}
       {unmatchedSceneMaterials.length > 0 && unmatchedSceneMaterials.some((u) => u.matched) && (

--- a/web/src/components/ShoppingListModal.tsx
+++ b/web/src/components/ShoppingListModal.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useMemo, useCallback, useRef } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import type { BomItem, Material } from "@/types";
+
+interface ShoppingListModalProps {
+  bom: BomItem[];
+  materials: Material[];
+  projectName?: string;
+  onClose: () => void;
+}
+
+interface SupplierGroup {
+  supplier: string;
+  items: {
+    name: string;
+    quantity: number;
+    unit: string;
+    unitPrice: number;
+    total: number;
+    link: string | null;
+  }[];
+  subtotal: number;
+}
+
+export default function ShoppingListModal({
+  bom,
+  materials,
+  projectName,
+  onClose,
+}: ShoppingListModalProps) {
+  const { t, locale } = useTranslation();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const localeTag = locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB";
+
+  const supplierGroups = useMemo(() => {
+    const materialMap = new Map(materials.map((m) => [m.id, m]));
+    const groups = new Map<string, SupplierGroup>();
+
+    for (const item of bom) {
+      const mat = materialMap.get(item.material_id);
+      const pricing = mat?.pricing?.find((p) => p.is_primary) ?? mat?.pricing?.[0];
+      const supplier = pricing?.supplier_name ?? item.supplier ?? t("shoppingList.otherSupplier");
+      const unitPrice = item.unit_price ?? pricing?.unit_price ?? 0;
+      const total = unitPrice * item.quantity;
+      const link = pricing?.link ?? null;
+      const name = item.material_name ?? mat?.name ?? item.material_id;
+
+      if (!groups.has(supplier)) {
+        groups.set(supplier, { supplier, items: [], subtotal: 0 });
+      }
+      const group = groups.get(supplier)!;
+      group.items.push({ name, quantity: item.quantity, unit: item.unit, unitPrice, total, link });
+      group.subtotal += total;
+    }
+
+    return Array.from(groups.values()).sort((a, b) => b.subtotal - a.subtotal);
+  }, [bom, materials, t]);
+
+  const grandTotal = useMemo(
+    () => supplierGroups.reduce((sum, g) => sum + g.subtotal, 0),
+    [supplierGroups],
+  );
+
+  const formatPrice = useCallback(
+    (value: number) =>
+      value.toLocaleString(localeTag, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) + " €",
+    [localeTag],
+  );
+
+  const handleCopy = useCallback(() => {
+    const lines: string[] = [];
+    if (projectName) lines.push(projectName);
+    lines.push("─".repeat(40));
+    for (const group of supplierGroups) {
+      lines.push("");
+      lines.push(`📦 ${group.supplier}`);
+      for (const item of group.items) {
+        lines.push(`  ${item.name} × ${item.quantity} ${item.unit} — ${formatPrice(item.total)}`);
+      }
+      lines.push(`  ${t("shoppingList.subtotal")}: ${formatPrice(group.subtotal)}`);
+    }
+    lines.push("");
+    lines.push(`${t("shoppingList.grandTotal")}: ${formatPrice(grandTotal)}`);
+    navigator.clipboard.writeText(lines.join("\n"));
+  }, [supplierGroups, grandTotal, projectName, formatPrice, t]);
+
+  const handlePrint = useCallback(() => {
+    window.print();
+  }, []);
+
+  return (
+    <div className="shopping-list-overlay" onClick={onClose}>
+      <div
+        className="shopping-list-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("shoppingList.title")}
+      >
+        <div className="shopping-list-header">
+          <h2 className="shopping-list-title">{t("shoppingList.title")}</h2>
+          <div className="shopping-list-actions">
+            <button className="shopping-list-action-btn" onClick={handleCopy} title={t("shoppingList.copy")}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+              {t("shoppingList.copy")}
+            </button>
+            <button className="shopping-list-action-btn" onClick={handlePrint} title={t("shoppingList.print")}>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="6 9 6 2 18 2 18 9" />
+                <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+                <rect x="6" y="14" width="12" height="8" />
+              </svg>
+              {t("shoppingList.print")}
+            </button>
+            <button className="shopping-list-close-btn" onClick={onClose} aria-label={t("shoppingList.close")}>
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="shopping-list-content" ref={contentRef}>
+          {projectName && <div className="shopping-list-project-name">{projectName}</div>}
+
+          {supplierGroups.map((group) => (
+            <div key={group.supplier} className="shopping-list-supplier-group">
+              <div className="shopping-list-supplier-header">
+                <span className="shopping-list-supplier-name">{group.supplier}</span>
+                <span className="shopping-list-supplier-subtotal">{formatPrice(group.subtotal)}</span>
+              </div>
+              <div className="shopping-list-items">
+                {group.items.map((item, i) => (
+                  <div key={i} className="shopping-list-item">
+                    <div className="shopping-list-item-name">
+                      {item.link ? (
+                        <a href={item.link} target="_blank" rel="noopener noreferrer">
+                          {item.name}
+                          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginLeft: 4, verticalAlign: "middle" }}>
+                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                            <polyline points="15 3 21 3 21 9" />
+                            <line x1="10" y1="14" x2="21" y2="3" />
+                          </svg>
+                        </a>
+                      ) : (
+                        item.name
+                      )}
+                    </div>
+                    <div className="shopping-list-item-qty">
+                      {item.quantity} {item.unit}
+                    </div>
+                    <div className="shopping-list-item-price">{formatPrice(item.total)}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+
+          <div className="shopping-list-grand-total">
+            <span>{t("shoppingList.grandTotal")}</span>
+            <span>{formatPrice(grandTotal)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1099,6 +1099,15 @@ const translations = {
       packageLock: 'Lukitse {{name}} pakettivaihdoilta',
       packageUnlock: 'Poista {{name}} pakettivaihdon lukitus',
     },
+    shoppingList: {
+      title: 'Ostoslista',
+      copy: 'Kopioi',
+      print: 'Tulosta',
+      close: 'Sulje',
+      subtotal: 'Välisumma',
+      grandTotal: 'Yhteensä',
+      otherSupplier: 'Muu toimittaja',
+    },
     bomTrends: {
       eyebrow: 'HINTATRENDI',
       title: 'Ostoajankohta',
@@ -2603,6 +2612,15 @@ const translations = {
       packageLock: 'Lock {{name}} from package switches',
       packageUnlock: 'Unlock {{name}} for package switches',
     },
+    shoppingList: {
+      title: 'Shopping list',
+      copy: 'Copy',
+      print: 'Print',
+      close: 'Close',
+      subtotal: 'Subtotal',
+      grandTotal: 'Grand total',
+      otherSupplier: 'Other supplier',
+    },
     bomTrends: {
       eyebrow: 'PRICE TREND',
       title: 'Purchase timing',
@@ -4015,6 +4033,15 @@ const translations = {
       packageLocked: '{{count}} låsta',
       packageLock: 'Lås {{name}} från paketbyten',
       packageUnlock: 'Lås upp {{name}} för paketbyten',
+    },
+    shoppingList: {
+      title: 'Inköpslista',
+      copy: 'Kopiera',
+      print: 'Skriv ut',
+      close: 'Stäng',
+      subtotal: 'Delsumma',
+      grandTotal: 'Totalt',
+      otherSupplier: 'Annan leverantör',
     },
     bomTrends: {
       eyebrow: 'PRISTREND',


### PR DESCRIPTION
## Summary
- Shopping list modal groups BOM items by supplier with subtotals and grand total
- Copy to clipboard as formatted text (for WhatsApp/email to contractors)
- Print-friendly layout with CSS @media print
- Product links open supplier pages in new tabs where available
- i18n for Finnish, English, and Swedish

Fixes #147

## Test plan
- [x] TypeScript compiles with no new errors
- [x] i18n key parity verified (47 tests pass)
- [ ] Click "Shopping list" button in BOM panel → modal opens
- [ ] Items correctly grouped by supplier
- [ ] Copy button copies formatted text
- [ ] Print button triggers browser print
- [ ] Product links work
- [ ] Modal closes on overlay click or X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)