### PR TITLE
Fix reduced-motion accessibility coverage

### DIFF
--- a/web/src/__tests__/accessibility-foundation.test.ts
+++ b/web/src/__tests__/accessibility-foundation.test.ts
@@ -27,6 +27,21 @@ describe("accessibility foundation", () => {
     expect(css).toContain("clip: rect(0, 0, 0, 0)");
   });
 
+  it("disables global and view-transition motion for reduced-motion users", () => {
+    const css = readSource("../app/globals.css");
+
+    expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(css).toContain("animation-delay: 0ms !important");
+    expect(css).toContain("animation-duration: 0.01ms !important");
+    expect(css).toContain("animation-iteration-count: 1 !important");
+    expect(css).toContain("transition-delay: 0ms !important");
+    expect(css).toContain("transition-duration: 0.01ms !important");
+    expect(css).toContain("scroll-behavior: auto !important");
+    expect(css).toContain("::view-transition-old(*)");
+    expect(css).toContain("::view-transition-new(*)");
+    expect(css).toContain("animation: none !important");
+  });
+
   it("makes the 3D viewport keyboard-operable and described for assistive tech", () => {
     const viewport = readSource("../components/Viewport3D.tsx");
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -5927,8 +5927,10 @@ select:focus {
 /* === Reduced motion === */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
+    animation-delay: 0ms !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
+    transition-delay: 0ms !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
@@ -6624,6 +6626,13 @@ select:focus {
 ::view-transition-new(*) {
   animation-duration: 0.25s;
   animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
 }
 
 /* ── Custom tooltips via data-tooltip attribute ─────────────────── */


### PR DESCRIPTION
Refs #41.\n\n## Summary\n- remove remaining reduced-motion delays from global CSS animations/transitions\n- disable View Transitions API animations when users prefer reduced motion\n- add accessibility foundation regression coverage for the reduced-motion safety net\n\n## Verification\n- npm test -- --run src/__tests__/accessibility-foundation.test.ts\n- npx tsc --noEmit\n- npm test -- --run\n- npm run build