### PR TITLE
fix: flaky isPriceStale boundary test

### DIFF
--- a/web/src/__tests__/confidence.test.ts
+++ b/web/src/__tests__/confidence.test.ts
@@ -18,9 +18,8 @@ describe("isPriceStale", () => {
     expect(isPriceStale(old)).toBe(true);
   });
 
-  it("returns false for a date exactly at the threshold boundary", () => {
-    const boundary = new Date(Date.now() - STALE_PRICE_THRESHOLD_DAYS * 86_400_000).toISOString();
-    // Exactly at threshold — not yet over it
+  it("returns false for a date just inside the threshold boundary", () => {
+    const boundary = new Date(Date.now() - (STALE_PRICE_THRESHOLD_DAYS * 86_400_000 - 3_600_000)).toISOString();
     expect(isPriceStale(boundary)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- The `isPriceStale` boundary test was flaky because it created a date at exactly the threshold, but milliseconds elapsed between `Date.now()` in the test setup and inside `isPriceStale`, making the date microscopically past the threshold
- Added 1-hour buffer so the boundary date is clearly inside the threshold
- This was causing CI failures on all open PRs

## Test plan
- [ ] CI passes consistently (no more flaky boundary test)


🤖 Generated with [Claude Code](https://claude.com/claude-code)