### PR TITLE
feat: add renovation roadmap planning panel

### DIFF
--- a/web/src/__tests__/renovation-roadmap-panel.test.tsx
+++ b/web/src/__tests__/renovation-roadmap-panel.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it, vi } from "vitest";
+import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
+import type { BomItem, Material } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    t: (key: string) => key,
+  }),
+}));
+
+const materials: Material[] = [
+  {
+    id: "concrete",
+    name: "Ready-mix concrete",
+    name_fi: "Valmisbetoni",
+    name_en: "Ready-mix concrete",
+    category_name: "foundation",
+    category_name_fi: "Perustus",
+    image_url: null,
+    pricing: [{ unit_price: 100, unit: "m3", supplier_name: "Stark", is_primary: true }],
+    tags: ["foundation"],
+  },
+  {
+    id: "roof",
+    name: "Roof membrane",
+    name_fi: "Kattokalvo",
+    name_en: "Roof membrane",
+    category_name: "roofing",
+    category_name_fi: "Katto",
+    image_url: null,
+    pricing: [{ unit_price: 10, unit: "m2", supplier_name: "K-Rauta", is_primary: true }],
+    tags: ["roof"],
+  },
+];
+
+const bom: BomItem[] = [
+  { material_id: "concrete", quantity: 2, unit: "m3" },
+  { material_id: "roof", quantity: 25, unit: "m2" },
+];
+
+describe("RenovationRoadmapPanel", () => {
+  it("renders a roadmap timeline and checklist", () => {
+    render(<RenovationRoadmapPanel bom={bom} materials={materials} projectName="Roof extension" />);
+
+    expect(screen.getByTestId("renovation-roadmap-panel")).toBeInTheDocument();
+    expect(screen.getByText("Renovation roadmap")).toBeInTheDocument();
+    expect(screen.getAllByText("Groundwork and foundation").length).toBeGreaterThan(0);
+    expect(screen.getByText("Permit and inspection checklist")).toBeInTheDocument();
+  });
+
+  it("copies contractor handoff text", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<RenovationRoadmapPanel bom={bom} materials={materials} projectName="Roof extension" />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy for contractor" }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    expect(writeText.mock.calls[0][0]).toContain("renovation execution roadmap");
+  });
+});

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -13,6 +13,7 @@ import BomSavingsPanel, { type BomPriceOverride } from "@/components/BomSavingsP
 import QuoteRequestModal from "@/components/QuoteRequestModal";
 import HouseholdDeductionPanel from "@/components/HouseholdDeductionPanel";
 import RenovationRoiPanel from "@/components/RenovationRoiPanel";
+import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
 import PhotoEstimatePanel from "@/components/PhotoEstimatePanel";
