### PR TITLE
feat: add guided renovation wizard

### DIFF
--- a/web/src/__tests__/guided-renovation-wizard.test.tsx
+++ b/web/src/__tests__/guided-renovation-wizard.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it, vi } from "vitest";
+import GuidedRenovationWizard from "@/components/GuidedRenovationWizard";
+import type { Material } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    t: (key: string) => key,
+  }),
+}));
+
+const materials: Material[] = [
+  {
+    id: "osb_18mm",
+    name: "OSB 18mm",
+    name_fi: "OSB 18mm",
+    name_en: "OSB 18mm",
+    category_name: "sheathing",
+    category_name_fi: "Levy",
+    image_url: null,
+    pricing: [{ unit_price: 18, unit: "m2", supplier_name: "K-Rauta", is_primary: true }],
+    tags: ["board"],
+  },
+];
+
+describe("GuidedRenovationWizard", () => {
+  it("renders the wizard with a running estimate and limited first-step choices", () => {
+    render(
+      <GuidedRenovationWizard
+        materials={materials}
+        source="project_list"
+        onClose={vi.fn()}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("guided-renovation-wizard")).toBeInTheDocument();
+    expect(screen.getByText("Guided renovation wizard")).toBeInTheDocument();
+    expect(screen.getByText("Running estimate")).toBeInTheDocument();
+    expect(screen.getByTestId("wizard-3d-preview")).toBeInTheDocument();
+    expect(screen.getByText("Kitchen")).toBeInTheDocument();
+    expect(screen.queryByText("Extension")).not.toBeInTheDocument();
+  });
+
+  it("reveals the sixth scope option behind show more", () => {
+    render(
+      <GuidedRenovationWizard
+        materials={materials}
+        source="project_list"
+        onClose={vi.fn()}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more option" }));
+    expect(screen.getByText("Extension")).toBeInTheDocument();
+  });
+
+  it("completes with a generated plan from the review step", async () => {
+    const onComplete = vi.fn();
+    const onStepViewed = vi.fn();
+    render(
+      <GuidedRenovationWizard
+        materials={materials}
+        source="project_list"
+        onClose={vi.fn()}
+        onComplete={onComplete}
+        onStepViewed={onStepViewed}
+      />,
+    );
+
+    for (let index = 0; index < 4; index += 1) {
+      fireEvent.click(screen.getByRole("button", { name: "Next" }));
+    }
+
+    expect(screen.getByText("Create plan")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Create plan" }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    const [plan, state] = onComplete.mock.calls[0];
+    expect(plan.sceneJs).toContain("scene.add");
+    expect(plan.bom.length).toBeGreaterThan(0);
+    expect(state.renovationType).toBe("bathroom");
+    expect(onStepViewed).toHaveBeenCalled();
+  });
+});

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -20,6 +20,7 @@ import SceneApiReference from "@/components/SceneApiReference";
 import SharePresentationPanel from "@/components/SharePresentationPanel";
 import ProjectVersionPanel from "@/components/ProjectVersionPanel";
 import LayerPanel from "@/components/LayerPanel";
+import GuidedRenovationWizard from "@/components/GuidedRenovationWizard";
 import { parseSceneParams, applyParamToScript } from "@/lib/scene-interpreter";
 import {
   analyzeSceneGeometry,
@@ -55,6 +56,7 @@ import SaveStatusIndicator from "@/components/SaveStatusIndicator";
 import EditorStatusBar from "@/components/EditorStatusBar";
 import type { SaveStatus } from "@/components/SaveStatusIndicator";
 import type { Material, BomItem, Project, ProjectVersionSnapshot, ProjectPriceChangeSummary } from "@/types";
+import type { GuidedRenovationPlan, RenovationWizardState, WizardStepId } from "@/lib/renovation-wizard";
 import type { ViewportMaterialSelection, ViewportPresentationApi } from "@/components/Viewport3D";
 import { shortcutLabel } from "@/lib/shortcut-label";
 import ConfidenceBadge from "@/components/ConfidenceBadge";
@@ -293,6 +295,8 @@ export default function ProjectPage() {
   const [activePreset, setActivePreset] = useState<string | null>(null);
   const defaultParamsRef = useRef<Record<string, number>>({});
   const [showCode, setShowCode] = useState(false);
+  const [editorMode, setEditorMode] = useState<"simple" | "advanced">("simple");
+  const [showGuidedWizard, setShowGuidedWizard] = useState(false);
   const [showBom, setShowBom] = useState(true);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
   const [showDocs, setShowDocs] = useState(false);
@@ -745,6 +749,7 @@ export default function ProjectPage() {
     return { colorMap, compliance };
   }, [thermalView, materials]);
   const sceneLayers = useMemo(() => buildSceneLayers(renderedLayers, bom), [bom, renderedLayers]);
+  const isAdvancedMode = editorMode === "advanced";
 
   const thermalColorMap = thermalData?.colorMap;
 
@@ -925,6 +930,42 @@ export default function ProjectPage() {
     [pushHistory, markChat, queueSceneAnnouncement]
   );
 
+  const handleEditorModeChange = useCallback((mode: "simple" | "advanced") => {
+    setEditorMode(mode);
+    track("editor_mode_changed", { mode });
+    if (mode === "advanced") markCodeEditor();
+  }, [markCodeEditor, track]);
+
+  const applyGuidedPlan = useCallback(
+    (plan: GuidedRenovationPlan, state: RenovationWizardState, advanced = false) => {
+      track("renovation_wizard_completed", {
+        source: "editor",
+        renovation_type: state.renovationType,
+        estimated_cost: plan.estimatedCost,
+        bom_count: plan.bom.length,
+      });
+      queueSceneAnnouncement("editor.sceneUpdatedFromEditor");
+      setProjectName(plan.name);
+      previousNameRef.current = plan.name;
+      setProjectDesc(plan.description);
+      setSceneJs(plan.sceneJs);
+      pushHistory(plan.sceneJs);
+      setBom(plan.bom);
+      setManualBomOverrideIds(new Set(plan.bom.map((item) => item.material_id)));
+      setGeometryBomUpdate(null);
+      setShowBom(true);
+      setShowGuidedWizard(false);
+      if (advanced) {
+        handleEditorModeChange("advanced");
+        setShowCode(true);
+      } else {
+        handleEditorModeChange("simple");
+      }
+      toast(locale === "fi" ? "Ohjattu suunnitelma otettu kayttoon" : "Guided plan applied", "success");
+    },
+    [handleEditorModeChange, locale, pushHistory, queueSceneAnnouncement, toast, track],
+  );
+
   const handleMobilePanelChange = useCallback(
     (panel: MobileEditorPanel) => {
       setActiveMobilePanel(panel);
@@ -945,10 +986,21 @@ export default function ProjectPage() {
     "viewport",
     "chat",
     "bom",
-    "code",
-    ...(sceneParams.length > 0 ? (["params"] as MobileEditorPanel[]) : []),
-    ...(showDocs ? (["docs"] as MobileEditorPanel[]) : []),
-  ], [sceneParams.length, showDocs]);
+    ...(isAdvancedMode ? (["code"] as MobileEditorPanel[]) : []),
+    ...(isAdvancedMode && sceneParams.length > 0 ? (["params"] as MobileEditorPanel[]) : []),
+    ...(isAdvancedMode && showDocs ? (["docs"] as MobileEditorPanel[]) : []),
+  ], [isAdvancedMode, sceneParams.length, showDocs]);
+
+  useEffect(() => {
+    if (isAdvancedMode) return;
+    setShowCode(false);
+    setShowDocs(false);
+    setShowParams(false);
+    setShowLayers(false);
+    if (activeMobilePanel === "code" || activeMobilePanel === "params" || activeMobilePanel === "docs") {
+      setActiveMobilePanel("viewport");
+    }
+  }, [activeMobilePanel, isAdvancedMode]);
 
   const handleMobilePanelSwipe = useCallback((direction: MobileEditorSwipeDirection) => {
     if (direction === "up") {
@@ -973,7 +1025,10 @@ export default function ProjectPage() {
   }, [activeMobilePanel, handleMobilePanelChange, mobilePanelOrder]);
 
   const toggleCodePanel = useCallback(() => {
-    if (!showCode) markCodeEditor();
+    if (!showCode) {
+      setEditorMode("advanced");
+      markCodeEditor();
+    }
     setShowCode((visible) => {
       const next = !visible;
       if (isMobileEditor) setActiveMobilePanel(next ? "code" : "viewport");
@@ -982,6 +1037,7 @@ export default function ProjectPage() {
   }, [isMobileEditor, markCodeEditor, showCode]);
 
   const toggleDocsPanel = useCallback(() => {
+    setEditorMode("advanced");
     setShowDocs((visible) => {
       const next = !visible;
       if (isMobileEditor) setActiveMobilePanel(next ? "docs" : "viewport");
@@ -990,6 +1046,7 @@ export default function ProjectPage() {
   }, [isMobileEditor]);
 
   const toggleParamsPanel = useCallback(() => {
+    setEditorMode("advanced");
     setShowParams((visible) => {
       const next = !visible;
       if (isMobileEditor) setActiveMobilePanel(next ? "params" : "viewport");
@@ -1545,11 +1602,11 @@ export default function ProjectPage() {
             <line x1="12" y1="17" x2="12.01" y2="17" />
           </svg>
         ),
-        action: () => setShowDocs((v) => !v),
-        isActive: showDocs,
+        action: toggleDocsPanel,
+        isActive: isAdvancedMode && showDocs,
       },
     ];
-  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, toggleCodePanel, wireframe, showBom, showDocs, resolvedTheme, exportIfcPermitModel, exportPermitPack, exportQuotePdf, resetViewportCamera, toggleViewportMeasurementMode, viewportMeasurementMode]);
+  }, [save, toast, t, track, locale, projectName, projectDesc, bom, projectId, shareToken, toggleTheme, showCode, toggleCodePanel, wireframe, showBom, showDocs, isAdvancedMode, resolvedTheme, exportIfcPermitModel, exportPermitPack, exportQuotePdf, resetViewportCamera, toggleViewportMeasurementMode, viewportMeasurementMode, toggleDocsPanel]);
 
   const handleViewportReset = useCallback(() => {
     queueSceneAnnouncement("editor.sceneResetAnnounced");
@@ -2024,6 +2081,24 @@ export default function ProjectPage() {
       data-mobile-panel-size={isMobileEditor ? mobilePanelSize : undefined}
     >
       {showConfetti && <ConfettiCelebration onComplete={() => setShowConfetti(false)} />}
+      {showGuidedWizard && (
+        <GuidedRenovationWizard
+          materials={materials}
+          buildingInfo={project?.building_info ?? null}
+          source="editor"
+          onClose={() => setShowGuidedWizard(false)}
+          onComplete={(plan, state) => applyGuidedPlan(plan, state, false)}
+          onCompleteAdvanced={(plan, state) => applyGuidedPlan(plan, state, true)}
+          onStepViewed={(step, stepId: WizardStepId, state) => {
+            track("renovation_wizard_step_viewed", {
+              source: "editor",
+              step,
+              step_id: stepId,
+              renovation_type: state.renovationType,
+            });
+          }}
+        />
+      )}
 
       {/* Header */}
       <div className="editor-header">
@@ -2083,6 +2158,41 @@ export default function ProjectPage() {
           <option value="completed">{t('project.statusCompleted')}</option>
           <option value="archived">{t('project.statusArchived')}</option>
         </select>
+        <div
+          role="group"
+          aria-label="Editor complexity mode"
+          style={{ display: "flex", gap: 2, padding: 2, border: "1px solid var(--border)", borderRadius: 999, background: "var(--bg-tertiary)" }}
+        >
+          {(["simple", "advanced"] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              className="btn btn-ghost"
+              aria-pressed={editorMode === mode}
+              data-active={editorMode === mode}
+              onClick={() => handleEditorModeChange(mode)}
+              style={{
+                padding: "4px 8px",
+                fontSize: 11,
+                border: "none",
+                color: editorMode === mode ? "var(--amber)" : "var(--text-muted)",
+              }}
+            >
+              {mode === "simple" ? "Simple" : "Advanced"}
+            </button>
+          ))}
+        </div>
+        <button
+          className="btn btn-primary"
+          type="button"
+          onClick={() => {
+            track("renovation_wizard_opened", { source: "editor" });
+            setShowGuidedWizard(true);
+          }}
+          style={{ padding: "5px 10px", fontSize: 12 }}
+        >
+          Wizard
+        </button>
         <div className="editor-header-actions">
           <CreditBalancePill compact />
           <button
@@ -2902,30 +3012,34 @@ export default function ProjectPage() {
               {t('editor.resetCamera')}
             </button>
             <span className="viewport-toolbar-sep" />
-            <button
-              className="viewport-toolbar-btn"
-              data-active={showCode}
-              onClick={toggleCodePanel}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="16 18 22 12 16 6" />
-                <polyline points="8 6 2 12 8 18" />
-              </svg>
-              {showCode ? t('editor.hideCode') : t('editor.showCode')}
-            </button>
-            <button
-              className="viewport-toolbar-btn"
-              data-active={showDocs}
-              onClick={toggleDocsPanel}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="10" />
-                <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-                <line x1="12" y1="17" x2="12.01" y2="17" />
-              </svg>
-              {t('editor.docs') || "Docs"}
-            </button>
-            {sceneParams.length > 0 && (
+            {isAdvancedMode && (
+              <button
+                className="viewport-toolbar-btn"
+                data-active={showCode}
+                onClick={toggleCodePanel}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="16 18 22 12 16 6" />
+                  <polyline points="8 6 2 12 8 18" />
+                </svg>
+                {showCode ? t('editor.hideCode') : t('editor.showCode')}
+              </button>
+            )}
+            {isAdvancedMode && (
+              <button
+                className="viewport-toolbar-btn"
+                data-active={showDocs}
+                onClick={toggleDocsPanel}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+                  <line x1="12" y1="17" x2="12.01" y2="17" />
+                </svg>
+                {t('editor.docs') || "Docs"}
+              </button>
+            )}
+            {isAdvancedMode && sceneParams.length > 0 && (
               <button
                 className="viewport-toolbar-btn"
                 data-active={showParams}
@@ -2942,7 +3056,7 @@ export default function ProjectPage() {
                 {t('editor.params') || "Params"}
               </button>
             )}
-            {!isMobileEditor && (
+            {isAdvancedMode && !isMobileEditor && (
               <button
                 className="viewport-toolbar-btn"
                 data-active={showLayers}
@@ -3092,7 +3206,7 @@ export default function ProjectPage() {
           )}
 
           {/* Collapsible Code Editor */}
-          {showCode && (
+          {isAdvancedMode && showCode && (
             <div
               className="editor-code-panel"
               style={{
@@ -3277,7 +3391,7 @@ export default function ProjectPage() {
         </div>
 
         {/* Scene parameters panel */}
-        {showParams && sceneParams.length > 0 && (
+        {isAdvancedMode && showParams && sceneParams.length > 0 && (
           <SceneParamsPanel
             params={sceneParams}
             onParamChange={handleParamChange}
@@ -3290,7 +3404,7 @@ export default function ProjectPage() {
           />
         )}
 
-        {showLayers && !isMobileEditor && (
+        {isAdvancedMode && showLayers && !isMobileEditor && (
           <LayerPanel
             layers={sceneLayers}
             selectedLayerId={selectedLayerId}
@@ -3341,7 +3455,7 @@ export default function ProjectPage() {
         )}
 
         {/* Scene API Reference panel */}
-        {showDocs && (
+        {isAdvancedMode && showDocs && (
           <div className="scene-docs-panel" style={{ width: 320, flexShrink: 0, height: "100%", overflow: "hidden" }}>
             <SceneApiReference
               onInsertCode={(code) => {

--- a/web/src/components/GuidedRenovationWizard.tsx
+++ b/web/src/components/GuidedRenovationWizard.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import {
+  DEFAULT_RENOVATION_WIZARD_STATE,
+  WIZARD_CURRENT_STATE_OPTIONS,
+  WIZARD_DESIGN_TIER_OPTIONS,
+  WIZARD_ENERGY_OPTIONS,
+  WIZARD_HOUSE_SIZE_OPTIONS,
+  WIZARD_SCOPE_OPTIONS,
+  buildGuidedRenovationPlan,
+  estimateWizardCost,
+  type GuidedRenovationPlan,
+  type RenovationWizardState,
+  type WizardCurrentState,
+  type WizardDesignTier,
+  type WizardEnergyUpgrade,
+  type WizardHouseSize,
+  type WizardOption,
+  type WizardRenovationType,
+} from "@/lib/renovation-wizard";
+import type { BuildingInfo, Material } from "@/types";
+
+type WizardStepId = "scope" | "house" | "current" | "design" | "review";
+type WizardSource = "project_list" | "editor";
+
+interface GuidedRenovationWizardProps {
+  materials: Material[];
+  buildingInfo?: BuildingInfo | null;
+  source: WizardSource;
+  onClose: () => void;
+  onComplete: (plan: GuidedRenovationPlan, state: RenovationWizardState) => Promise<void> | void;
+  onCompleteAdvanced?: (plan: GuidedRenovationPlan, state: RenovationWizardState) => Promise<void> | void;
+  onStepViewed?: (step: number, stepId: WizardStepId, state: RenovationWizardState) => void;
+}
+
+const STEPS: { id: WizardStepId; label: string; description: string }[] = [
+  { id: "scope", label: "Renovation type", description: "Choose one scope to keep the first pass focused." },
+  { id: "house", label: "Your house", description: "Set project scale before choosing materials." },
+  { id: "current", label: "Current state", description: "Add a realistic risk buffer for older houses." },
+  { id: "design", label: "Design choices", description: "Pick a material tier and optional energy add-on." },
+  { id: "review", label: "Review", description: "Create a real scene script and material list." },
+];
+
+const COPY = {
+  fi: {
+    title: "Ohjattu remonttivelho",
+    subtitle: "Valitse 3-5 asiaa kerrallaan. Helscoop luo mallin, BOMin ja kustannuspolun.",
+    total: "Juokseva arvio",
+    preview: "Live 3D -esikatselu",
+    showMore: "Näytä lisävaihtoehto",
+    showLess: "Piilota lisävaihtoehto",
+    customize: "Mukauta lisää",
+    back: "Takaisin",
+    next: "Seuraava",
+    close: "Sulje",
+    apply: "Luo suunnitelma",
+    applyAdvanced: "Luo ja avaa advanced-tila",
+    bom: "BOM-rivit",
+    scene: "Scene script",
+    cost: "Arvioitu kokonaisbudjetti",
+    energy: "Energiapäivitys",
+    noEnergy: "Ei lisäystä",
+  },
+  en: {
+    title: "Guided renovation wizard",
+    subtitle: "Choose 3-5 things at a time. Helscoop creates the model, BOM, and cost path.",
+    total: "Running estimate",
+    preview: "Live 3D preview",
+    showMore: "Show more option",
+    showLess: "Hide extra option",
+    customize: "Customize further",
+    back: "Back",
+    next: "Next",
+    close: "Close",
+    apply: "Create plan",
+    applyAdvanced: "Create and open advanced mode",
+    bom: "BOM rows",
+    scene: "Scene script",
+    cost: "Estimated total budget",
+    energy: "Energy add-on",
+    noEnergy: "No add-on",
+  },
+  sv: {
+    title: "Guidad renoveringsguide",
+    subtitle: "Valj 3-5 saker i taget. Helscoop skapar modell, BOM och kostnadsvag.",
+    total: "Lopande uppskattning",
+    preview: "Live 3D-forhandsvisning",
+    showMore: "Visa fler alternativ",
+    showLess: "Dolj extra alternativ",
+    customize: "Anpassa mer",
+    back: "Tillbaka",
+    next: "Nasta",
+    close: "Stang",
+    apply: "Skapa plan",
+    applyAdvanced: "Skapa och oppna avancerat lage",
+    bom: "BOM-rader",
+    scene: "Scene script",
+    cost: "Uppskattad totalbudget",
+    energy: "Energitillagg",
+    noEnergy: "Inget tillagg",
+  },
+} as const;
+
+function localeKey(locale: string): keyof typeof COPY {
+  if (locale === "fi" || locale === "sv") return locale;
+  return "en";
+}
+
+function formatEuro(value: number, locale: string): string {
+  return `${value.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB", { maximumFractionDigits: 0 })} EUR`;
+}
+
+function OptionGrid<T extends string>({
+  options,
+  value,
+  onSelect,
+  maxPrimary = 5,
+  showMore,
+  onToggleMore,
+  showMoreLabel = "Show more",
+  showLessLabel = "Show less",
+}: {
+  options: WizardOption<T>[];
+  value: T;
+  onSelect: (value: T) => void;
+  maxPrimary?: number;
+  showMore?: boolean;
+  onToggleMore?: () => void;
+  showMoreLabel?: string;
+  showLessLabel?: string;
+}) {
+  const visible = showMore ? options : options.slice(0, maxPrimary);
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8 }}>
+        {visible.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            onClick={() => onSelect(option.id)}
+            className="btn btn-ghost"
+            data-active={value === option.id}
+            style={{
+              minHeight: 112,
+              alignItems: "stretch",
+              justifyContent: "flex-start",
+              flexDirection: "column",
+              textAlign: "left",
+              padding: 12,
+              borderColor: value === option.id ? "var(--amber-border)" : "var(--border)",
+              background: value === option.id ? "rgba(229,160,75,0.12)" : "var(--bg-tertiary)",
+            }}
+          >
+            <span style={{ color: "var(--text-primary)", fontSize: 13, fontWeight: 800 }}>{option.label}</span>
+            <span style={{ color: "var(--text-muted)", fontSize: 11, lineHeight: 1.35, marginTop: 5 }}>
+              {option.description}
+            </span>
+            <span className="badge badge-amber" style={{ marginTop: "auto", alignSelf: "flex-start", fontSize: 10 }}>
+              {option.costHint}
+            </span>
+          </button>
+        ))}
+      </div>
+      {options.length > maxPrimary && onToggleMore && (
+        <button type="button" className="btn btn-ghost" onClick={onToggleMore} style={{ justifySelf: "start", fontSize: 12 }}>
+          {showMore ? showLessLabel : showMoreLabel}
+        </button>
+      )}
+    </div>
+  );
+}
+
+function PreviewModel({ state }: { state: RenovationWizardState }) {
+  const roofColor = state.renovationType === "roof" ? "#9aa3a7" : "#c99a5b";
+  const wallColor = state.designTier === "best" ? "#e7d7b8" : state.designTier === "better" ? "#d7be8f" : "#bca577";
+  const accent = state.energyUpgrade === "none" ? "#e5a04b" : "#7abf87";
+  return (
+    <div
+      data-testid="wizard-3d-preview"
+      aria-label="Live 3D preview"
+      style={{
+        minHeight: 220,
+        borderRadius: 18,
+        border: "1px solid rgba(229,160,75,0.24)",
+        background: "radial-gradient(circle at 30% 20%, rgba(229,160,75,0.18), transparent 30%), linear-gradient(145deg, #101820, #0b1117)",
+        display: "grid",
+        placeItems: "center",
+        perspective: 900,
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ position: "relative", width: 165, height: 140, transform: "rotateX(58deg) rotateZ(-38deg)", transformStyle: "preserve-3d" }}>
+        <div style={{ position: "absolute", inset: "58px 20px 18px", background: "#3b3f3d", transform: "translateZ(-8px)", boxShadow: "0 24px 40px rgba(0,0,0,0.35)" }} />
+        <div style={{ position: "absolute", left: 35, top: 58, width: 100, height: 58, background: wallColor, transform: "rotateX(90deg) translateZ(29px)", border: "1px solid rgba(255,255,255,0.16)" }} />
+        <div style={{ position: "absolute", left: 35, top: 29, width: 100, height: 58, background: wallColor, transform: "translateZ(29px)", border: "1px solid rgba(255,255,255,0.14)" }} />
+        <div style={{ position: "absolute", left: 135, top: 29, width: 58, height: 58, background: "#9e875e", transformOrigin: "left", transform: "rotateY(90deg) translateZ(0)", border: "1px solid rgba(255,255,255,0.12)" }} />
+        <div style={{ position: "absolute", left: 26, top: 20, width: 118, height: 34, background: roofColor, transform: "translateZ(42px)", border: `2px solid ${accent}`, boxShadow: `0 0 24px ${accent}55` }} />
+        <div style={{ position: "absolute", left: 64, top: 66, width: 42, height: 20, background: accent, transform: "translateZ(34px)", opacity: 0.9 }} />
+      </div>
+    </div>
+  );
+}
+
+export default function GuidedRenovationWizard({
+  materials,
+  buildingInfo,
+  source,
+  onClose,
+  onComplete,
+  onCompleteAdvanced,
+  onStepViewed,
+}: GuidedRenovationWizardProps) {
+  const { locale } = useTranslation();
+  const copy = COPY[localeKey(locale)];
+  const [state, setState] = useState<RenovationWizardState>(DEFAULT_RENOVATION_WIZARD_STATE);
+  const [stepIndex, setStepIndex] = useState(0);
+  const [showMoreScope, setShowMoreScope] = useState(false);
+  const [showAdvancedChoices, setShowAdvancedChoices] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const step = STEPS[stepIndex];
+  const estimate = estimateWizardCost(state, buildingInfo);
+  const plan = useMemo(() => buildGuidedRenovationPlan(state, materials, buildingInfo), [buildingInfo, materials, state]);
+
+  useEffect(() => {
+    onStepViewed?.(stepIndex + 1, step.id, state);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step.id, stepIndex]);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const update = <K extends keyof RenovationWizardState>(key: K, value: RenovationWizardState[K]) => {
+    setState((current) => ({ ...current, [key]: value }));
+  };
+
+  const complete = async (advanced: boolean) => {
+    setSaving(true);
+    try {
+      if (advanced && onCompleteAdvanced) {
+        await onCompleteAdvanced(plan, state);
+      } else {
+        await onComplete(plan, state);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="guided-renovation-wizard-title"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 1400,
+        padding: 18,
+        background: "rgba(2,6,12,0.72)",
+        display: "grid",
+        placeItems: "center",
+      }}
+    >
+      <section
+        data-testid="guided-renovation-wizard"
+        style={{
+          width: "min(1120px, 100%)",
+          maxHeight: "min(780px, calc(100vh - 36px))",
+          overflow: "auto",
+          borderRadius: 22,
+          border: "1px solid rgba(229,160,75,0.24)",
+          background: "linear-gradient(145deg, rgba(22,27,31,0.98), rgba(10,15,22,0.98))",
+          boxShadow: "0 30px 80px rgba(0,0,0,0.45)",
+        }}
+      >
+        <header style={{ display: "flex", justifyContent: "space-between", gap: 16, padding: 18, borderBottom: "1px solid var(--border)" }}>
+          <div>
+            <div className="label-mono" style={{ color: "var(--amber)", marginBottom: 6 }}>WIZARD</div>
+            <h2 id="guided-renovation-wizard-title" className="heading-display" style={{ fontSize: 24, margin: 0 }}>
+              {copy.title}
+            </h2>
+            <p style={{ color: "var(--text-muted)", margin: "6px 0 0", fontSize: 13, lineHeight: 1.45 }}>
+              {copy.subtitle}
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+            <div style={{ textAlign: "right" }}>
+              <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 10 }}>{copy.total}</div>
+              <strong style={{ color: "var(--amber)", fontSize: 18 }}>{formatEuro(estimate, locale)}</strong>
+            </div>
+            <button type="button" className="btn btn-ghost" onClick={onClose} aria-label={copy.close}>
+              {copy.close}
+            </button>
+          </div>
+        </header>
+
+        <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 320px", gap: 18, padding: 18 }}>
+          <div style={{ minWidth: 0 }}>
+            <nav aria-label="Wizard steps" style={{ display: "grid", gridTemplateColumns: "repeat(5, minmax(0, 1fr))", gap: 6, marginBottom: 16 }}>
+              {STEPS.map((item, index) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setStepIndex(index)}
+                  className="btn btn-ghost"
+                  data-active={index === stepIndex}
+                  style={{
+                    padding: "8px 6px",
+                    fontSize: 11,
+                    borderColor: index === stepIndex ? "var(--amber-border)" : "var(--border)",
+                    color: index === stepIndex ? "var(--amber)" : "var(--text-secondary)",
+                  }}
+                >
+                  {index + 1}. {item.label}
+                </button>
+              ))}
+            </nav>
+
+            <div style={{ marginBottom: 14 }}>
+              <h3 style={{ color: "var(--text-primary)", margin: 0, fontSize: 18 }}>{step.label}</h3>
+              <p style={{ color: "var(--text-muted)", margin: "4px 0 0", fontSize: 12 }}>{step.description}</p>
+            </div>
+
+            {step.id === "scope" && (
+              <OptionGrid<WizardRenovationType>
+                options={WIZARD_SCOPE_OPTIONS}
+                value={state.renovationType}
+                onSelect={(value) => update("renovationType", value)}
+                showMore={showMoreScope}
+                onToggleMore={() => setShowMoreScope((visible) => !visible)}
+                showMoreLabel={copy.showMore}
+                showLessLabel={copy.showLess}
+              />
+            )}
+            {step.id === "house" && (
+              <OptionGrid<WizardHouseSize>
+                options={WIZARD_HOUSE_SIZE_OPTIONS}
+                value={state.houseSize}
+                onSelect={(value) => update("houseSize", value)}
+              />
+            )}
+            {step.id === "current" && (
+              <OptionGrid<WizardCurrentState>
+                options={WIZARD_CURRENT_STATE_OPTIONS}
+                value={state.currentState}
+                onSelect={(value) => update("currentState", value)}
+              />
+            )}
+            {step.id === "design" && (
+              <div style={{ display: "grid", gap: 12 }}>
+                <OptionGrid<WizardDesignTier>
+                  options={WIZARD_DESIGN_TIER_OPTIONS}
+                  value={state.designTier}
+                  onSelect={(value) => update("designTier", value)}
+                />
+                <details open={showAdvancedChoices} onToggle={(event) => setShowAdvancedChoices(event.currentTarget.open)}>
+                  <summary style={{ cursor: "pointer", color: "var(--amber)", fontSize: 12, fontWeight: 800 }}>
+                    {copy.customize}: {copy.energy}
+                  </summary>
+                  <div style={{ marginTop: 10 }}>
+                    <OptionGrid<WizardEnergyUpgrade>
+                      options={WIZARD_ENERGY_OPTIONS}
+                      value={state.energyUpgrade}
+                      onSelect={(value) => update("energyUpgrade", value)}
+                    />
+                  </div>
+                </details>
+              </div>
+            )}
+            {step.id === "review" && (
+              <div style={{ display: "grid", gap: 12 }}>
+                <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8 }}>
+                  <Metric label={copy.cost} value={formatEuro(plan.estimatedCost, locale)} />
+                  <Metric label={copy.bom} value={String(plan.bom.length)} />
+                  <Metric label={copy.scene} value={`${plan.sceneJs.split("\n").length} lines`} />
+                </div>
+                <div style={{ border: "1px solid var(--border)", borderRadius: 14, padding: 12, background: "var(--bg-tertiary)" }}>
+                  <h4 style={{ margin: "0 0 8px", color: "var(--text-primary)", fontSize: 13 }}>{plan.name}</h4>
+                  <p style={{ margin: 0, color: "var(--text-muted)", fontSize: 12, lineHeight: 1.45 }}>{plan.description}</p>
+                  <ul style={{ margin: "10px 0 0", paddingLeft: 18, display: "grid", gap: 4 }}>
+                    {plan.bom.slice(0, 5).map((item) => (
+                      <li key={item.material_id} style={{ color: "var(--text-secondary)", fontSize: 11 }}>
+                        {item.material_name}: {item.quantity} {item.unit}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )}
+
+            <footer style={{ display: "flex", justifyContent: "space-between", gap: 10, marginTop: 18 }}>
+              <button type="button" className="btn btn-ghost" onClick={() => setStepIndex((index) => Math.max(0, index - 1))} disabled={stepIndex === 0}>
+                {copy.back}
+              </button>
+              {stepIndex < STEPS.length - 1 ? (
+                <button type="button" className="btn btn-primary" onClick={() => setStepIndex((index) => Math.min(STEPS.length - 1, index + 1))}>
+                  {copy.next}
+                </button>
+              ) : (
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+                  {onCompleteAdvanced && (
+                    <button type="button" className="btn btn-ghost" onClick={() => void complete(true)} disabled={saving}>
+                      {copy.applyAdvanced}
+                    </button>
+                  )}
+                  <button type="button" className="btn btn-primary" onClick={() => void complete(false)} disabled={saving}>
+                    {saving ? <span className="btn-spinner" /> : copy.apply}
+                  </button>
+                </div>
+              )}
+            </footer>
+          </div>
+
+          <aside style={{ display: "grid", gap: 12, alignSelf: "start" }}>
+            <div>
+              <div className="label-mono" style={{ color: "var(--text-muted)", marginBottom: 6 }}>{copy.preview}</div>
+              <PreviewModel state={state} />
+            </div>
+            <div style={{ border: "1px solid var(--border)", borderRadius: 16, padding: 12, background: "var(--bg-tertiary)" }}>
+              <div className="label-mono" style={{ color: "var(--text-muted)", marginBottom: 8 }}>
+                {source === "editor" ? "EDITOR WEDGE" : "NEW PROJECT WEDGE"}
+              </div>
+              <div style={{ display: "grid", gap: 7, fontSize: 12, color: "var(--text-secondary)" }}>
+                <span>Scope: {WIZARD_SCOPE_OPTIONS.find((option) => option.id === state.renovationType)?.label}</span>
+                <span>Tier: {WIZARD_DESIGN_TIER_OPTIONS.find((option) => option.id === state.designTier)?.label}</span>
+                <span>{copy.energy}: {WIZARD_ENERGY_OPTIONS.find((option) => option.id === state.energyUpgrade)?.label ?? copy.noEnergy}</span>
+                <span>{copy.bom}: {plan.bom.length}</span>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ border: "1px solid var(--border)", borderRadius: 12, padding: 10, background: "var(--bg-secondary)" }}>
+      <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 9, marginBottom: 4 }}>{label}</div>
+      <div style={{ color: "var(--text-primary)", fontSize: 13, fontWeight: 800 }}>{value}</div>
+    </div>
+  );
+}

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -14,8 +14,10 @@ import ConfirmDialog from "@/components/ConfirmDialog";
 import ProjectCard from "@/components/ProjectCard";
 import TemplateGrid from "@/components/TemplateGrid";
 import AddressSearch from "@/components/AddressSearch";
+import GuidedRenovationWizard from "@/components/GuidedRenovationWizard";
 import Link from "next/link";
-import type { BomAggregateResponse, Project, ProjectStatus, Template, BuildingResult } from "@/types";
+import type { BomAggregateResponse, Project, ProjectStatus, Template, BuildingResult, Material } from "@/types";
+import type { GuidedRenovationPlan, RenovationWizardState, WizardStepId } from "@/lib/renovation-wizard";
 
 type SortKey = "modified" | "created" | "name" | "cost";
 
@@ -50,6 +52,9 @@ export default function ProjectList({
   const [aggregate, setAggregate] = useState<BomAggregateResponse | null>(null);
   const [aggregateLoading, setAggregateLoading] = useState(false);
   const [aggregateError, setAggregateError] = useState(false);
+  const [showGuidedWizard, setShowGuidedWizard] = useState(false);
+  const [wizardMaterials, setWizardMaterials] = useState<Material[]>([]);
+  const [wizardMaterialsLoading, setWizardMaterialsLoading] = useState(false);
   const { toast } = useToast();
   const { t, locale } = useTranslation();
   const { track } = useAnalytics();
@@ -109,6 +114,53 @@ export default function ProjectList({
       toast(err instanceof Error ? err.message : t('toast.templateFailed'), "error");
     }
     setCreating(false);
+  }
+
+  async function openGuidedWizard() {
+    track("renovation_wizard_opened", { source: "project_list" });
+    setShowGuidedWizard(true);
+    if (wizardMaterials.length > 0 || wizardMaterialsLoading) return;
+    setWizardMaterialsLoading(true);
+    try {
+      setWizardMaterials(await api.getMaterials());
+    } catch (err) {
+      toast(err instanceof Error ? err.message : t("toast.loadMaterialsFailed"), "error");
+    } finally {
+      setWizardMaterialsLoading(false);
+    }
+  }
+
+  async function createFromWizard(plan: GuidedRenovationPlan, state: RenovationWizardState) {
+    setCreating(true);
+    try {
+      track("project_created", { source: "wizard" });
+      track("renovation_wizard_completed", {
+        source: "project_list",
+        renovation_type: state.renovationType,
+        estimated_cost: plan.estimatedCost,
+        bom_count: plan.bom.length,
+      });
+      const project = await api.createProject({
+        name: plan.name,
+        description: plan.description,
+        scene_js: plan.sceneJs,
+      });
+      if (plan.bomRows.length > 0) {
+        await api.saveBOM(project.id, plan.bomRows.map((row) => ({
+          material_id: row.material_id,
+          quantity: row.quantity,
+          unit: row.unit,
+        })));
+      }
+      setProjects([{ ...project, estimated_cost: plan.estimatedCost, bom: plan.bom }, ...projects]);
+      setShowGuidedWizard(false);
+      toast(t('toast.projectCreated'), "success");
+      router.push(`/project/${project.id}`);
+    } catch (err) {
+      toast(err instanceof Error ? err.message : t('toast.createProjectFailed'), "error");
+    } finally {
+      setCreating(false);
+    }
   }
 
   function deleteProject(id: string) {
@@ -464,6 +516,22 @@ export default function ProjectList({
 
   return (
     <div style={{ minHeight: "100vh" }}>
+      {showGuidedWizard && (
+        <GuidedRenovationWizard
+          materials={wizardMaterials}
+          source="project_list"
+          onClose={() => setShowGuidedWizard(false)}
+          onComplete={createFromWizard}
+          onStepViewed={(step, stepId: WizardStepId, state) => {
+            track("renovation_wizard_step_viewed", {
+              source: "project_list",
+              step,
+              step_id: stepId,
+              renovation_type: state.renovationType,
+            });
+          }}
+        />
+      )}
       {/* Top bar */}
       <div className="nav-bar">
         <div className="nav-inner" style={{ maxWidth: 1080 }}>
@@ -579,6 +647,15 @@ export default function ProjectList({
                 </svg>
               )}
               {t('project.import')}
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={() => void openGuidedWizard()}
+              disabled={creating || wizardMaterialsLoading}
+              style={{ padding: "11px 18px", display: "flex", alignItems: "center", gap: 6 }}
+            >
+              {wizardMaterialsLoading ? <span className="btn-spinner" /> : null}
+              Guided wizard
             </button>
           </div>
 

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -16,6 +16,10 @@ import { useCallback, useEffect, useRef } from "react";
 export type AnalyticsEvent =
   | "address_search"
   | "project_created"
+  | "renovation_wizard_opened"
+  | "renovation_wizard_step_viewed"
+  | "renovation_wizard_completed"
+  | "editor_mode_changed"
   | "editor_session"
   | "bom_item_added"
   | "bom_imported"
@@ -51,7 +55,11 @@ export type AnalyticsEvent =
 // ── Property maps per event ────────────────────────────────────────
 export interface AnalyticsEventProps {
   address_search: { query_length: number; had_result: boolean };
-  project_created: { source: "address" | "template" | "blank"; building_type?: string };
+  project_created: { source: "address" | "template" | "blank" | "wizard"; building_type?: string };
+  renovation_wizard_opened: { source: "project_list" | "editor" };
+  renovation_wizard_step_viewed: { source: "project_list" | "editor"; step: number; step_id: string; renovation_type: string };
+  renovation_wizard_completed: { source: "project_list" | "editor"; renovation_type: string; estimated_cost: number; bom_count: number };
+  editor_mode_changed: { mode: "simple" | "advanced" };
   editor_session: { duration_s: number; used_code_editor: boolean; used_chat: boolean };
   bom_item_added: { material_id: string; category?: string };
   bom_imported: { count: number; mode: "merge" | "replace" };

--- a/web/src/lib/__tests__/renovation-wizard.test.ts
+++ b/web/src/lib/__tests__/renovation-wizard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Material } from "@/types";
+import {
+  DEFAULT_RENOVATION_WIZARD_STATE,
+  buildGuidedRenovationPlan,
+  buildWizardScene,
+  estimateWizardCost,
+  hydrateWizardBomRows,
+  type RenovationWizardState,
+} from "../renovation-wizard";
+
+const materials: Material[] = [
+  {
+    id: "galvanized_roofing",
+    name: "Peltikatto Sinkitty",
+    name_fi: "Peltikatto Sinkitty",
+    name_en: "Galvanized roofing",
+    category_name: "roofing",
+    category_name_fi: "Katto",
+    image_url: null,
+    pricing: [{ unit_price: 22, unit: "m2", supplier_name: "K-Rauta", is_primary: true }],
+    tags: ["roof"],
+  },
+  {
+    id: "insulation_100mm",
+    name: "Mineraalivilla 100mm",
+    name_fi: "Mineraalivilla 100mm",
+    name_en: "Mineral wool 100mm",
+    category_name: "insulation",
+    category_name_fi: "Eriste",
+    image_url: null,
+    pricing: [{ unit_price: 8, unit: "m2", supplier_name: "Stark", is_primary: true }],
+    tags: ["energy"],
+  },
+];
+
+describe("renovation wizard planner", () => {
+  it("estimates higher cost for premium and energy upgrade choices", () => {
+    const good: RenovationWizardState = {
+      ...DEFAULT_RENOVATION_WIZARD_STATE,
+      designTier: "good",
+      energyUpgrade: "none",
+    };
+    const best: RenovationWizardState = {
+      ...good,
+      designTier: "best",
+      energyUpgrade: "insulation",
+    };
+
+    expect(estimateWizardCost(best)).toBeGreaterThan(estimateWizardCost(good));
+  });
+
+  it("hydrates BOM rows using catalog prices when available", () => {
+    const rows = [{ material_id: "galvanized_roofing", quantity: 10, unit: "m2", note: "Roof" }];
+    const bom = hydrateWizardBomRows(rows, materials);
+
+    expect(bom[0].material_name).toBe("Galvanized roofing");
+    expect(bom[0].total).toBe(220);
+    expect(bom[0].manual_override).toBe(true);
+  });
+
+  it("generates a valid scene script with selected material references", () => {
+    const scene = buildWizardScene({
+      ...DEFAULT_RENOVATION_WIZARD_STATE,
+      renovationType: "roof",
+      designTier: "best",
+    });
+
+    expect(scene).toContain("scene.add");
+    expect(scene).toContain("galvanized_roofing");
+  });
+
+  it("builds a complete guided plan with scene, BOM rows, and estimate", () => {
+    const plan = buildGuidedRenovationPlan({
+      ...DEFAULT_RENOVATION_WIZARD_STATE,
+      renovationType: "extension",
+      energyUpgrade: "insulation",
+    }, materials, { area_m2: 140 });
+
+    expect(plan.name).toContain("Extension");
+    expect(plan.sceneJs).toContain("guided renovation wizard");
+    expect(plan.bom.length).toBeGreaterThan(3);
+    expect(plan.estimatedCost).toBeGreaterThan(0);
+  });
+});

--- a/web/src/lib/renovation-wizard.ts
+++ b/web/src/lib/renovation-wizard.ts
@@ -1,0 +1,273 @@
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+export type WizardRenovationType = "kitchen" | "bathroom" | "facade" | "roof" | "full_house" | "extension";
+export type WizardStepId = "scope" | "house" | "current" | "design" | "review";
+export type WizardHouseSize = "compact" | "standard" | "large" | "estate";
+export type WizardCurrentState = "modern" | "dated" | "cold" | "unknown";
+export type WizardDesignTier = "good" | "better" | "best";
+export type WizardEnergyUpgrade = "none" | "insulation" | "windows" | "heating";
+
+export interface WizardOption<T extends string> {
+  id: T;
+  label: string;
+  description: string;
+  costHint: string;
+}
+
+export interface RenovationWizardState {
+  renovationType: WizardRenovationType;
+  houseSize: WizardHouseSize;
+  currentState: WizardCurrentState;
+  designTier: WizardDesignTier;
+  energyUpgrade: WizardEnergyUpgrade;
+}
+
+export interface WizardBomRow {
+  material_id: string;
+  quantity: number;
+  unit: string;
+  note: string;
+}
+
+export interface GuidedRenovationPlan {
+  name: string;
+  description: string;
+  sceneJs: string;
+  bom: BomItem[];
+  bomRows: WizardBomRow[];
+  estimatedCost: number;
+}
+
+export const WIZARD_SCOPE_OPTIONS: WizardOption<WizardRenovationType>[] = [
+  { id: "kitchen", label: "Kitchen", description: "Cabinets, wall finish, floor and lighting-ready surfaces.", costHint: "8-25k EUR" },
+  { id: "bathroom", label: "Bathroom", description: "Wet-room shell, waterproofing, floor and ventilation assumptions.", costHint: "10-30k EUR" },
+  { id: "facade", label: "Facade", description: "Cladding, insulation layer and exterior paint package.", costHint: "12-45k EUR" },
+  { id: "roof", label: "Roof", description: "Roofing sheets, flashing and insulation checks.", costHint: "15-55k EUR" },
+  { id: "full_house", label: "Full house", description: "Envelope, interior refresh and phased material plan.", costHint: "40-120k EUR" },
+  { id: "extension", label: "Extension", description: "New slab, frame, envelope and handover-ready shell.", costHint: "35-150k EUR" },
+];
+
+export const WIZARD_HOUSE_SIZE_OPTIONS: WizardOption<WizardHouseSize>[] = [
+  { id: "compact", label: "< 80 m2", description: "Small detached house, cottage or single-room project.", costHint: "0.75x" },
+  { id: "standard", label: "80-140 m2", description: "Typical Finnish omakotitalo scope.", costHint: "1.0x" },
+  { id: "large", label: "140-220 m2", description: "Large family house or multi-room renovation.", costHint: "1.35x" },
+  { id: "estate", label: "220+ m2", description: "Large property with bigger envelope and logistics load.", costHint: "1.7x" },
+];
+
+export const WIZARD_CURRENT_STATE_OPTIONS: WizardOption<WizardCurrentState>[] = [
+  { id: "modern", label: "Modernized", description: "Updated after 2010; fewer hidden-risk allowances.", costHint: "-8%" },
+  { id: "dated", label: "Dated", description: "Typical 1980-2009 condition; standard contingency.", costHint: "Base" },
+  { id: "cold", label: "Cold / original", description: "Older envelope, weak insulation or unknown structures.", costHint: "+18%" },
+  { id: "unknown", label: "Not sure", description: "Keep risk buffer until inspection or contractor visit.", costHint: "+10%" },
+];
+
+export const WIZARD_DESIGN_TIER_OPTIONS: WizardOption<WizardDesignTier>[] = [
+  { id: "good", label: "Good", description: "Durable standard materials, tight budget control.", costHint: "1.0x" },
+  { id: "better", label: "Better", description: "Improved finish, insulation and longer service life.", costHint: "1.25x" },
+  { id: "best", label: "Best", description: "Premium finish, higher comfort and resale story.", costHint: "1.6x" },
+];
+
+export const WIZARD_ENERGY_OPTIONS: WizardOption<WizardEnergyUpgrade>[] = [
+  { id: "none", label: "No energy add-on", description: "Keep scope focused on visible renovation.", costHint: "0 EUR" },
+  { id: "insulation", label: "Add insulation", description: "Upgrade envelope while surfaces are open.", costHint: "+4-18k EUR" },
+  { id: "windows", label: "Window allowance", description: "Reserve budget for openings and cold-bridge fixes.", costHint: "+6-24k EUR" },
+  { id: "heating", label: "Heating readiness", description: "Prepare BOM for heat-pump or radiator work.", costHint: "+5-20k EUR" },
+];
+
+export const DEFAULT_RENOVATION_WIZARD_STATE: RenovationWizardState = {
+  renovationType: "bathroom",
+  houseSize: "standard",
+  currentState: "dated",
+  designTier: "better",
+  energyUpgrade: "none",
+};
+
+const AREA_BY_SIZE: Record<WizardHouseSize, number> = {
+  compact: 70,
+  standard: 120,
+  large: 180,
+  estate: 260,
+};
+
+const SCOPE_AREA_FACTOR: Record<WizardRenovationType, number> = {
+  kitchen: 0.18,
+  bathroom: 0.12,
+  facade: 1.05,
+  roof: 0.9,
+  full_house: 1.25,
+  extension: 0.32,
+};
+
+const BASE_RATE: Record<WizardRenovationType, number> = {
+  kitchen: 920,
+  bathroom: 1450,
+  facade: 260,
+  roof: 310,
+  full_house: 520,
+  extension: 1800,
+};
+
+const TIER_MULTIPLIER: Record<WizardDesignTier, number> = {
+  good: 1,
+  better: 1.25,
+  best: 1.6,
+};
+
+const STATE_MULTIPLIER: Record<WizardCurrentState, number> = {
+  modern: 0.92,
+  dated: 1,
+  cold: 1.18,
+  unknown: 1.1,
+};
+
+const ENERGY_ALLOWANCE: Record<WizardEnergyUpgrade, number> = {
+  none: 0,
+  insulation: 8500,
+  windows: 12000,
+  heating: 9500,
+};
+
+const MATERIAL_FALLBACK: Record<string, { name: string; category: string; unitPrice: number }> = {
+  pine_48x98_c24: { name: "48x98 Framing timber C24", category: "lumber", unitPrice: 2.6 },
+  pine_48x148_c24: { name: "48x148 Floor joist C24", category: "lumber", unitPrice: 4.8 },
+  osb_18mm: { name: "OSB 18mm floor board", category: "sheathing", unitPrice: 18 },
+  osb_9mm: { name: "OSB 9mm board", category: "sheathing", unitPrice: 10 },
+  insulation_100mm: { name: "Mineral wool 100mm", category: "insulation", unitPrice: 8 },
+  vapor_barrier: { name: "PE vapor barrier", category: "membrane", unitPrice: 1.5 },
+  exterior_board_yellow: { name: "Exterior cladding board", category: "cladding", unitPrice: 3.4 },
+  exterior_paint_white: { name: "Exterior paint", category: "finish", unitPrice: 12 },
+  galvanized_roofing: { name: "Galvanized roof sheet", category: "roofing", unitPrice: 22 },
+  galvanized_flashing: { name: "Galvanized flashing", category: "roofing", unitPrice: 9 },
+  trim_21x45: { name: "Interior trim 21x45", category: "trim", unitPrice: 2.2 },
+  concrete_block: { name: "Concrete block 200mm", category: "masonry", unitPrice: 4.5 },
+};
+
+function scopeArea(state: RenovationWizardState, buildingInfo?: BuildingInfo | null): number {
+  const baseArea = Number(buildingInfo?.area_m2 || AREA_BY_SIZE[state.houseSize]);
+  return Math.max(8, Math.round(baseArea * SCOPE_AREA_FACTOR[state.renovationType]));
+}
+
+export function estimateWizardCost(state: RenovationWizardState, buildingInfo?: BuildingInfo | null): number {
+  const area = scopeArea(state, buildingInfo);
+  const labourAndMaterials = area * BASE_RATE[state.renovationType] * TIER_MULTIPLIER[state.designTier] * STATE_MULTIPLIER[state.currentState];
+  return Math.round((labourAndMaterials + ENERGY_ALLOWANCE[state.energyUpgrade]) / 100) * 100;
+}
+
+function rowsForScope(state: RenovationWizardState, buildingInfo?: BuildingInfo | null): WizardBomRow[] {
+  const area = scopeArea(state, buildingInfo);
+  const frameLm = Math.max(20, Math.round(area * 2.8));
+  const surfaceM2 = Math.max(12, Math.round(area * 1.15));
+  const envelopeM2 = Math.max(30, Math.round(area));
+
+  const rows: WizardBomRow[] = [];
+  if (state.renovationType === "extension") {
+    rows.push({ material_id: "concrete_block", quantity: Math.round(area * 2.2), unit: "kpl", note: "Foundation allowance" });
+    rows.push({ material_id: "pine_48x98_c24", quantity: frameLm, unit: "jm", note: "Wall frame" });
+    rows.push({ material_id: "pine_48x148_c24", quantity: Math.round(area * 1.3), unit: "jm", note: "Floor and roof framing" });
+  }
+  if (state.renovationType === "roof" || state.renovationType === "extension" || state.renovationType === "full_house") {
+    rows.push({ material_id: "galvanized_roofing", quantity: envelopeM2, unit: "m2", note: "Roof sheet allowance" });
+    rows.push({ material_id: "galvanized_flashing", quantity: Math.round(Math.sqrt(envelopeM2) * 5), unit: "jm", note: "Edges and penetrations" });
+  }
+  if (state.renovationType === "facade" || state.renovationType === "extension" || state.renovationType === "full_house") {
+    rows.push({ material_id: "exterior_board_yellow", quantity: envelopeM2, unit: "jm", note: "Exterior cladding" });
+    rows.push({ material_id: "exterior_paint_white", quantity: Math.ceil(envelopeM2 / 8), unit: "l", note: "Exterior finish" });
+  }
+  if (state.renovationType === "kitchen" || state.renovationType === "bathroom" || state.renovationType === "full_house") {
+    rows.push({ material_id: "osb_18mm", quantity: surfaceM2, unit: "m2", note: "Floor and backing board" });
+    rows.push({ material_id: "trim_21x45", quantity: Math.round(Math.sqrt(area) * 8), unit: "jm", note: "Finish trim" });
+  }
+  if (state.renovationType === "bathroom") {
+    rows.push({ material_id: "vapor_barrier", quantity: surfaceM2, unit: "m2", note: "Wet-room membrane proxy" });
+  }
+  if (state.energyUpgrade === "insulation" || state.renovationType === "facade" || state.renovationType === "extension") {
+    rows.push({ material_id: "insulation_100mm", quantity: envelopeM2, unit: "m2", note: "Envelope insulation" });
+  }
+  if (state.energyUpgrade === "windows") {
+    rows.push({ material_id: "osb_9mm", quantity: Math.max(6, Math.round(area / 10)), unit: "m2", note: "Opening repair allowance" });
+  }
+  if (state.energyUpgrade === "heating") {
+    rows.push({ material_id: "vapor_barrier", quantity: Math.max(10, Math.round(area / 3)), unit: "m2", note: "Heating route protection allowance" });
+  }
+  return rows;
+}
+
+function materialFor(id: string, materials: Material[]): Material | undefined {
+  return materials.find((material) => material.id === id);
+}
+
+export function hydrateWizardBomRows(rows: WizardBomRow[], materials: Material[] = []): BomItem[] {
+  return rows.map((row) => {
+    const material = materialFor(row.material_id, materials);
+    const primary = material?.pricing?.find((price) => price.is_primary) ?? material?.pricing?.[0];
+    const fallback = MATERIAL_FALLBACK[row.material_id] ?? { name: row.material_id, category: "wizard", unitPrice: 0 };
+    const unitPrice = Number(primary?.unit_price ?? fallback.unitPrice ?? 0);
+    return {
+      material_id: row.material_id,
+      material_name: material?.name_en || material?.name_fi || material?.name || fallback.name,
+      category_name: material?.category_name || fallback.category,
+      image_url: material?.image_url,
+      quantity: row.quantity,
+      unit: row.unit || material?.design_unit || primary?.unit || "kpl",
+      unit_price: unitPrice,
+      total: unitPrice * row.quantity,
+      supplier: primary?.supplier_name,
+      link: primary?.link,
+      in_stock: primary?.in_stock,
+      stock_level: primary?.stock_level ?? "unknown",
+      store_location: primary?.store_location,
+      stock_last_checked_at: primary?.last_checked_at,
+      note: row.note,
+      manual_override: true,
+    };
+  });
+}
+
+export function buildWizardScene(state: RenovationWizardState): string {
+  const scale = state.houseSize === "compact" ? 0.85 : state.houseSize === "large" ? 1.25 : state.houseSize === "estate" ? 1.55 : 1;
+  const width = state.renovationType === "bathroom" ? 3.2 : state.renovationType === "kitchen" ? 4.6 : 7 * scale;
+  const depth = state.renovationType === "bathroom" ? 2.4 : state.renovationType === "kitchen" ? 3.2 : 5 * scale;
+  const height = state.renovationType === "extension" ? 3.1 : 2.7;
+  const roofHeight = state.renovationType === "roof" || state.renovationType === "full_house" || state.renovationType === "extension" ? 0.55 : 0.18;
+  const facadeMaterial = state.renovationType === "roof" ? "galvanized_roofing" : "exterior_board_yellow";
+  const interiorMaterial = state.designTier === "best" ? "trim_21x45" : "osb_18mm";
+
+  return `// Helscoop guided renovation wizard
+// Scope: ${state.renovationType}, tier: ${state.designTier}, energy: ${state.energyUpgrade}
+
+const floor = box(${width.toFixed(2)}, 0.18, ${depth.toFixed(2)});
+const backWall = translate(box(${width.toFixed(2)}, ${height.toFixed(2)}, 0.16), 0, ${(height / 2 + 0.09).toFixed(2)}, ${(-depth / 2).toFixed(2)});
+const leftWall = translate(box(0.16, ${height.toFixed(2)}, ${depth.toFixed(2)}), ${(-width / 2).toFixed(2)}, ${(height / 2 + 0.09).toFixed(2)}, 0);
+const rightWall = translate(box(0.16, ${height.toFixed(2)}, ${depth.toFixed(2)}), ${(width / 2).toFixed(2)}, ${(height / 2 + 0.09).toFixed(2)}, 0);
+const roof = translate(box(${(width + 0.45).toFixed(2)}, ${roofHeight.toFixed(2)}, ${(depth + 0.45).toFixed(2)}), 0, ${(height + 0.45).toFixed(2)}, 0);
+const feature = translate(box(${Math.max(0.8, width * 0.28).toFixed(2)}, 0.12, ${Math.max(0.8, depth * 0.28).toFixed(2)}), 0, 0.32, 0);
+
+scene.add(floor, { material: "concrete_block", color: [0.58, 0.58, 0.55] });
+scene.add(backWall, { material: "${state.renovationType === "bathroom" ? "vapor_barrier" : facadeMaterial}", color: [0.82, 0.72, 0.55] });
+scene.add(leftWall, { material: "${interiorMaterial}", color: [0.86, 0.80, 0.68] });
+scene.add(rightWall, { material: "${interiorMaterial}", color: [0.86, 0.80, 0.68] });
+scene.add(roof, { material: "${state.renovationType === "roof" ? "galvanized_roofing" : "exterior_board_yellow"}", color: [0.45, 0.50, 0.48] });
+scene.add(feature, { material: "${state.energyUpgrade === "insulation" ? "insulation_100mm" : interiorMaterial}", color: [0.95, 0.82, 0.48] });
+`;
+}
+
+export function buildGuidedRenovationPlan(
+  state: RenovationWizardState,
+  materials: Material[] = [],
+  buildingInfo?: BuildingInfo | null,
+): GuidedRenovationPlan {
+  const typeLabel = WIZARD_SCOPE_OPTIONS.find((option) => option.id === state.renovationType)?.label ?? "Renovation";
+  const tierLabel = WIZARD_DESIGN_TIER_OPTIONS.find((option) => option.id === state.designTier)?.label ?? state.designTier;
+  const rows = rowsForScope(state, buildingInfo);
+  const bom = hydrateWizardBomRows(rows, materials);
+  const estimatedCost = estimateWizardCost(state, buildingInfo);
+
+  return {
+    name: `${typeLabel} renovation plan`,
+    description: `${tierLabel} guided ${typeLabel.toLowerCase()} plan generated from the Helscoop renovation wizard. Estimated budget ${estimatedCost.toLocaleString("en-GB")} EUR.`,
+    sceneJs: buildWizardScene(state),
+    bom,
+    bomRows: rows,
+    estimatedCost,
+  };
+}


### PR DESCRIPTION
Fixes #434

Summary:
- Add a reusable 5-step guided renovation wizard with limited primary choices, running budget estimate, generated scene script, generated BOM rows, and review step.
- Wire the wizard into new project creation and the project editor so homeowners can start from a guided path instead of the scene script.
- Add Simple / Advanced editor mode: Simple hides script/docs/layers; Advanced restores power-user panels.
- Add typed wizard funnel analytics for open, step viewed, completion, and editor mode changes.

Validation:
- npm test -- --run src/lib/__tests__/renovation-wizard.test.ts src/__tests__/guided-renovation-wizard.test.tsx
- npx tsc --noEmit
- npm test -- --run
- npm run build

Note: build still reports the existing Next.js warning about experimental.viewTransition.