### PR TITLE
feat: PWA service worker for offline resilience

### DIFF
--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,12 +1,15 @@
 {
-  "name": "Helscoop",
+  "name": "Helscoop — Suunnittele remonttisi 3D:ssä",
   "short_name": "Helscoop",
   "description": "Finnish house visualization and renovation platform",
   "start_url": "/",
   "display": "standalone",
+  "orientation": "any",
   "background_color": "#12110f",
   "theme_color": "#12110f",
+  "categories": ["utilities", "lifestyle"],
+  "lang": "fi",
   "icons": [
-    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml" }
+    { "src": "/icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
   ]
 }

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,51 @@
+const CACHE_NAME = "helscoop-v1";
+const STATIC_ASSETS = [
+  "/",
+  "/manifest.json",
+  "/icon.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+
+  if (url.pathname.startsWith("/api/")) return;
+
+  if (url.pathname.match(/\.(js|css|woff2?|svg|png|jpg|ico)$/)) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then((cache) =>
+        cache.match(request).then((cached) => {
+          const fetched = fetch(request).then((response) => {
+            if (response.ok) cache.put(request, response.clone());
+            return response;
+          });
+          return cached || fetched;
+        })
+      )
+    );
+    return;
+  }
+
+  event.respondWith(
+    fetch(request).catch(() => caches.match(request))
+  );
+});

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -102,6 +102,11 @@ export default function RootLayout({
             __html: `(function(){try{var l=localStorage.getItem("helscoop_locale")||"fi";document.documentElement.lang=l}catch(e){}})()`
           }}
         />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}`
+          }}
+        />
         {/* Google Identity Services — for Google Sign-In */}
         <script src="https://accounts.google.com/gsi/client" async defer />
         {/* Apple JS SDK — for Sign in with Apple */}


### PR DESCRIPTION
## Summary
- Add service worker (`sw.js`) with stale-while-revalidate caching for static assets (JS, CSS, fonts, images)
- Network-first for navigation, cache fallback for offline access
- API requests bypass the cache entirely
- Register service worker from layout.tsx on page load
- Enhanced `manifest.json` with orientation, categories, lang fields for better PWA installability

## Test plan
- [ ] Load the app, check DevTools > Application > Service Workers shows registered worker
- [ ] Go offline (DevTools Network tab), reload — verify cached pages load
- [ ] Verify API calls are not cached (create/edit project while online, check data persists)
- [ ] On mobile, verify "Add to Home Screen" prompt or install option appears

Fixes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)