### PR TITLE
fix(a11y): improve required form accessibility

### DIFF
--- a/web/src/__tests__/accessibility-foundation.test.ts
+++ b/web/src/__tests__/accessibility-foundation.test.ts
@@ -72,4 +72,33 @@ describe("accessibility foundation", () => {
     expect(editor).toContain('aria-atomic="true"');
     expect(editor).toContain("editor.sceneChangeAnnouncement");
   });
+
+  it("associates required auth and password fields with labels and ARIA required state", () => {
+    const forgotPassword = readSource("../app/forgot-password/page.tsx");
+    const resetPassword = readSource("../app/reset-password/page.tsx");
+    const settings = readSource("../app/settings/page.tsx");
+    const loginForm = readSource("../components/LoginForm.tsx");
+
+    expect(forgotPassword).toContain('htmlFor="forgot-password-email"');
+    expect(forgotPassword).toContain('id="forgot-password-email"');
+    expect(forgotPassword).toContain('aria-required="true"');
+    expect(forgotPassword).toContain('id="forgot-password-error"');
+    expect(forgotPassword).toContain('role="alert"');
+
+    expect(resetPassword).toContain('htmlFor="reset-password-new"');
+    expect(resetPassword).toContain('id="reset-password-new"');
+    expect(resetPassword).toContain('htmlFor="reset-password-confirm"');
+    expect(resetPassword).toContain('id="reset-password-confirm"');
+    expect(resetPassword.match(/aria-required="true"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(resetPassword).toContain('id="reset-password-error"');
+    expect(resetPassword).toContain('role="alert"');
+
+    expect(settings.match(/aria-required="true"/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(settings).toContain('autoComplete="current-password"');
+    expect(settings).toContain('autoComplete="new-password"');
+
+    expect(loginForm.match(/aria-required="true"/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(loginForm).toContain('htmlFor="login-email"');
+    expect(loginForm).toContain('htmlFor="login-password"');
+  });
 });

--- a/web/src/app/forgot-password/page.tsx
+++ b/web/src/app/forgot-password/page.tsx
@@ -92,23 +92,26 @@ export default function ForgotPasswordPage() {
 
             <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 18 }}>
               <div>
-                <label className="label-mono" style={{ display: "block", marginBottom: 8 }}>
+                <label htmlFor="forgot-password-email" className="label-mono" style={{ display: "block", marginBottom: 8 }}>
                   {t("auth.email")}
                 </label>
                 <input
+                  id="forgot-password-email"
                   className="input"
                   type="email"
                   placeholder={t("auth.emailPlaceholder")}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   required
+                  aria-required="true"
+                  aria-describedby={error ? "forgot-password-error" : undefined}
                   autoComplete="email"
                   autoFocus
                 />
               </div>
 
               {error && (
-                <div role="alert" style={{
+                <div id="forgot-password-error" role="alert" style={{
                   padding: "10px 14px",
                   borderRadius: "var(--radius-md)",
                   background: "var(--danger-dim)",

--- a/web/src/app/reset-password/page.tsx
+++ b/web/src/app/reset-password/page.tsx
@@ -113,16 +113,19 @@ function ResetPasswordForm() {
 
       <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 18 }}>
         <div>
-          <label className="label-mono" style={{ display: "block", marginBottom: 8 }}>
+          <label htmlFor="reset-password-new" className="label-mono" style={{ display: "block", marginBottom: 8 }}>
             {t("auth.resetPasswordNew")}
           </label>
           <input
+            id="reset-password-new"
             className="input"
             type="password"
             placeholder={t("auth.resetPasswordNewPlaceholder")}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
+            aria-required="true"
+            aria-describedby={error ? "reset-password-error" : undefined}
             minLength={8}
             autoComplete="new-password"
             autoFocus
@@ -130,23 +133,26 @@ function ResetPasswordForm() {
         </div>
 
         <div>
-          <label className="label-mono" style={{ display: "block", marginBottom: 8 }}>
+          <label htmlFor="reset-password-confirm" className="label-mono" style={{ display: "block", marginBottom: 8 }}>
             {t("auth.resetPasswordConfirm")}
           </label>
           <input
+            id="reset-password-confirm"
             className="input"
             type="password"
             placeholder={t("auth.resetPasswordConfirmPlaceholder")}
             value={confirmPassword}
             onChange={(e) => setConfirmPassword(e.target.value)}
             required
+            aria-required="true"
+            aria-describedby={error ? "reset-password-error" : undefined}
             minLength={8}
             autoComplete="new-password"
           />
         </div>
 
         {error && (
-          <div style={{
+          <div id="reset-password-error" role="alert" style={{
             padding: "10px 14px",
             borderRadius: "var(--radius-md)",
             background: "var(--danger-dim)",

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -551,6 +551,8 @@ export default function SettingsPage() {
                 onChange={(e) => setCurrentPassword(e.target.value)}
                 placeholder={t("settings.currentPassword")}
                 required
+                aria-required="true"
+                autoComplete="current-password"
               />
             </div>
             <div>
@@ -569,6 +571,8 @@ export default function SettingsPage() {
                 onChange={(e) => setNewPassword(e.target.value)}
                 placeholder={t("settings.newPassword")}
                 required
+                aria-required="true"
+                autoComplete="new-password"
               />
             </div>
             <div>
@@ -587,6 +591,8 @@ export default function SettingsPage() {
                 onChange={(e) => setConfirmPassword(e.target.value)}
                 placeholder={t("settings.confirmPassword")}
                 required
+                aria-required="true"
+                autoComplete="new-password"
               />
             </div>
             <div>

--- a/web/src/components/LoginForm.tsx
+++ b/web/src/components/LoginForm.tsx
@@ -303,6 +303,7 @@ export default function LoginForm({
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   required
+                  aria-required="true"
                   autoComplete="name"
                 />
               </div>
@@ -317,6 +318,7 @@ export default function LoginForm({
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
+                aria-required="true"
                 autoComplete="email"
               />
             </div>
@@ -330,6 +332,7 @@ export default function LoginForm({
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
+                aria-required="true"
                 minLength={isRegister ? 8 : undefined}
                 autoComplete={isRegister ? "new-password" : "current-password"}
               />


### PR DESCRIPTION
## Summary
- associate forgot/reset password labels with their inputs via `htmlFor`/`id`
- mark required auth and password fields with `aria-required="true"`
- connect forgot/reset password errors to fields with `aria-describedby` and alert regions
- add regression coverage for the required-field accessibility contract

## Verification
- npm ci
- ./node_modules/.bin/tsc --noEmit
- npm test -- --run src/__tests__/accessibility-foundation.test.ts src/__tests__/LoginForm.test.tsx
- npm test -- --run
- npm run build
- git diff --check

Refs #41

Note: this addresses a concrete #41 forms/inputs gap. Full WCAG certification still requires broader form audits and manual assistive-tech testing.