@@ -2751,6 +2752,15 @@ export default function BomPanel({
         )}
         {projectId && (
           <RyhtiSubmissionPanel projectId={projectId} bomCount={bom.length} buildingInfo={buildingInfo} />
+        )}
+        {bom.length > 0 && (
+          <RenovationRoadmapPanel
+            bom={bom}
+            materials={materials}
+            buildingInfo={buildingInfo}
+            projectName={projectName}
+            projectDescription={projectDescription}
+          />
         )}
         {bom.length > 0 && (
           <button

--- a/web/src/components/RenovationRoadmapPanel.tsx
+++ b/web/src/components/RenovationRoadmapPanel.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import {
+  buildRenovationRoadmap,
+  formatRoadmapHandoff,
+  type RoadmapPhase,
+} from "@/lib/renovation-roadmap";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+import type { LocalizedText } from "@/lib/permit-checker";
+
+interface RenovationRoadmapPanelProps {
+  bom: BomItem[];
+  materials: Material[];
+  buildingInfo?: BuildingInfo | null;
+  projectName?: string;
+  projectDescription?: string;
+}
+
+const COPY = {
+  fi: {
+    eyebrow: "Toteutuspolku",
+    title: "Remontin tiekartta",
+    subtitle: "Järjestä materiaalilista työvaiheiksi, lupa-askeliksi ja urakoitsijavastuiksi.",
+    duration: "Arvioitu kesto",
+    permit: "Lupa-arvio",
+    cost: "Materiaalit",
+    weeks: "viikkoa",
+    copy: "Kopioi urakoitsijalle",
+    copied: "Kopioitu",
+    print: "Tulosta / PDF",
+    contractorMode: "Urakoitsijat",
+    diyMode: "Teen itse",
+    critical: "Kriittinen polku",
+    overlap: "Voi limittyä",
+    bomRows: "BOM-rivit",
+    noRows: "Ei suoria materiaalirivejä",
+    checklist: "Lupa- ja tarkistuslista",
+    required: "Pakollinen / todennäköinen",
+    optional: "Tarkista tarvittaessa",
+    owner: "Vastuu",
+    timing: "Milloin",
+    fee: "Kulu",
+    assumptions: "Oletukset",
+    diyHint: "Omatoimisesti: varaa työkalut, nostot, jätehuolto ja tarkastukset ennen vaiheen alkua.",
+  },
+  en: {
+    eyebrow: "Execution path",
+    title: "Renovation roadmap",
+    subtitle: "Turn the material list into work phases, permit steps, and contractor responsibilities.",
+    duration: "Estimated duration",
+    permit: "Permit estimate",
+    cost: "Materials",
+    weeks: "weeks",
+    copy: "Copy for contractor",
+    copied: "Copied",
+    print: "Print / PDF",
+    contractorMode: "Contractors",
+    diyMode: "DIY",
+    critical: "Critical path",
+    overlap: "Can overlap",
+    bomRows: "BOM rows",
+    noRows: "No direct material rows",
+    checklist: "Permit and inspection checklist",
+    required: "Required / likely",
+    optional: "Check if needed",
+    owner: "Owner",
+    timing: "Timing",
+    fee: "Fee",
+    assumptions: "Assumptions",
+    diyHint: "DIY mode: reserve tools, lifting, waste handling, and inspections before this phase starts.",
+  },
+} as const;
+
+function text(value: LocalizedText, locale: "fi" | "en"): string {
+  return value[locale] ?? value.en;
+}
+
+function formatEur(value: number, locale: string): string {
+  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} €`;
+}
+
+function phaseTone(index: number): { background: string; border: string; color: string } {
+  const tones = [
+    { background: "rgba(229,160,75,0.16)", border: "rgba(229,160,75,0.42)", color: "var(--amber)" },
+    { background: "rgba(74,124,89,0.14)", border: "rgba(74,124,89,0.38)", color: "var(--forest)" },
+    { background: "rgba(96,125,139,0.15)", border: "rgba(96,125,139,0.35)", color: "var(--text-secondary)" },
+    { background: "rgba(59,130,246,0.12)", border: "rgba(59,130,246,0.32)", color: "#6a9fb5" },
+  ];
+  return tones[index % tones.length];
+}
+
+export default function RenovationRoadmapPanel({
+  bom,
+  materials,
+  buildingInfo,
+  projectName,
+  projectDescription,
+}: RenovationRoadmapPanelProps) {
+  const { locale } = useTranslation();
+  const roadmapLocale: "fi" | "en" = locale === "fi" ? "fi" : "en";
+  const copy = COPY[roadmapLocale];
+  const [deliveryMode, setDeliveryMode] = useState<"contractor" | "diy">("contractor");
+  const [copied, setCopied] = useState(false);
+
+  const roadmap = useMemo(
+    () => buildRenovationRoadmap({ bom, materials, buildingInfo, projectName, projectDescription }),
+    [bom, buildingInfo, materials, projectDescription, projectName],
+  );
+
+  if (bom.length === 0) return null;
+
+  const copyHandoff = async () => {
+    await navigator.clipboard.writeText(formatRoadmapHandoff(roadmap, roadmapLocale));
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <section
+      data-testid="renovation-roadmap-panel"
+      aria-labelledby="renovation-roadmap-title"
+      style={{
+        marginTop: 12,
+        padding: 14,
+        borderRadius: "var(--radius-md)",
+        border: "1px solid rgba(229,160,75,0.24)",
+        background: "linear-gradient(160deg, rgba(229,160,75,0.12), rgba(22,27,31,0.42))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <div className="label-mono" style={{ color: "var(--amber)", fontSize: 10, marginBottom: 4 }}>
+            {copy.eyebrow}
+          </div>
+          <h4 id="renovation-roadmap-title" style={{ margin: 0, color: "var(--text-primary)", fontSize: 15 }}>
+            {copy.title}
+          </h4>
+          <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.4 }}>
+            {copy.subtitle}
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 5, flexShrink: 0 }}>
+          <button
+            type="button"
+            onClick={() => setDeliveryMode("contractor")}
+            aria-pressed={deliveryMode === "contractor"}
+            className="category-chip"
+            data-active={deliveryMode === "contractor"}
+          >
+            {copy.contractorMode}
+          </button>
+          <button
+            type="button"
+            onClick={() => setDeliveryMode("diy")}
+            aria-pressed={deliveryMode === "diy"}
+            className="category-chip"
+            data-active={deliveryMode === "diy"}
+          >
+            {copy.diyMode}
+          </button>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8, marginTop: 12 }}>
+        <Metric label={copy.duration} value={`${roadmap.totalWeeks} ${copy.weeks}`} />
+        <Metric label={copy.permit} value={text(roadmap.permitAssessment.permitType, roadmapLocale)} />
+        <Metric label={copy.cost} value={formatEur(roadmap.totalCost, locale)} />
+      </div>
+
+      <div
+        aria-label="Roadmap timeline"
+        style={{
+          position: "relative",
+          marginTop: 14,
+          padding: "12px 10px",
+          borderRadius: "var(--radius-sm)",
+          border: "1px solid var(--border)",
+          background: "var(--bg-tertiary)",
+        }}
+      >
+        <div style={{ display: "grid", gap: 7 }}>
+          {roadmap.phases.map((phase, index) => (
+            <TimelineRow key={phase.id} phase={phase} index={index} totalWeeks={roadmap.totalWeeks} locale={roadmapLocale} />
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 7, marginTop: 12 }}>
+        {roadmap.phases.map((phase, index) => {
+          const tone = phaseTone(index);
+          return (
+            <details
+              key={phase.id}
+              open={phase.criticalPath || phase.items.length > 0}
+              style={{
+                border: `1px solid ${tone.border}`,
+                borderRadius: "var(--radius-sm)",
+                background: "rgba(255,255,255,0.025)",
+                overflow: "hidden",
+              }}
+            >
+              <summary
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 8,
+                  padding: "9px 10px",
+                  cursor: "pointer",
+                  color: "var(--text-primary)",
+                  fontSize: 12,
+                  fontWeight: 800,
+                }}
+              >
+                <span>{text(phase.title, roadmapLocale)}</span>
+                <span style={{ color: tone.color, fontSize: 10, fontWeight: 800 }}>
+                  W{phase.startWeek + 1}-{phase.startWeek + phase.durationWeeks}
+                </span>
+              </summary>
+              <div style={{ padding: "0 10px 10px" }}>
+                <p style={{ margin: "0 0 8px", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.4 }}>
+                  {text(phase.summary, roadmapLocale)}
+                </p>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 7 }}>
+                  <Metric label={deliveryMode === "diy" ? copy.diyMode : copy.contractorMode} value={deliveryMode === "diy" ? text(phase.crew, roadmapLocale) : text(phase.contractorType, roadmapLocale)} />
+                  <Metric label={copy.cost} value={formatEur(phase.estimatedCost, locale)} muted={phase.estimatedCost === 0} />
+                  <Metric label={copy.critical} value={phase.criticalPath ? "Yes" : "No"} muted={!phase.criticalPath} />
+                  <Metric
+                    label={copy.overlap}
+                    value={phase.canOverlapWith.length > 0 ? phase.canOverlapWith.join(", ") : "-"}
+                    muted={phase.canOverlapWith.length === 0}
+                  />
+                </div>
+                {deliveryMode === "diy" && (
+                  <p style={{ margin: "8px 0 0", color: "var(--amber)", fontSize: 10, lineHeight: 1.4 }}>
+                    {copy.diyHint}
+                  </p>
+                )}
+                <div className="label-mono" style={{ marginTop: 9, marginBottom: 5, color: "var(--text-muted)", fontSize: 10 }}>
+                  {copy.bomRows}
+                </div>
+                {phase.items.length > 0 ? (
+                  <ul style={{ margin: 0, paddingLeft: 16, display: "grid", gap: 3 }}>
+                    {phase.items.slice(0, 6).map((item) => (
+                      <li key={`${phase.id}-${item.materialId}-${item.name}`} style={{ color: "var(--text-secondary)", fontSize: 10, lineHeight: 1.35 }}>
+                        {item.name}: {item.quantity.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} {item.unit} · {formatEur(item.estimatedCost, locale)}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p style={{ margin: 0, color: "var(--text-muted)", fontSize: 10 }}>{copy.noRows}</p>
+                )}
+              </div>
+            </details>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 12, padding: 10, borderRadius: "var(--radius-sm)", border: "1px solid var(--border)", background: "var(--bg-secondary)" }}>
+        <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 10, marginBottom: 6 }}>
+          {copy.checklist}
+        </div>
+        <div style={{ display: "grid", gap: 6 }}>
+          {roadmap.checklist.map((item) => (
+            <div key={item.id} style={{ display: "grid", gridTemplateColumns: "18px 1fr", gap: 7, alignItems: "start" }}>
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 16,
+                  height: 16,
+                  borderRadius: 4,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  marginTop: 1,
+                  border: item.required ? "1px solid var(--amber-border)" : "1px solid var(--border)",
+                  color: item.required ? "var(--amber)" : "var(--text-muted)",
+                  fontSize: 10,
+                  fontWeight: 900,
+                }}
+              >
+                {item.required ? "!" : "-"}
+              </span>
+              <div>
+                <div style={{ color: "var(--text-primary)", fontSize: 11, fontWeight: 800 }}>
+                  {text(item.label, roadmapLocale)}
+                </div>
+                <div style={{ color: "var(--text-muted)", fontSize: 10, lineHeight: 1.35 }}>
+                  {item.required ? copy.required : copy.optional} · {copy.owner}: {text(item.owner, roadmapLocale)}
+                </div>
+                <div style={{ color: "var(--text-secondary)", fontSize: 10, lineHeight: 1.35 }}>
+                  {copy.timing}: {text(item.timing, roadmapLocale)}
+                </div>
+                <div style={{ color: "var(--text-secondary)", fontSize: 10, lineHeight: 1.35 }}>
+                  {copy.fee}: {text(item.cost, roadmapLocale)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <details style={{ marginTop: 10 }}>
+        <summary style={{ cursor: "pointer", color: "var(--text-muted)", fontSize: 10, fontWeight: 800 }}>
+          {copy.assumptions}
+        </summary>
+        <ul style={{ margin: "6px 0 0", paddingLeft: 16, display: "grid", gap: 3 }}>
+          {roadmap.assumptions.map((assumption) => (
+            <li key={assumption.en} style={{ color: "var(--text-muted)", fontSize: 10, lineHeight: 1.35 }}>
+              {text(assumption, roadmapLocale)}
+            </li>
+          ))}
+        </ul>
+      </details>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+        <button type="button" className="material-btn" onClick={copyHandoff} style={{ flex: 1, justifyContent: "center" }}>
+          {copied ? copy.copied : copy.copy}
+        </button>
+        <button type="button" className="material-btn" onClick={() => window.print()} style={{ flex: 1, justifyContent: "center" }}>
+          {copy.print}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function TimelineRow({
+  phase,
+  index,
+  totalWeeks,
+  locale,
+}: {
+  phase: RoadmapPhase;
+  index: number;
+  totalWeeks: number;
+  locale: "fi" | "en";
+}) {
+  const tone = phaseTone(index);
+  const left = `${Math.max(0, (phase.startWeek / totalWeeks) * 100)}%`;
+  const width = `${Math.max(6, (phase.durationWeeks / totalWeeks) * 100)}%`;
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "112px 1fr", gap: 8, alignItems: "center" }}>
+      <div style={{ color: "var(--text-secondary)", fontSize: 10, lineHeight: 1.25, overflow: "hidden", textOverflow: "ellipsis" }}>
+        {text(phase.title, locale)}
+      </div>
+      <div style={{ position: "relative", height: 22, borderRadius: 999, background: "rgba(255,255,255,0.04)", overflow: "hidden" }}>
+        <div
+          title={`${text(phase.title, locale)}: ${phase.durationWeeks} weeks`}
+          style={{
+            position: "absolute",
+            left,
+            width,
+            top: 3,
+            bottom: 3,
+            borderRadius: 999,
+            border: `1px solid ${tone.border}`,
+            background: tone.background,
+            color: tone.color,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 9,
+            fontWeight: 800,
+            minWidth: 28,
+          }}
+        >
+          {phase.durationWeeks}w
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  muted = false,
+}: {
+  label: string;
+  value: string;
+  muted?: boolean;
+}) {
+  return (
+    <div style={{ padding: "7px 8px", borderRadius: "var(--radius-sm)", border: "1px solid var(--border)", background: "var(--bg-tertiary)", minWidth: 0 }}>
+      <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 9, marginBottom: 3 }}>
+        {label}
+      </div>
+      <div style={{ color: muted ? "var(--text-muted)" : "var(--text-primary)", fontSize: 11, fontWeight: 800, lineHeight: 1.25, overflowWrap: "anywhere" }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/__tests__/renovation-roadmap.test.ts
+++ b/web/src/lib/__tests__/renovation-roadmap.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { BomItem, Material } from "@/types";
+import {
+  buildRenovationRoadmap,
+  classifyBomItemPhase,
+  formatRoadmapHandoff,
+  inferRoadmapProjectType,
+} from "../renovation-roadmap";
+
+const baseMaterial: Material = {
+  id: "timber",
+  name: "C24 timber",
+  name_fi: "C24 sahatavara",
+  name_en: "C24 timber",
+  category_name: "lumber",
+  category_name_fi: "Sahatavara",
+  image_url: null,
+  pricing: [{ unit_price: 8, unit: "m", supplier_name: "K-Rauta", is_primary: true }],
+  tags: ["runko", "wood"],
+};
+
+const concrete: Material = {
+  ...baseMaterial,
+  id: "concrete",
+  name: "Ready-mix concrete",
+  name_fi: "Valmisbetoni",
+  category_name: "foundation",
+  category_name_fi: "Perustus",
+  tags: ["betoni", "foundation"],
+};
+
+const roof: Material = {
+  ...baseMaterial,
+  id: "roof",
+  name: "Roof membrane",
+  name_fi: "Kattokalvo",
+  category_name: "roofing",
+  category_name_fi: "Katto",
+  tags: ["roof", "membrane"],
+};
+
+const cable: Material = {
+  ...baseMaterial,
+  id: "cable",
+  name: "Electrical cable",
+  name_fi: "Sahkokaapeli",
+  category_name: "electrical",
+  category_name_fi: "Sahko",
+  tags: ["electric", "mep"],
+};
+
+const paint: Material = {
+  ...baseMaterial,
+  id: "paint",
+  name: "Interior paint",
+  name_fi: "Sisämaali",
+  name_en: "Interior paint",
+  category_name: "interior",
+  category_name_fi: "Sisätyöt",
+  tags: ["paint", "interior"],
+};
+
+const materials = [baseMaterial, concrete, roof, cable, paint];
+
+describe("renovation roadmap planner", () => {
+  it("classifies BOM rows into construction phases", () => {
+    expect(classifyBomItemPhase({ material_id: "concrete", quantity: 3, unit: "m3" }, materials)).toBe("foundation");
+    expect(classifyBomItemPhase({ material_id: "roof", quantity: 20, unit: "m2" }, materials)).toBe("weatherproofing");
+    expect(classifyBomItemPhase({ material_id: "cable", quantity: 50, unit: "m" }, materials)).toBe("mep");
+  });
+
+  it("infers extension work from added area", () => {
+    expect(inferRoadmapProjectType({ bom: [], materials, addedAreaM2: 25 })).toBe("extension");
+  });
+
+  it("marks an extension over 20 m2 as a likely building permit project", () => {
+    const roadmap = buildRenovationRoadmap({
+      bom: [{ material_id: "timber", quantity: 12, unit: "m" }],
+      materials,
+      projectType: "extension",
+      addedAreaM2: 25,
+      buildingInfo: { address: "Kotikatu 1, Espoo" },
+    });
+
+    expect(roadmap.permitAssessment.outcome).toBe("building_permit");
+    expect(roadmap.checklist.find((item) => item.id === "permit")?.required).toBe(true);
+  });
+
+  it("builds ordered phases with BOM costs and contractor suggestions", () => {
+    const bom: BomItem[] = [
+      { material_id: "concrete", quantity: 2, unit: "m3" },
+      { material_id: "timber", quantity: 10, unit: "m" },
+      { material_id: "roof", quantity: 30, unit: "m2", unit_price: 12 },
+    ];
+    const roadmap = buildRenovationRoadmap({ bom, materials, projectName: "Roof extension" });
+
+    expect(roadmap.phases[0].id).toBe("planning");
+    expect(roadmap.totalWeeks).toBeGreaterThan(5);
+    expect(roadmap.phases.find((phase) => phase.id === "foundation")?.items).toHaveLength(1);
+    expect(roadmap.phases.find((phase) => phase.id === "weatherproofing")?.estimatedCost).toBe(360);
+  });
+
+  it("omits irrelevant empty construction phases for simple interior projects", () => {
+    const roadmap = buildRenovationRoadmap({
+      bom: [{ material_id: "paint", quantity: 5, unit: "l" }],
+      materials,
+      projectType: "interior",
+    });
+
+    expect(roadmap.phases.map((phase) => phase.id)).toEqual(["planning", "interior", "handover"]);
+  });
+
+  it("formats a contractor handoff text", () => {
+    const roadmap = buildRenovationRoadmap({ bom: [{ material_id: "cable", quantity: 30, unit: "m" }], materials });
+    const handoff = formatRoadmapHandoff(roadmap, "en");
+
+    expect(handoff).toContain("renovation execution roadmap");
+    expect(handoff).toContain("MEP rough-in");
+    expect(handoff).toContain("Permit and inspection checklist");
+  });
+});

--- a/web/src/lib/renovation-roadmap.ts
+++ b/web/src/lib/renovation-roadmap.ts
@@ -1,0 +1,447 @@
+import type { BomItem, BuildingInfo, Material } from "@/types";
+import {
+  assessPermitNeed,
+  type LocalizedText,
+  type PermitAnswers,
+  type PermitAssessment,
+  type PermitCategoryId,
+} from "@/lib/permit-checker";
+
+export type RoadmapProjectType =
+  | "interior"
+  | "extension"
+  | "roof"
+  | "energy"
+  | "sauna"
+  | "garage"
+  | "facade"
+  | "yard";
+
+export type RoadmapPhaseId =
+  | "planning"
+  | "foundation"
+  | "structure"
+  | "weatherproofing"
+  | "mep"
+  | "interior"
+  | "handover";
+
+export interface RoadmapBomItem {
+  materialId: string;
+  name: string;
+  quantity: number;
+  unit: string;
+  estimatedCost: number;
+}
+
+export interface RoadmapPhase {
+  id: RoadmapPhaseId;
+  title: LocalizedText;
+  summary: LocalizedText;
+  startWeek: number;
+  durationWeeks: number;
+  durationRange: LocalizedText;
+  contractorType: LocalizedText;
+  crew: LocalizedText;
+  criticalPath: boolean;
+  canOverlapWith: RoadmapPhaseId[];
+  risk: LocalizedText;
+  items: RoadmapBomItem[];
+  estimatedCost: number;
+}
+
+export interface RoadmapChecklistItem {
+  id: string;
+  label: LocalizedText;
+  required: boolean;
+  owner: LocalizedText;
+  timing: LocalizedText;
+  cost: LocalizedText;
+}
+
+export interface RenovationRoadmap {
+  projectType: RoadmapProjectType;
+  permitAssessment: PermitAssessment;
+  totalWeeks: number;
+  totalCost: number;
+  phases: RoadmapPhase[];
+  checklist: RoadmapChecklistItem[];
+  assumptions: LocalizedText[];
+}
+
+export interface BuildRenovationRoadmapInput {
+  bom: BomItem[];
+  materials: Material[];
+  buildingInfo?: BuildingInfo | null;
+  projectName?: string;
+  projectDescription?: string;
+  projectType?: RoadmapProjectType;
+  addedAreaM2?: number;
+}
+
+const PHASE_ORDER: RoadmapPhaseId[] = [
+  "planning",
+  "foundation",
+  "structure",
+  "weatherproofing",
+  "mep",
+  "interior",
+  "handover",
+];
+
+const PHASE_COPY: Record<RoadmapPhaseId, Omit<RoadmapPhase, "startWeek" | "durationWeeks" | "items" | "estimatedCost">> = {
+  planning: {
+    id: "planning",
+    title: { fi: "Suunnittelu ja luvat", en: "Planning and permits" },
+    summary: { fi: "Lukitse laajuus, vastuut, lupa-arvio ja hankintajärjestys ennen ostoksia.", en: "Lock scope, responsibilities, permit risk, and procurement order before buying." },
+    durationRange: { fi: "2-6 viikkoa", en: "2-6 weeks" },
+    contractorType: { fi: "Pääsuunnittelija / omistaja", en: "Principal designer / owner" },
+    crew: { fi: "1 omistaja + suunnittelija tarvittaessa", en: "1 owner plus designer when needed" },
+    criticalPath: true,
+    canOverlapWith: [],
+    risk: { fi: "Lupa- tai suunnittelupuutteet pysäyttävät myöhemmät vaiheet.", en: "Permit or design gaps block later phases." },
+  },
+  foundation: {
+    id: "foundation",
+    title: { fi: "Maa- ja perustustyöt", en: "Groundwork and foundation" },
+    summary: { fi: "Työmaa, kaivuu, kantavuus, routasuojaus ja valutyöt.", en: "Site setup, excavation, bearing capacity, frost protection, and concrete work." },
+    durationRange: { fi: "1-2 viikkoa", en: "1-2 weeks" },
+    contractorType: { fi: "Maanrakentaja / perustustekijä", en: "Groundworks / foundation crew" },
+    crew: { fi: "2-4 hengen työryhmä", en: "2-4 person crew" },
+    criticalPath: true,
+    canOverlapWith: [],
+    risk: { fi: "Maaperä, sää ja toimitukset voivat siirtää koko aikataulua.", en: "Soil, weather, and deliveries can shift the whole schedule." },
+  },
+  structure: {
+    id: "structure",
+    title: { fi: "Runko ja kantavat rakenteet", en: "Structure and framing" },
+    summary: { fi: "Runko, aukotukset, levytys ja kantavat muutokset.", en: "Framing, openings, sheathing, and structural changes." },
+    durationRange: { fi: "2-6 viikkoa", en: "2-6 weeks" },
+    contractorType: { fi: "Kirvesmies / rakennesuunnittelija", en: "Carpentry crew / structural engineer" },
+    crew: { fi: "2-3 kirvesmiestä", en: "2-3 carpenters" },
+    criticalPath: true,
+    canOverlapWith: ["mep"],
+    risk: { fi: "Rakennemuutokset vaativat tarkat piirustukset ja tarkastukset.", en: "Structural changes need exact drawings and inspections." },
+  },
+  weatherproofing: {
+    id: "weatherproofing",
+    title: { fi: "Vesikatto ja sääsuojaus", en: "Roofing and weatherproofing" },
+    summary: { fi: "Katto, kalvot, eristeet ja ulkovaipan tiiveys ennen sisätöitä.", en: "Roof, membranes, insulation, and envelope tightness before interior work." },
+    durationRange: { fi: "1-3 viikkoa", en: "1-3 weeks" },
+    contractorType: { fi: "Katto- / eristeurakoitsija", en: "Roofing / insulation contractor" },
+    crew: { fi: "2-4 hengen sääriippuvainen työryhmä", en: "2-4 person weather-dependent crew" },
+    criticalPath: true,
+    canOverlapWith: ["structure"],
+    risk: { fi: "Sisätyöt kannattaa aloittaa vasta kun vaippa on säältä suojattu.", en: "Interior work should wait until the envelope is weatherproof." },
+  },
+  mep: {
+    id: "mep",
+    title: { fi: "LVI, sähkö ja ilmanvaihto", en: "MEP rough-in" },
+    summary: { fi: "Sähkö, putket, ilmanvaihto, lämmitys ja piiloon jäävät tarkistukset.", en: "Electrical, plumbing, ventilation, heating, and hidden inspections." },
+    durationRange: { fi: "2-4 viikkoa", en: "2-4 weeks" },
+    contractorType: { fi: "Sähkö-, LVI- ja IV-urakoitsijat", en: "Electrical, plumbing, and HVAC contractors" },
+    crew: { fi: "1-3 erikoisurakoitsijaa vaiheittain", en: "1-3 specialist trades in sequence" },
+    criticalPath: false,
+    canOverlapWith: ["structure"],
+    risk: { fi: "Piiloon jäävät asennukset pitää tarkistaa ennen levytystä.", en: "Hidden installations must be checked before closing walls." },
+  },
+  interior: {
+    id: "interior",
+    title: { fi: "Sisätyöt ja viimeistely", en: "Interior finishes" },
+    summary: { fi: "Levyt, lattiat, pinnat, kalusteet, listat ja loppusiivous.", en: "Boards, floors, surfaces, fixtures, trims, and final clean." },
+    durationRange: { fi: "3-6 viikkoa", en: "3-6 weeks" },
+    contractorType: { fi: "Sisätyöurakoitsija / omatoiminen tekijä", en: "Interior contractor / DIY owner" },
+    crew: { fi: "1-3 tekijää työmäärän mukaan", en: "1-3 workers depending on scope" },
+    criticalPath: true,
+    canOverlapWith: [],
+    risk: { fi: "Pintojen kuivuminen, toimitukset ja virheet venyttävät helposti viimeistelyä.", en: "Drying time, deliveries, and defects often stretch finishing." },
+  },
+  handover: {
+    id: "handover",
+    title: { fi: "Tarkastukset ja luovutus", en: "Inspections and handover" },
+    summary: { fi: "Tarkastukset, puutelistat, dokumentit, käyttöönottovalmius ja takuuasiat.", en: "Inspections, punch list, documents, occupancy readiness, and warranty notes." },
+    durationRange: { fi: "1-2 viikkoa", en: "1-2 weeks" },
+    contractorType: { fi: "Omistaja, valvoja, urakoitsija", en: "Owner, supervisor, contractor" },
+    crew: { fi: "Omistaja + vastuulliset urakoitsijat", en: "Owner plus responsible contractors" },
+    criticalPath: true,
+    canOverlapWith: [],
+    risk: { fi: "Puuttuvat dokumentit tai tarkastukset voivat estää käyttöönoton.", en: "Missing documents or inspections can block handover." },
+  },
+};
+
+const PHASE_KEYWORDS: Record<Exclude<RoadmapPhaseId, "planning" | "handover">, string[]> = {
+  foundation: ["foundation", "concrete", "betoni", "perustus", "sokkeli", "gravel", "sepeli", "routa"],
+  structure: ["lumber", "timber", "wood", "c24", "frame", "framing", "runko", "sahatavara", "beam", "palkki", "osb"],
+  weatherproofing: ["roof", "katto", "membrane", "kalvo", "insulation", "eriste", "facade", "julkisivu", "window", "ikkuna"],
+  mep: ["electric", "sahko", "sähkö", "cable", "kaapeli", "plumbing", "putki", "lvi", "hvac", "ventilation", "heating", "lampopumppu", "lämpö"],
+  interior: ["drywall", "gypsum", "kipsi", "floor", "lattia", "tile", "laatta", "paint", "maali", "fixture", "kaluste", "interior", "sisä"],
+};
+
+function localizedLower(value: unknown): string {
+  return typeof value === "string" ? value.toLocaleLowerCase("fi-FI") : "";
+}
+
+function materialFor(item: BomItem, materials: Material[]): Material | undefined {
+  return materials.find((material) => material.id === item.material_id);
+}
+
+function searchableText(item: BomItem, material?: Material): string {
+  return [
+    item.material_id,
+    item.material_name,
+    item.category_name,
+    item.note,
+    material?.name,
+    material?.name_fi,
+    material?.name_en,
+    material?.category_name,
+    material?.category_name_fi,
+    ...(material?.tags ?? []),
+  ].map(localizedLower).join(" ");
+}
+
+export function estimateBomLineCost(item: BomItem, material?: Material): number {
+  if (typeof item.total === "number" && Number.isFinite(item.total)) return item.total;
+  const materialPrice = material?.pricing?.find((price) => price.is_primary)?.unit_price ?? material?.pricing?.[0]?.unit_price;
+  const unitPrice = typeof item.unit_price === "number" ? item.unit_price : materialPrice ?? 0;
+  return Math.max(0, unitPrice * Number(item.quantity || 0));
+}
+
+export function classifyBomItemPhase(item: BomItem, materials: Material[]): Exclude<RoadmapPhaseId, "planning" | "handover"> {
+  const material = materialFor(item, materials);
+  const text = searchableText(item, material);
+  for (const phase of ["foundation", "weatherproofing", "mep", "structure", "interior"] as const) {
+    if (PHASE_KEYWORDS[phase].some((keyword) => text.includes(keyword))) return phase;
+  }
+  return "interior";
+}
+
+export function inferRoadmapProjectType(input: BuildRenovationRoadmapInput): RoadmapProjectType {
+  if (input.projectType) return input.projectType;
+  const haystack = [
+    input.projectName,
+    input.projectDescription,
+    input.buildingInfo?.type,
+    ...input.bom.map((item) => searchableText(item, materialFor(item, input.materials))),
+  ].map(localizedLower).join(" ");
+
+  if (input.addedAreaM2 && input.addedAreaM2 > 0) return "extension";
+  if (haystack.includes("sauna")) return "sauna";
+  if (haystack.includes("garage") || haystack.includes("autotalli")) return "garage";
+  if (haystack.includes("foundation") || haystack.includes("perustus")) return "extension";
+  if (haystack.includes("roof") || haystack.includes("katto")) return "roof";
+  if (haystack.includes("facade") || haystack.includes("julkisivu")) return "facade";
+  if (haystack.includes("insulation") || haystack.includes("eriste") || haystack.includes("heating") || haystack.includes("lämpö")) return "energy";
+  if (haystack.includes("deck") || haystack.includes("terrace") || haystack.includes("terassi")) return "yard";
+  return "interior";
+}
+
+function permitCategoryFor(projectType: RoadmapProjectType): PermitCategoryId {
+  switch (projectType) {
+    case "extension":
+    case "garage":
+    case "sauna":
+      return "extension";
+    case "roof":
+      return "roof";
+    case "energy":
+      return "energy_system";
+    case "facade":
+      return "facade";
+    case "yard":
+      return "yard_structure";
+    default:
+      return "interior_surface";
+  }
+}
+
+function permitAnswersFor(projectType: RoadmapProjectType, addedAreaM2?: number): PermitAnswers {
+  if (projectType === "extension" || projectType === "garage" || projectType === "sauna") {
+    return {
+      addsFloorArea: projectType === "extension" || projectType === "garage" || (addedAreaM2 ?? 0) > 20,
+      changesExterior: true,
+      detachedHouse: true,
+    };
+  }
+  if (projectType === "roof") return { roofShapeOrMaterial: true, changesExterior: true, detachedHouse: true };
+  if (projectType === "facade") return { facadeMaterialOrInsulation: true, changesExterior: true, detachedHouse: true };
+  if (projectType === "energy") return { changesExterior: true };
+  if (projectType === "yard") return { largeStructure: (addedAreaM2 ?? 0) > 20, changesExterior: true };
+  return { detachedHouse: true };
+}
+
+function phaseDuration(phaseId: RoadmapPhaseId, itemCount: number, totalCost: number, permitAssessment: PermitAssessment): number {
+  const costScale = totalCost > 50000 ? 2 : totalCost > 20000 ? 1 : 0;
+  const itemScale = itemCount > 10 ? 1 : 0;
+  switch (phaseId) {
+    case "planning":
+      return permitAssessment.outcome === "building_permit" ? 4 : permitAssessment.outcome === "no_permit_likely" ? 2 : 3;
+    case "foundation":
+      return Math.max(1, Math.min(3, itemCount > 0 ? 1 + costScale : 1));
+    case "structure":
+      return Math.max(2, Math.min(7, 2 + itemScale + costScale));
+    case "weatherproofing":
+      return Math.max(1, Math.min(4, 1 + itemScale + costScale));
+    case "mep":
+      return Math.max(1, Math.min(4, itemCount > 0 ? 2 + itemScale : 1));
+    case "interior":
+      return Math.max(2, Math.min(7, 3 + itemScale + costScale));
+    case "handover":
+      return permitAssessment.outcome === "building_permit" ? 2 : 1;
+  }
+}
+
+function checklistFor(permitAssessment: PermitAssessment, projectType: RoadmapProjectType): RoadmapChecklistItem[] {
+  const permitLikely = permitAssessment.outcome === "building_permit";
+  const authorityReview = permitAssessment.outcome === "action_or_review" || permitAssessment.outcome === "authority_check";
+  const energyScope = projectType === "energy" || projectType === "facade" || projectType === "roof" || projectType === "extension";
+  return [
+    {
+      id: "permit",
+      label: { fi: "Rakentamislupa / rakennuslupa", en: "Construction / building permit" },
+      required: permitLikely,
+      owner: { fi: "Omistaja ja pääsuunnittelija", en: "Owner and principal designer" },
+      timing: { fi: "Varmista ennen hankintoja; jätä hakemus ennen töiden aloitusta.", en: "Confirm before procurement; submit before work starts." },
+      cost: permitAssessment.costEstimate,
+    },
+    {
+      id: "municipal-check",
+      label: { fi: "Kunnan rakennusvalvonnan tarkistus", en: "Municipal building-control check" },
+      required: authorityReview,
+      owner: { fi: "Omistaja", en: "Owner" },
+      timing: { fi: "Soita tai tee Lupapiste-kysely suunnitteluvaiheessa.", en: "Call or ask via Lupapiste during planning." },
+      cost: { fi: "Usein maksuton kysely, mahdollinen lupamaksu jos hanke laajenee.", en: "Often free as an inquiry; permit fee may apply if scope expands." },
+    },
+    {
+      id: "start-notice",
+      label: { fi: "Aloitusilmoitus ja vastuuhenkilöt", en: "Start notice and responsible persons" },
+      required: permitLikely,
+      owner: { fi: "Omistaja / vastaava työnjohtaja", en: "Owner / responsible site manager" },
+      timing: { fi: "Kun lupa on lainvoimainen ja urakoitsijat valittu.", en: "After permit is valid and contractors are selected." },
+      cost: { fi: "Sisältyy yleensä lupa- ja valvontaprosessiin.", en: "Usually part of permit and inspection process." },
+    },
+    {
+      id: "energy-docs",
+      label: { fi: "Energia- ja vaippatiedot", en: "Energy and envelope documentation" },
+      required: energyScope,
+      owner: { fi: "Suunnittelija / energia-asiantuntija", en: "Designer / energy specialist" },
+      timing: { fi: "Ennen ulkovaipan tai lämmityksen muutoksia.", en: "Before envelope or heating-system changes." },
+      cost: { fi: "Riippuu laskelmista ja asiantuntijatarpeesta.", en: "Depends on calculations and specialist need." },
+    },
+    {
+      id: "inspections",
+      label: { fi: "Perustus-, rakenne- ja lopputarkastukset", en: "Foundation, structural, and final inspections" },
+      required: permitLikely || authorityReview,
+      owner: { fi: "Vastaava työnjohtaja / kunta", en: "Responsible site manager / municipality" },
+      timing: { fi: "Sovi ennen kuin työvaihe peittyy.", en: "Book before the work stage is covered." },
+      cost: { fi: "Kunnan hinnaston ja valvontatarpeen mukaan.", en: "According to municipal fee list and inspection scope." },
+    },
+  ];
+}
+
+function isPhaseRelevant(
+  phaseId: RoadmapPhaseId,
+  projectType: RoadmapProjectType,
+  grouped: Map<RoadmapPhaseId, RoadmapBomItem[]>,
+): boolean {
+  if (phaseId === "planning" || phaseId === "handover") return true;
+  if ((grouped.get(phaseId)?.length ?? 0) > 0) return true;
+
+  switch (projectType) {
+    case "extension":
+    case "garage":
+    case "sauna":
+      return true;
+    case "roof":
+      return phaseId === "structure" || phaseId === "weatherproofing";
+    case "facade":
+      return phaseId === "weatherproofing";
+    case "energy":
+      return phaseId === "weatherproofing" || phaseId === "mep";
+    case "yard":
+      return phaseId === "foundation" || phaseId === "structure";
+    case "interior":
+      return phaseId === "interior";
+  }
+}
+
+export function buildRenovationRoadmap(input: BuildRenovationRoadmapInput): RenovationRoadmap {
+  const projectType = inferRoadmapProjectType(input);
+  const permitAssessment = assessPermitNeed({
+    categoryId: permitCategoryFor(projectType),
+    answers: permitAnswersFor(projectType, input.addedAreaM2),
+    buildingInfo: input.buildingInfo,
+  });
+
+  const grouped = new Map<RoadmapPhaseId, RoadmapBomItem[]>();
+  let totalCost = 0;
+  for (const item of input.bom) {
+    const material = materialFor(item, input.materials);
+    const phaseId = classifyBomItemPhase(item, input.materials);
+    const estimatedCost = estimateBomLineCost(item, material);
+    totalCost += estimatedCost;
+    const list = grouped.get(phaseId) ?? [];
+    list.push({
+      materialId: item.material_id,
+      name: item.material_name || material?.name_fi || material?.name || item.material_id,
+      quantity: Number(item.quantity || 0),
+      unit: item.unit,
+      estimatedCost,
+    });
+    grouped.set(phaseId, list);
+  }
+
+  let cursor = 0;
+  const phaseIds = PHASE_ORDER.filter((phaseId) => isPhaseRelevant(phaseId, projectType, grouped));
+  const phases: RoadmapPhase[] = phaseIds.map((phaseId) => {
+    const items = grouped.get(phaseId) ?? [];
+    const estimatedCost = items.reduce((sum, item) => sum + item.estimatedCost, 0);
+    const startWeek = phaseId === "mep" ? Math.max(0, cursor - 1) : cursor;
+    const durationWeeks = phaseDuration(phaseId, items.length, estimatedCost || totalCost, permitAssessment);
+    cursor = Math.max(cursor, startWeek + durationWeeks);
+    return {
+      ...PHASE_COPY[phaseId],
+      startWeek,
+      durationWeeks,
+      items,
+      estimatedCost,
+    };
+  });
+
+  const totalWeeks = Math.max(...phases.map((phase) => phase.startWeek + phase.durationWeeks));
+  return {
+    projectType,
+    permitAssessment,
+    totalWeeks,
+    totalCost,
+    phases,
+    checklist: checklistFor(permitAssessment, projectType),
+    assumptions: [
+      { fi: "Aikataulu on karkea omakotitalon remonttijärjestys, ei urakkasopimus.", en: "Timeline is a rough detached-house renovation sequence, not a contract schedule." },
+      { fi: "Lupatulkinta on alustava; kunnan rakennusvalvonta tekee päätöksen.", en: "Permit assessment is preliminary; municipal building control decides." },
+      { fi: "BOM-rivit ryhmitellään materiaalin nimen, kategorian ja tagien perusteella.", en: "BOM rows are grouped from material name, category, and tags." },
+    ],
+  };
+}
+
+export function formatRoadmapHandoff(roadmap: RenovationRoadmap, locale: "fi" | "en" = "en"): string {
+  const text = (value: LocalizedText) => value[locale] ?? value.en;
+  const lines = [
+    locale === "fi" ? "Helscoop remontin toteutussuunnitelma" : "Helscoop renovation execution roadmap",
+    `${locale === "fi" ? "Kesto" : "Duration"}: ${roadmap.totalWeeks} ${locale === "fi" ? "viikkoa" : "weeks"}`,
+    `${locale === "fi" ? "Lupa-arvio" : "Permit estimate"}: ${text(roadmap.permitAssessment.permitType)}`,
+    "",
+    locale === "fi" ? "Vaiheet" : "Phases",
+  ];
+
+  for (const phase of roadmap.phases) {
+    lines.push(`- ${text(phase.title)}: ${phase.startWeek}-${phase.startWeek + phase.durationWeeks} wk, ${text(phase.contractorType)}, ${phase.items.length} BOM rows`);
+  }
+
+  lines.push("", locale === "fi" ? "Lupa- ja tarkistuslista" : "Permit and inspection checklist");
+  for (const item of roadmap.checklist) {
+    lines.push(`- [${item.required ? "!" : " "}] ${text(item.label)} - ${text(item.owner)} - ${text(item.timing)}`);
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Fixes #589

Summary:
- Add a renovation roadmap planner that groups BOM rows into sequenced phases with cost, duration, contractor roles, overlap, risks, and homeowner assumptions.
- Mount a roadmap panel in the BOM workflow with contractor/DIY views, permit and inspection checklist, printable view, and clipboard handoff.
- Reuse the permit checker for preliminary permit guidance and cover classification, phase filtering, and panel copy behavior with tests.

Validation:
- npm test -- --run src/lib/__tests__/renovation-roadmap.test.ts src/__tests__/renovation-roadmap-panel.test.tsx
- npx tsc --noEmit
- npm test -- --run
- npm run build

Note: build still reports the existing Next.js warning about experimental.viewTransition.