### PR TITLE
test(a11y): add axe accessibility smoke coverage

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "@types/node": "^20.11.0",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
+        "axe-core": "^4.11.3",
         "jsdom": "^29.0.2",
         "typescript": "^5.3.3",
         "vitest": "^1.2.0"
@@ -3816,6 +3817,16 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/balanced-match": {

--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^20.11.0",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
+    "axe-core": "^4.11.3",
     "jsdom": "^29.0.2",
     "typescript": "^5.3.3",
     "vitest": "^1.2.0"

--- a/web/src/__tests__/accessibility-axe.test.tsx
+++ b/web/src/__tests__/accessibility-axe.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import axe from "axe-core";
+import CommandPalette, { type Command } from "@/components/CommandPalette";
+import ConfirmDialog from "@/components/ConfirmDialog";
+import SaveStatusIndicator from "@/components/SaveStatusIndicator";
+import { ToastContainer } from "@/components/Toast";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const map: Record<string, string> = {
+        "commandPalette.title": "Command Palette",
+        "commandPalette.placeholder": "Search commands",
+        "commandPalette.noResults": "No results found",
+        "commandPalette.categoryRecent": "Recent",
+        "commandPalette.categoryScene": "Scene",
+        "commandPalette.categoryProject": "Project",
+        "commandPalette.categoryPreferences": "Preferences",
+        "commandPalette.navigate": "Navigate",
+        "commandPalette.execute": "Run",
+        "commandPalette.close": "Close",
+        "commandPalette.stateOn": "On",
+        "commandPalette.stateOff": "Off",
+        "cmd.save": "Save",
+        "cmd.saveEn": "Save project",
+        "cmd.wireframe": "Toggle wireframe",
+        "cmd.wireframeEn": "Toggle wireframe",
+        "dialog.confirm": "Confirm",
+        "dialog.cancel": "Cancel",
+        "editor.save": "Save",
+        "saveStatus.error": "Save failed",
+        "saveStatus.saving": "Saving",
+        "saveStatus.unsaved": "Unsaved changes",
+        "saveStatus.saved": "Saved",
+        "toast.dismiss": "Dismiss",
+        "toast.overflowMore": `+${params?.count ?? "?"} more`,
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+Element.prototype.scrollIntoView = vi.fn();
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+async function expectNoAxeViolations(container: HTMLElement) {
+  const results = await axe.run(container, {
+    rules: {
+      // These tests render isolated components, not full app pages with landmarks.
+      region: { enabled: false },
+      // axe-core's contrast rule depends on canvas APIs that jsdom does not implement.
+      "color-contrast": { enabled: false },
+    },
+  });
+
+  expect(
+    results.violations.map((violation) => ({
+      id: violation.id,
+      impact: violation.impact,
+      targets: violation.nodes.map((node) => node.target.join(" ")),
+    })),
+  ).toEqual([]);
+}
+
+function makeCommand(overrides: Partial<Command> = {}): Command {
+  return {
+    id: "save",
+    labelKey: "cmd.save",
+    labelSecondaryKey: "cmd.saveEn",
+    action: vi.fn(),
+    category: "project",
+    ...overrides,
+  };
+}
+
+describe("axe-core accessibility smoke tests", () => {
+  it("keeps the command palette free of automated axe violations", async () => {
+    const { container } = render(
+      <CommandPalette
+        open
+        onClose={vi.fn()}
+        commands={[
+          makeCommand(),
+          makeCommand({
+            id: "wireframe",
+            labelKey: "cmd.wireframe",
+            labelSecondaryKey: "cmd.wireframeEn",
+            category: "scene",
+            isActive: true,
+          }),
+        ]}
+      />,
+    );
+
+    await expectNoAxeViolations(container);
+  });
+
+  it("keeps the confirmation dialog free of automated axe violations", async () => {
+    const { container } = render(
+      <ConfirmDialog
+        open
+        title="Delete project"
+        message="This cannot be undone."
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+        variant="danger"
+      />,
+    );
+
+    await expectNoAxeViolations(container);
+  });
+
+  it("keeps live status widgets free of automated axe violations", async () => {
+    const { container } = render(
+      <>
+        <SaveStatusIndicator status="saved" lastSaved="09:00" />
+        <ToastContainer
+          toasts={[]}
+          onDismiss={vi.fn()}
+        />
+      </>,
+    );
+
+    await expectNoAxeViolations(container);
+  });
+});


### PR DESCRIPTION
## Summary
- add `axe-core` as a web dev dependency so accessibility regressions can be checked in CI
- add automated axe smoke tests for the command palette, confirmation dialog, and live status widgets
- keep component-isolated tests honest by disabling only landmark-region checks and jsdom-incompatible color contrast checks

## Verification
- npm install --save-dev axe-core
- ./node_modules/.bin/tsc --noEmit
- npm test -- --run src/__tests__/accessibility-axe.test.tsx
- npm test -- --run
- npm run build
- git diff --check

Refs #41

Note: this starts the automated axe-core coverage requested by #41, but it is not a full page-level WCAG audit. Remaining #41 work still needs page-level axe/Lighthouse runs, contrast review, form-field audit, and manual screen-reader testing.
