### PR TITLE
feat: add renovation financing comparison panel

### DIFF
--- a/web/src/__tests__/renovation-financing-panel.test.tsx
+++ b/web/src/__tests__/renovation-financing-panel.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import RenovationFinancingPanel from "@/components/RenovationFinancingPanel";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+const mocks = vi.hoisted(() => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ track: mocks.track }),
+}));
+
+const materials: Material[] = [
+  {
+    id: "heat-pump",
+    name: "Air-water heat pump",
+    name_fi: "Ilma-vesilampopumppu",
+    name_en: "Air-water heat pump",
+    category_name: "heating",
+    category_name_fi: "lammitys",
+    image_url: null,
+    tags: ["energy", "air-water heat pump"],
+    pricing: [{ unit_price: 4500, unit: "pcs", supplier_name: "Test supplier", is_primary: true }],
+  },
+  {
+    id: "tile",
+    name: "Tile",
+    name_fi: "Laatta",
+    name_en: "Tile",
+    category_name: "interior",
+    category_name_fi: "sisustus",
+    image_url: null,
+    pricing: [{ unit_price: 45, unit: "m2", supplier_name: "Test supplier", is_primary: true }],
+  },
+];
+
+const eligibleBom: BomItem[] = [
+  { material_id: "heat-pump", material_name: "Air-water heat pump", quantity: 1, unit: "pcs" },
+  { material_id: "tile", material_name: "Tile", quantity: 200, unit: "m2" },
+];
+
+const buildingInfo: BuildingInfo = {
+  type: "omakotitalo",
+  year_built: 1978,
+  area_m2: 140,
+  heating: "oil",
+};
+
+describe("RenovationFinancingPanel", () => {
+  beforeEach(() => {
+    mocks.track.mockClear();
+  });
+
+  it("does not render below the financing threshold", () => {
+    const smallBom: BomItem[] = [{ material_id: "tile", material_name: "Tile", quantity: 1, unit: "m2" }];
+    const { container } = render(
+      <RenovationFinancingPanel bom={smallBom} materials={materials} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders financing offers and contextual subsidy notices", async () => {
+    render(<RenovationFinancingPanel bom={eligibleBom} materials={materials} buildingInfo={buildingInfo} />);
+
+    expect(screen.getByRole("heading", { name: "Finance this renovation" })).toBeInTheDocument();
+    expect(screen.getByText("Unsecured remonttilaina")).toBeInTheDocument();
+    expect(screen.getByText("Secured bank loan")).toBeInTheDocument();
+    expect(screen.getByText("Material payment split")).toBeInTheDocument();
+    expect(screen.getByText(/Household expense tax credit may reduce cash need/)).toBeInTheDocument();
+    expect(screen.getByText(/Energy-upgrade grant signal detected/)).toBeInTheDocument();
+    await waitFor(() => expect(mocks.track).toHaveBeenCalledWith("financing_widget_viewed", expect.objectContaining({
+      energy_grant_signal: true,
+      offer_count: 3,
+    })));
+  });
+
+  it("updates estimates when the term changes", () => {
+    render(<RenovationFinancingPanel bom={eligibleBom} materials={materials} buildingInfo={buildingInfo} />);
+
+    fireEvent.change(screen.getByLabelText("Loan term"), { target: { value: "10" } });
+
+    expect(screen.getAllByText(/120 months/).length).toBeGreaterThan(0);
+  });
+
+  it("tracks partner click-throughs", () => {
+    render(<RenovationFinancingPanel bom={eligibleBom} materials={materials} buildingInfo={buildingInfo} />);
+
+    const link = screen.getByRole("link", { name: "Compare renovation loans" });
+    expect(link).toHaveAttribute("href", expect.stringContaining("utm_source=helscoop"));
+
+    fireEvent.click(link);
+
+    expect(mocks.track).toHaveBeenCalledWith("financing_partner_clicked", expect.objectContaining({
+      partner: "sortter-remonttilaina",
+      target: "loan_comparison",
+    }));
+  });
+});

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -13,6 +13,7 @@ import BomSavingsPanel, { type BomPriceOverride } from "@/components/BomSavingsP
 import QuoteRequestModal from "@/components/QuoteRequestModal";
 import HouseholdDeductionPanel from "@/components/HouseholdDeductionPanel";
 import RenovationRoiPanel from "@/components/RenovationRoiPanel";
+import RenovationFinancingPanel from "@/components/RenovationFinancingPanel";
 import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
@@ -2709,6 +2710,13 @@ export default function BomPanel({
             materials={materials}
             buildingInfo={buildingInfo}
             coupleMode={householdDeductionJoint}
+          />
+        )}
+        {bom.length > 0 && (
+          <RenovationFinancingPanel
+            bom={bom}
+            materials={materials}
+            buildingInfo={buildingInfo}
           />
         )}
         <button

--- a/web/src/components/RenovationFinancingPanel.tsx
+++ b/web/src/components/RenovationFinancingPanel.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import {
+  RENOVATION_FINANCING_CONFIG,
+  buildRenovationFinancingPlan,
+  type FinancingNotice,
+  type FinancingOffer,
+} from "@/lib/renovation-financing";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+interface RenovationFinancingPanelProps {
+  bom: BomItem[];
+  materials: Material[];
+  buildingInfo?: BuildingInfo | null;
+}
+
+const COPY = {
+  fi: {
+    eyebrow: "Rahoitus",
+    title: "Rahoita remontti",
+    subtitle: "Muunna materiaalilista remonttilaina- ja osamaksuarvioksi ennen kumppanihakemusta.",
+    amount: "Lainasumma",
+    term: "Laina-aika",
+    years: "vuotta",
+    compare: "Vertaa remonttilainoja",
+    external: "Avaa kumppanin palvelun uudessa ikkunassa.",
+    terms: "Nopeat laina-aikavertailut",
+    details: "Arviot ennen luottopaatosta",
+    assumptions: "Oletukset",
+    notCreditOffer: "Ei luottotarjous",
+    products: {
+      unsecured_remonttilaina: "Vakuudeton remonttilaina",
+      secured_bank_loan: "Vakuudellinen pankkilaina",
+      materials_bnpl: "Materiaalien osamaksu",
+    },
+    productBodies: {
+      unsecured_remonttilaina: "Nopea vertailu, mutta korkohaitari on levea ja henkilokohtainen.",
+      secured_bank_loan: "Usein halvempi isoille remonteille, vaatii pankin ja vakuuden.",
+      materials_bnpl: "Sopii materiaaliosuuden jakamiseen, ei kata urakoitsijatyota.",
+    },
+    notices: {
+      household_deduction: (amount: string, max: string) =>
+        `Kotitalousvahennys voi pienentaa kassatarvetta noin ${amount}. Mallin katto on ${max}; tarkista Vero ja urakoitsijan ennakkoperintarekisteri.`,
+      energy_grant: (amount: string) =>
+        `Energiaremontin tukisignaali havaittu. Varaa rahoitukseen puskuri: alustava tukilippu enintaan ${amount}, mutta viranomainen ratkaisee.`,
+      unsecured_limit: (_amount: string, max: string) =>
+        `Summa ylittaa tyypillisen vakuudettoman remonttilainan ylarajan (${max}). Ohjaa kayttaja pankkiin tai jaa rahoitus osiin.`,
+      credit_disclaimer:
+        "Helscoop ei ole luotonantaja. Namat ovat suunnitteluarvioita; lopullinen korko, kulut ja hyvaksynta tulevat kumppanilta.",
+    },
+  },
+  en: {
+    eyebrow: "Financing",
+    title: "Finance this renovation",
+    subtitle: "Turn the BOM into renovation-loan and material split estimates before partner handoff.",
+    amount: "Loan amount",
+    term: "Loan term",
+    years: "years",
+    compare: "Compare renovation loans",
+    external: "Opens the partner service in a new window.",
+    terms: "Fast term comparison",
+    details: "Pre-credit-decision estimates",
+    assumptions: "Assumptions",
+    notCreditOffer: "Not a credit offer",
+    products: {
+      unsecured_remonttilaina: "Unsecured remonttilaina",
+      secured_bank_loan: "Secured bank loan",
+      materials_bnpl: "Material payment split",
+    },
+    productBodies: {
+      unsecured_remonttilaina: "Fast comparison, but the rate range is wide and personal.",
+      secured_bank_loan: "Often cheaper for larger renovations, but requires bank review and collateral.",
+      materials_bnpl: "Useful for material checkout only; it does not finance contractor labour.",
+    },
+    notices: {
+      household_deduction: (amount: string, max: string) =>
+        `Household expense tax credit may reduce cash need by about ${amount}. Model cap is ${max}; verify Vero rules and contractor registration.`,
+      energy_grant: (amount: string) =>
+        `Energy-upgrade grant signal detected. Keep financing buffer: planning flag up to ${amount}, but authority review decides eligibility.`,
+      unsecured_limit: (_amount: string, max: string) =>
+        `Amount exceeds the typical unsecured renovation-loan ceiling (${max}). Route to a bank review or split financing.`,
+      credit_disclaimer:
+        "Helscoop is not a lender. These are planning estimates; final APR, fees, and approval come from the partner.",
+    },
+  },
+} as const;
+
+function formatEur(value: number, locale: string): string {
+  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} EUR`;
+}
+
+function formatMonthlyRange(offer: Pick<FinancingOffer, "monthlyMin" | "monthlyMax">, locale: string): string {
+  if (offer.monthlyMin === offer.monthlyMax) return `${formatEur(offer.monthlyMin, locale)}/mo`;
+  return `${formatEur(offer.monthlyMin, locale)}-${formatEur(offer.monthlyMax, locale)}/mo`;
+}
+
+function noticeText(notice: FinancingNotice, locale: "fi" | "en"): string {
+  const copy = COPY[locale].notices;
+  const amount = formatEur(notice.amount ?? 0, locale);
+  const maxAmount = formatEur(notice.maxAmount ?? 0, locale);
+
+  if (notice.id === "household_deduction") return copy.household_deduction(amount, maxAmount);
+  if (notice.id === "energy_grant") return copy.energy_grant(amount);
+  if (notice.id === "unsecured_limit") return copy.unsecured_limit(amount, maxAmount);
+  return copy.credit_disclaimer;
+}
+
+function noticeTone(tone: FinancingNotice["tone"]): { border: string; background: string; color: string } {
+  if (tone === "positive") {
+    return { border: "rgba(74,124,89,0.36)", background: "rgba(74,124,89,0.12)", color: "var(--forest)" };
+  }
+  if (tone === "warning") {
+    return { border: "rgba(229,160,75,0.42)", background: "rgba(229,160,75,0.13)", color: "var(--amber)" };
+  }
+  return { border: "var(--border)", background: "rgba(255,255,255,0.025)", color: "var(--text-muted)" };
+}
+
+export default function RenovationFinancingPanel({
+  bom,
+  materials,
+  buildingInfo,
+}: RenovationFinancingPanelProps) {
+  const { locale } = useTranslation();
+  const financingLocale: "fi" | "en" = locale === "fi" ? "fi" : "en";
+  const copy = COPY[financingLocale];
+  const { track } = useAnalytics();
+  const [loanAmount, setLoanAmount] = useState("");
+  const [termYears, setTermYears] = useState<number>(RENOVATION_FINANCING_CONFIG.defaultTermYears);
+  const initializedAmountRef = useRef<number | null>(null);
+  const trackedViewRef = useRef<string | null>(null);
+
+  const recommendedPlan = useMemo(
+    () => buildRenovationFinancingPlan({ bom, materials, buildingInfo, locale: financingLocale }),
+    [bom, buildingInfo, financingLocale, materials],
+  );
+
+  useEffect(() => {
+    if (!recommendedPlan.eligible) return;
+    if (initializedAmountRef.current === recommendedPlan.quote.grandTotal) return;
+    initializedAmountRef.current = recommendedPlan.quote.grandTotal;
+    setLoanAmount(String(recommendedPlan.quote.grandTotal));
+  }, [recommendedPlan.eligible, recommendedPlan.quote.grandTotal]);
+
+  const requestedAmount = Number(loanAmount.replace(",", "."));
+  const plan = useMemo(
+    () => buildRenovationFinancingPlan({
+      bom,
+      materials,
+      buildingInfo,
+      loanAmount: Number.isFinite(requestedAmount) && requestedAmount > 0 ? requestedAmount : undefined,
+      termYears,
+      locale: financingLocale,
+    }),
+    [bom, buildingInfo, financingLocale, materials, requestedAmount, termYears],
+  );
+
+  useEffect(() => {
+    if (!plan.eligible) return;
+    const viewKey = `${plan.quote.grandTotal}`;
+    if (trackedViewRef.current === viewKey) return;
+    trackedViewRef.current = viewKey;
+    track("financing_widget_viewed", {
+      bom_total: plan.quote.grandTotal,
+      loan_amount: plan.requestedAmount,
+      term_years: plan.termYears,
+      offer_count: plan.offers.length,
+      energy_grant_signal: plan.notices.some((notice) => notice.id === "energy_grant"),
+    });
+  }, [plan, track]);
+
+  if (!plan.eligible) return null;
+
+  return (
+    <section
+      data-testid="renovation-financing-panel"
+      aria-labelledby="renovation-financing-title"
+      style={{
+        marginTop: 12,
+        padding: 14,
+        borderRadius: "var(--radius-md)",
+        border: "1px solid rgba(91,127,145,0.34)",
+        background: "linear-gradient(155deg, rgba(91,127,145,0.16), rgba(229,160,75,0.08))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <div className="label-mono" style={{ color: "#7aa5b6", fontSize: 10, marginBottom: 4 }}>
+            {copy.eyebrow}
+          </div>
+          <h4 id="renovation-financing-title" style={{ margin: 0, color: "var(--text-primary)", fontSize: 15 }}>
+            {copy.title}
+          </h4>
+          <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+            {copy.subtitle}
+          </p>
+        </div>
+        <span
+          style={{
+            borderRadius: 999,
+            padding: "4px 7px",
+            border: "1px solid rgba(91,127,145,0.35)",
+            background: "rgba(91,127,145,0.13)",
+            color: "#7aa5b6",
+            fontSize: 10,
+            fontWeight: 800,
+            textTransform: "uppercase",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {copy.notCreditOffer}
+        </span>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 12 }}>
+        <label style={{ display: "grid", gap: 5, fontSize: 11, color: "var(--text-muted)" }}>
+          <span className="label-mono">{copy.amount}</span>
+          <input
+            aria-label={copy.amount}
+            type="number"
+            min={plan.threshold}
+            step={500}
+            value={loanAmount}
+            onChange={(event) => setLoanAmount(event.target.value)}
+            style={{
+              width: "100%",
+              borderRadius: "var(--radius-sm)",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              padding: "8px 9px",
+              fontSize: 12,
+              fontFamily: "var(--font-mono)",
+            }}
+          />
+        </label>
+        <label style={{ display: "grid", gap: 5, fontSize: 11, color: "var(--text-muted)" }}>
+          <span className="label-mono">{copy.term}</span>
+          <select
+            aria-label={copy.term}
+            value={termYears}
+            onChange={(event) => setTermYears(Number(event.target.value))}
+            style={{
+              width: "100%",
+              borderRadius: "var(--radius-sm)",
+              border: "1px solid var(--border)",
+              background: "var(--bg-secondary)",
+              color: "var(--text-primary)",
+              padding: "8px 9px",
+              fontSize: 12,
+              fontFamily: "var(--font-mono)",
+            }}
+          >
+            {Array.from({ length: RENOVATION_FINANCING_CONFIG.maxTermYears }, (_, index) => index + 1).map((years) => (
+              <option key={years} value={years}>
+                {years} {copy.years}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+        {plan.offers.map((offer) => (
+          <div
+            key={offer.id}
+            style={{
+              padding: "9px 10px",
+              borderRadius: "var(--radius-sm)",
+              background: "var(--bg-tertiary)",
+              border: "1px solid var(--border)",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+              <strong style={{ fontSize: 12, color: "var(--text-primary)" }}>
+                {copy.products[offer.productType]}
+              </strong>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 12, fontWeight: 800, color: "var(--amber)" }}>
+                {formatMonthlyRange(offer, locale)}
+              </span>
+            </div>
+            <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+              {copy.productBodies[offer.productType]} APR {offer.aprMinPercent}-{offer.aprMaxPercent}%,
+              {" "}{offer.termMonths} months, total {formatEur(offer.totalRepayableMin, locale)}-
+              {formatEur(offer.totalRepayableMax, locale)}.
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ marginTop: 12 }}>
+        <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 10, marginBottom: 6 }}>
+          {copy.terms}
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 6 }}>
+          {plan.termComparisons.map((comparison) => (
+            <button
+              key={comparison.years}
+              type="button"
+              onClick={() => setTermYears(comparison.years)}
+              aria-pressed={termYears === comparison.years}
+              className="category-chip"
+              data-active={termYears === comparison.years}
+              style={{
+                display: "grid",
+                justifyItems: "start",
+                gap: 3,
+                whiteSpace: "normal",
+                textAlign: "left",
+              }}
+            >
+              <span>{comparison.years} {copy.years}</span>
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}>
+                {formatEur(comparison.unsecuredMonthlyMin, locale)}-{formatEur(comparison.unsecuredMonthlyMax, locale)}/mo
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 6, marginTop: 12 }}>
+        {plan.notices.map((notice) => {
+          const tone = noticeTone(notice.tone);
+          return (
+            <p
+              key={notice.id}
+              style={{
+                margin: 0,
+                padding: "8px 9px",
+                borderRadius: "var(--radius-sm)",
+                border: `1px solid ${tone.border}`,
+                background: tone.background,
+                color: tone.color,
+                fontSize: 11,
+                lineHeight: 1.45,
+              }}
+            >
+              {noticeText(notice, financingLocale)}
+            </p>
+          );
+        })}
+      </div>
+
+      <a
+        href={plan.partnerUrl}
+        target="_blank"
+        rel="noopener noreferrer sponsored"
+        onClick={() => track("financing_partner_clicked", {
+          partner: plan.primaryPartner.id,
+          loan_amount: plan.requestedAmount,
+          term_years: plan.termYears,
+          target: "loan_comparison",
+        })}
+        aria-label={copy.compare}
+        style={{
+          marginTop: 12,
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          padding: "9px 12px",
+          fontSize: 12,
+          fontWeight: 800,
+          color: "var(--bg-primary)",
+          background: "#7aa5b6",
+          border: "1px solid rgba(91,127,145,0.45)",
+          borderRadius: "var(--radius-sm)",
+          textDecoration: "none",
+        }}
+      >
+        {copy.compare}
+      </a>
+      <p style={{ margin: "7px 0 0", color: "var(--text-muted)", fontSize: 10, lineHeight: 1.45 }}>
+        {copy.external} {copy.assumptions}: {plan.assumptions.join(" ")}
+      </p>
+    </section>
+  );
+}

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -38,6 +38,9 @@ export type AnalyticsEvent =
   | "presentation_link_copied"
   | "presentation_render_downloaded"
   | "quote_request_submitted"
+  | "financing_widget_viewed"
+  | "financing_partner_clicked"
+  | "financing_conversion_reported"
   | "bom_exported"
   | "project_exported"
   | "project_imported"
@@ -78,6 +81,9 @@ export interface AnalyticsEventProps {
   presentation_link_copied: { preset: string };
   presentation_render_downloaded: { preset: string; watermarked: boolean };
   quote_request_submitted: { project_id: string; bom_line_count: number; estimated_cost: number };
+  financing_widget_viewed: { bom_total: number; loan_amount: number; term_years: number; offer_count: number; energy_grant_signal: boolean };
+  financing_partner_clicked: { partner: string; loan_amount: number; term_years: number; target: "loan_comparison" | "materials_bnpl" };
+  financing_conversion_reported: { partner: string; amount: number; status: "started" | "qualified" | "approved" | "rejected" };
   bom_exported: { format: "pdf" | "csv" | "json" };
   project_exported: { format: "helscoop" | "ara_grant_package" | "ifc4x3_permit" | "permit_pack_zip" };
   project_imported: { format: "helscoop" };

--- a/web/src/lib/__tests__/renovation-financing.test.ts
+++ b/web/src/lib/__tests__/renovation-financing.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFinancingPartnerUrl,
+  buildRenovationFinancingPlan,
+  calculateMonthlyPayment,
+  FINANCING_PARTNERS,
+  RENOVATION_FINANCING_CONFIG,
+} from "@/lib/renovation-financing";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+const materials: Material[] = [
+  {
+    id: "heat-pump",
+    name: "Air-water heat pump",
+    name_fi: "Ilma-vesilampopumppu",
+    name_en: "Air-water heat pump",
+    category_name: "heating",
+    category_name_fi: "lammitys",
+    image_url: null,
+    tags: ["energy", "air-water heat pump"],
+    pricing: [{ unit_price: 4500, unit: "pcs", supplier_name: "Test supplier", is_primary: true }],
+  },
+  {
+    id: "tile",
+    name: "Tile",
+    name_fi: "Laatta",
+    name_en: "Tile",
+    category_name: "interior",
+    category_name_fi: "sisustus",
+    image_url: null,
+    pricing: [{ unit_price: 45, unit: "m2", supplier_name: "Test supplier", is_primary: true }],
+  },
+];
+
+const energyBom: BomItem[] = [
+  { material_id: "heat-pump", material_name: "Air-water heat pump", quantity: 1, unit: "pcs" },
+  { material_id: "tile", material_name: "Tile", quantity: 200, unit: "m2" },
+];
+
+const buildingInfo: BuildingInfo = {
+  address: "Hidden Street 1",
+  type: "omakotitalo",
+  year_built: 1978,
+  area_m2: 140,
+  heating: "oil",
+};
+
+describe("renovation financing", () => {
+  it("calculates zero-interest monthly payments as straight-line instalments", () => {
+    expect(calculateMonthlyPayment(1200, 0, 12)).toBe(100);
+  });
+
+  it("amortizes interest-bearing loans", () => {
+    expect(calculateMonthlyPayment(1000, 12, 12)).toBeCloseTo(88.85, 2);
+  });
+
+  it("does not mark small BOMs as financing eligible", () => {
+    const plan = buildRenovationFinancingPlan({
+      bom: [{ material_id: "tile", quantity: 1, unit: "m2" }],
+      materials,
+    });
+
+    expect(plan.eligible).toBe(false);
+    expect(plan.threshold).toBe(RENOVATION_FINANCING_CONFIG.minBomTotal);
+  });
+
+  it("builds unsecured, secured, and material split offers for eligible renovations", () => {
+    const plan = buildRenovationFinancingPlan({ bom: energyBom, materials, buildingInfo, termYears: 7 });
+
+    expect(plan.eligible).toBe(true);
+    expect(plan.offers.map((offer) => offer.productType)).toEqual([
+      "unsecured_remonttilaina",
+      "secured_bank_loan",
+      "materials_bnpl",
+    ]);
+    expect(plan.offers[0].monthlyMin).toBeLessThan(plan.offers[0].monthlyMax);
+    expect(plan.termComparisons).toHaveLength(3);
+  });
+
+  it("adds household deduction and energy grant notices when context supports them", () => {
+    const plan = buildRenovationFinancingPlan({ bom: energyBom, materials, buildingInfo });
+
+    expect(plan.notices.some((notice) => notice.id === "household_deduction" && (notice.amount ?? 0) > 0)).toBe(true);
+    expect(plan.notices.some((notice) => notice.id === "energy_grant" && notice.amount === 4000)).toBe(true);
+    expect(plan.notices.at(-1)?.id).toBe("credit_disclaimer");
+  });
+
+  it("builds affiliate-ready partner URLs without leaking the address", () => {
+    const plan = buildRenovationFinancingPlan({ bom: energyBom, materials, buildingInfo, loanAmount: 12000, termYears: 5 });
+    const url = buildFinancingPartnerUrl(FINANCING_PARTNERS[0], plan, buildingInfo, "fi");
+
+    expect(url).toContain("utm_source=helscoop");
+    expect(url).toContain("amount_eur=12000");
+    expect(url).toContain("term_years=5");
+    expect(url).toContain("building_type=omakotitalo");
+    expect(url).not.toContain("Hidden");
+    expect(url).not.toContain("address");
+  });
+});

--- a/web/src/lib/renovation-financing.ts
+++ b/web/src/lib/renovation-financing.ts
@@ -1,0 +1,328 @@
+import type { BomItem, BuildingInfo, EnergyHeatingType, Material } from "@/types";
+import { calculateQuote, defaultQuoteConfig } from "@/lib/quote-engine";
+import { buildHouseholdDeductionRows, calculateHouseholdDeduction } from "@/lib/household-deduction";
+import { detectHeatingGrantOpportunity } from "@/lib/heating-grant-context";
+
+export type FinancingProductType = "unsecured_remonttilaina" | "secured_bank_loan" | "materials_bnpl";
+export type FinancingNoticeId = "household_deduction" | "energy_grant" | "unsecured_limit" | "credit_disclaimer";
+
+export interface FinancingPartner {
+  id: string;
+  name: string;
+  productType: "loan_comparison" | "materials_bnpl";
+  baseUrl: string;
+  estimatedLeadValueEur: number | null;
+  affiliateReady: boolean;
+}
+
+export interface FinancingOffer {
+  id: string;
+  productType: FinancingProductType;
+  amount: number;
+  termMonths: number;
+  aprMinPercent: number;
+  aprMaxPercent: number;
+  monthlyMin: number;
+  monthlyMax: number;
+  totalRepayableMin: number;
+  totalRepayableMax: number;
+  maxAmount: number;
+  partnerId: string | null;
+}
+
+export interface FinancingTermComparison {
+  years: number;
+  unsecuredMonthlyMin: number;
+  unsecuredMonthlyMax: number;
+  securedMonthlyMin: number;
+  securedMonthlyMax: number;
+}
+
+export interface FinancingNotice {
+  id: FinancingNoticeId;
+  tone: "positive" | "warning" | "neutral";
+  amount?: number;
+  maxAmount?: number;
+  targetHeating?: EnergyHeatingType | null;
+}
+
+export interface RenovationFinancingPlan {
+  eligible: boolean;
+  threshold: number;
+  requestedAmount: number;
+  termYears: number;
+  quote: {
+    grandTotal: number;
+    materialTotal: number;
+    labourTotal: number;
+  };
+  offers: FinancingOffer[];
+  termComparisons: FinancingTermComparison[];
+  notices: FinancingNotice[];
+  primaryPartner: FinancingPartner;
+  partnerUrl: string;
+  assumptions: string[];
+}
+
+export interface BuildRenovationFinancingInput {
+  bom: BomItem[];
+  materials: Material[];
+  buildingInfo?: BuildingInfo | null;
+  loanAmount?: number;
+  termYears?: number;
+  locale?: "fi" | "en" | "sv";
+}
+
+const UNSECURED_RATE = { min: 4, max: 15, maxAmount: 70000 };
+const SECURED_RATE = { min: 4, max: 8, maxAmount: 150000 };
+const BNPL_RATE = { min: 0, max: 18, maxAmount: 15000, termMonths: 12 };
+
+export const RENOVATION_FINANCING_CONFIG = {
+  minBomTotal: 2000,
+  defaultTermYears: 7,
+  comparisonTermsYears: [3, 7, 12],
+  minTermYears: 1,
+  maxTermYears: 15,
+  checkedAt: "2026-04-23",
+} as const;
+
+export const FINANCING_PARTNERS: FinancingPartner[] = [
+  {
+    id: "sortter-remonttilaina",
+    name: "Sortter",
+    productType: "loan_comparison",
+    baseUrl: "https://www.sortter.fi/lainaa/remonttilaina/",
+    estimatedLeadValueEur: 50,
+    affiliateReady: true,
+  },
+  {
+    id: "materials-bnpl-slot",
+    name: "Klarna/Walley material split",
+    productType: "materials_bnpl",
+    baseUrl: "https://www.helscoop.fi/partners/material-financing",
+    estimatedLeadValueEur: null,
+    affiliateReady: false,
+  },
+];
+
+function roundEuro(value: number): number {
+  return Math.round(value);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizedMoney(value: number | undefined, fallback: number): number {
+  if (value == null || !Number.isFinite(value)) return fallback;
+  return Math.max(0, value);
+}
+
+export function calculateMonthlyPayment(principal: number, annualRatePercent: number, termMonths: number): number {
+  const amount = Math.max(0, principal);
+  const months = Math.max(1, Math.round(termMonths));
+  const monthlyRate = Math.max(0, annualRatePercent) / 100 / 12;
+
+  if (monthlyRate === 0) return amount / months;
+  return amount * (monthlyRate / (1 - (1 + monthlyRate) ** -months));
+}
+
+function buildOffer(input: {
+  id: string;
+  productType: FinancingProductType;
+  amount: number;
+  termMonths: number;
+  aprMinPercent: number;
+  aprMaxPercent: number;
+  maxAmount: number;
+  partnerId: string | null;
+}): FinancingOffer {
+  const monthlyMin = calculateMonthlyPayment(input.amount, input.aprMinPercent, input.termMonths);
+  const monthlyMax = calculateMonthlyPayment(input.amount, input.aprMaxPercent, input.termMonths);
+
+  return {
+    id: input.id,
+    productType: input.productType,
+    amount: roundEuro(input.amount),
+    termMonths: input.termMonths,
+    aprMinPercent: input.aprMinPercent,
+    aprMaxPercent: input.aprMaxPercent,
+    monthlyMin: roundEuro(monthlyMin),
+    monthlyMax: roundEuro(monthlyMax),
+    totalRepayableMin: roundEuro(monthlyMin * input.termMonths),
+    totalRepayableMax: roundEuro(monthlyMax * input.termMonths),
+    maxAmount: input.maxAmount,
+    partnerId: input.partnerId,
+  };
+}
+
+function estimateEnergyGrantAmount(targetHeating: EnergyHeatingType | null, fossilSourceHeating: boolean): number {
+  if (!targetHeating && !fossilSourceHeating) return 0;
+  if (
+    targetHeating === "district_heat" ||
+    targetHeating === "ground_source_heat_pump" ||
+    targetHeating === "air_water_heat_pump"
+  ) {
+    return 4000;
+  }
+  return 2500;
+}
+
+function primaryPartner(): FinancingPartner {
+  return FINANCING_PARTNERS[0];
+}
+
+export function buildFinancingPartnerUrl(
+  partner: FinancingPartner,
+  plan: Pick<RenovationFinancingPlan, "requestedAmount" | "termYears" | "quote">,
+  buildingInfo?: BuildingInfo | null,
+  locale: "fi" | "en" | "sv" = "fi",
+): string {
+  const url = new URL(partner.baseUrl);
+
+  url.searchParams.set("utm_source", "helscoop");
+  url.searchParams.set("utm_medium", "embedded_financing");
+  url.searchParams.set("utm_campaign", "bom_financing");
+  url.searchParams.set("product", partner.productType);
+  url.searchParams.set("amount_eur", String(Math.round(plan.requestedAmount)));
+  url.searchParams.set("term_years", String(plan.termYears));
+  url.searchParams.set("material_cost_eur", String(Math.round(plan.quote.materialTotal)));
+  url.searchParams.set("labour_cost_eur", String(Math.round(plan.quote.labourTotal)));
+  url.searchParams.set("locale", locale);
+
+  if (buildingInfo?.type) url.searchParams.set("building_type", buildingInfo.type);
+  if (buildingInfo?.area_m2) url.searchParams.set("area_m2", String(Math.round(buildingInfo.area_m2)));
+  if (buildingInfo?.year_built) url.searchParams.set("year_built", String(buildingInfo.year_built));
+  if (buildingInfo?.heating) url.searchParams.set("heating", buildingInfo.heating);
+
+  return url.toString();
+}
+
+export function buildRenovationFinancingPlan(input: BuildRenovationFinancingInput): RenovationFinancingPlan {
+  const quote = calculateQuote(input.bom, input.materials, defaultQuoteConfig("homeowner"));
+  const materialTotal = quote.materialSubtotal * (1 + quote.config.vatRate);
+  const labourTotal = quote.labourSubtotal * (1 + quote.config.vatRate);
+  const recommendedAmount = roundEuro(quote.grandTotal);
+  const requestedAmount = roundEuro(normalizedMoney(input.loanAmount, recommendedAmount));
+  const termYears = clamp(
+    Math.round(input.termYears ?? RENOVATION_FINANCING_CONFIG.defaultTermYears),
+    RENOVATION_FINANCING_CONFIG.minTermYears,
+    RENOVATION_FINANCING_CONFIG.maxTermYears,
+  );
+  const termMonths = termYears * 12;
+  const quoteSummary = {
+    grandTotal: roundEuro(quote.grandTotal),
+    materialTotal: roundEuro(materialTotal),
+    labourTotal: roundEuro(labourTotal),
+  };
+
+  const partner = primaryPartner();
+  const offers = [
+    buildOffer({
+      id: "unsecured-remonttilaina",
+      productType: "unsecured_remonttilaina",
+      amount: requestedAmount,
+      termMonths,
+      aprMinPercent: UNSECURED_RATE.min,
+      aprMaxPercent: UNSECURED_RATE.max,
+      maxAmount: UNSECURED_RATE.maxAmount,
+      partnerId: partner.id,
+    }),
+    buildOffer({
+      id: "secured-bank-loan",
+      productType: "secured_bank_loan",
+      amount: requestedAmount,
+      termMonths,
+      aprMinPercent: SECURED_RATE.min,
+      aprMaxPercent: SECURED_RATE.max,
+      maxAmount: SECURED_RATE.maxAmount,
+      partnerId: partner.id,
+    }),
+    buildOffer({
+      id: "materials-bnpl",
+      productType: "materials_bnpl",
+      amount: Math.min(quoteSummary.materialTotal, BNPL_RATE.maxAmount),
+      termMonths: BNPL_RATE.termMonths,
+      aprMinPercent: BNPL_RATE.min,
+      aprMaxPercent: BNPL_RATE.max,
+      maxAmount: BNPL_RATE.maxAmount,
+      partnerId: "materials-bnpl-slot",
+    }),
+  ];
+
+  const termComparisons = RENOVATION_FINANCING_CONFIG.comparisonTermsYears.map((years) => {
+    const months = years * 12;
+    return {
+      years,
+      unsecuredMonthlyMin: roundEuro(calculateMonthlyPayment(requestedAmount, UNSECURED_RATE.min, months)),
+      unsecuredMonthlyMax: roundEuro(calculateMonthlyPayment(requestedAmount, UNSECURED_RATE.max, months)),
+      securedMonthlyMin: roundEuro(calculateMonthlyPayment(requestedAmount, SECURED_RATE.min, months)),
+      securedMonthlyMax: roundEuro(calculateMonthlyPayment(requestedAmount, SECURED_RATE.max, months)),
+    };
+  });
+
+  const deduction = calculateHouseholdDeduction(buildHouseholdDeductionRows(quote));
+  const grantOpportunity = detectHeatingGrantOpportunity({
+    bom: input.bom,
+    materials: input.materials,
+    buildingInfo: input.buildingInfo,
+  });
+  const notices: FinancingNotice[] = [];
+
+  if (deduction.credit > 0) {
+    notices.push({
+      id: "household_deduction",
+      tone: "positive",
+      amount: roundEuro(deduction.credit),
+      maxAmount: roundEuro(deduction.maxCredit),
+    });
+  }
+
+  const grantAmount = estimateEnergyGrantAmount(
+    grantOpportunity.detectedTargetHeating,
+    grantOpportunity.fossilSourceHeating,
+  );
+  if (grantOpportunity.shouldShow && grantAmount > 0) {
+    notices.push({
+      id: "energy_grant",
+      tone: "positive",
+      amount: grantAmount,
+      targetHeating: grantOpportunity.detectedTargetHeating,
+    });
+  }
+
+  if (requestedAmount > UNSECURED_RATE.maxAmount) {
+    notices.push({
+      id: "unsecured_limit",
+      tone: "warning",
+      amount: requestedAmount,
+      maxAmount: UNSECURED_RATE.maxAmount,
+    });
+  }
+
+  notices.push({ id: "credit_disclaimer", tone: "neutral" });
+
+  const planShell = {
+    requestedAmount,
+    termYears,
+    quote: quoteSummary,
+  };
+
+  return {
+    eligible: quote.grandTotal >= RENOVATION_FINANCING_CONFIG.minBomTotal,
+    threshold: RENOVATION_FINANCING_CONFIG.minBomTotal,
+    requestedAmount,
+    termYears,
+    quote: quoteSummary,
+    offers,
+    termComparisons,
+    notices,
+    primaryPartner: partner,
+    partnerUrl: buildFinancingPartnerUrl(partner, planShell, input.buildingInfo, input.locale ?? "fi"),
+    assumptions: [
+      `Planning APR ranges: unsecured ${UNSECURED_RATE.min}-${UNSECURED_RATE.max}%, secured ${SECURED_RATE.min}-${SECURED_RATE.max}%.`,
+      `Material split estimate caps financed materials at ${BNPL_RATE.maxAmount} EUR over ${BNPL_RATE.termMonths} months.`,
+      `Config checked ${RENOVATION_FINANCING_CONFIG.checkedAt}; replace with partner API rates before credit decisions.`,
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- add a BOM-driven renovation financing planner for loan amount, 1-15 year term, unsecured/secured loan ranges, and material split estimates
- mount a financing panel in the BOM flow above quote requests when estimated renovation cost exceeds 2000 EUR
- add contextual household deduction and energy grant notices, affiliate-ready Sortter handoff URL, and typed financing funnel analytics

## Validation
- npm test -- --run src/lib/__tests__/renovation-financing.test.ts src/__tests__/renovation-financing-panel.test.tsx
- npx tsc --noEmit
- npm test -- --run
- npm run build

Note: build still prints the existing Next warning for experimental.viewTransition.

Fixes #430