### PR TITLE
fix: announce async a11y states

### DIFF
--- a/web/src/__tests__/accessibility-foundation.test.ts
+++ b/web/src/__tests__/accessibility-foundation.test.ts
@@ -130,4 +130,17 @@ describe("accessibility foundation", () => {
     expect(projectEditor).toContain("aria-label={t('share.linkLabel')}");
     expect(bomPanel).toContain("aria-label={t('pricing.searchMaterials')}");
   });
+
+  it("announces async loading and error states to assistive tech", () => {
+    const addressSearch = readSource("../components/AddressSearch.tsx");
+    const projectEditor = readSource("../app/project/[id]/page.tsx");
+    const sharedProject = readSource("../app/shared/[token]/SharedProjectContent.tsx");
+
+    expect(addressSearch.match(/className="inline-error-banner" role="alert"/g)?.length).toBeGreaterThanOrEqual(3);
+    expect(projectEditor).toContain('className="anim-up" role="alert"');
+    expect(sharedProject.match(/role="status"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(sharedProject.match(/aria-live="polite"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(sharedProject.match(/aria-busy="true"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(sharedProject).toContain('role="alert"');
+  });
 });

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1917,7 +1917,7 @@ export default function ProjectPage() {
 
   if (loadError) {
     return (
-      <div className="anim-up" style={{ padding: 60, textAlign: "center" }}>
+      <div className="anim-up" role="alert" style={{ padding: 60, textAlign: "center" }}>
         <h2 className="heading-display" style={{ marginBottom: 8 }}>{t('editor.error')}</h2>
         <p style={{ color: "var(--danger)", marginBottom: 16 }}>{t('editor.errorLoadProject')}</p>
         <button className="btn btn-primary" onClick={() => router.push("/")}>

--- a/web/src/app/shared/[token]/SharedProjectContent.tsx
+++ b/web/src/app/shared/[token]/SharedProjectContent.tsx
@@ -12,7 +12,7 @@ import type { BomItem, Project } from "@/types";
 function Viewport3DLoading() {
   const { t } = useTranslation();
   return (
-    <div style={{ width: "100%", height: "100%", background: "var(--bg-secondary)", borderRadius: "var(--radius-md)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-muted)", fontSize: 13 }}>
+    <div role="status" aria-live="polite" aria-busy="true" style={{ width: "100%", height: "100%", background: "var(--bg-secondary)", borderRadius: "var(--radius-md)", display: "flex", alignItems: "center", justifyContent: "center", color: "var(--text-muted)", fontSize: 13 }}>
       {t('editor.loading3D')}
     </div>
   );
@@ -61,7 +61,7 @@ export default function SharedProjectContent({ token }: { token: string }) {
         background: "var(--bg-primary)",
         color: "var(--text-muted)",
         fontSize: 14,
-      }}>
+      }} role="status" aria-live="polite" aria-busy="true">
         {t('editor.loadingProject')}
       </div>
     );
@@ -79,7 +79,7 @@ export default function SharedProjectContent({ token }: { token: string }) {
         gap: 12,
         padding: 40,
         textAlign: "center",
-      }}>
+      }} role="alert">
         <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
           <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />

--- a/web/src/components/AddressSearch.tsx
+++ b/web/src/components/AddressSearch.tsx
@@ -305,7 +305,7 @@ export default function AddressSearch({
                 </div>
               </div>
               {createError && (
-                <div className="inline-error-banner">
+                <div className="inline-error-banner" role="alert">
                   {t('search.createError')}
                 </div>
               )}
@@ -596,13 +596,13 @@ export default function AddressSearch({
               )}
 
               {editError && (
-                <div className="inline-error-banner">
+                <div className="inline-error-banner" role="alert">
                   {t('search.updateError')}
                 </div>
               )}
 
               {createError && (
-                <div className="inline-error-banner">
+                <div className="inline-error-banner" role="alert">
                   {t('search.createError')}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- add assertive alerts for project load failures and address search create/update errors
- expose shared project loading states as polite busy statuses and shared project failures as alerts
- extend the accessibility foundation test to lock these async semantics in

## Testing
- npm test -- --run src/__tests__/accessibility-foundation.test.ts
- npx tsc --noEmit
- npm test -- --run
- npm run build

Fixes #41