### PR TITLE
feat: build sequence auto-play in layer panel

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -333,6 +333,25 @@
   border-left-color: rgba(0, 0, 0, 0.06);
 }
 
+.layer-autoplay-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+.layer-autoplay-btn:hover {
+  color: var(--amber);
+  border-color: rgba(229, 160, 75, 0.3);
+  background: rgba(229, 160, 75, 0.06);
+}
+
 [data-theme="light"] .chat-messages-area {
   background: rgba(250, 250, 250, 0.7);
   backdrop-filter: blur(14px) saturate(1.2);

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -3427,6 +3427,7 @@ export default function ProjectPage() {
             onToggleLayerLock={handleToggleLayerLock}
             onOpenLayerMaterial={handleOpenLayerMaterial}
             onFocusLayer={(layerId) => focusObjectRef.current?.(layerId)}
+            onSetHiddenLayers={setHiddenLayerIds}
           />
         )}
 

--- a/web/src/components/LayerPanel.tsx
+++ b/web/src/components/LayerPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import type { SceneLayer } from "@/lib/scene-layers";
 
@@ -14,6 +14,7 @@ interface LayerPanelProps {
   onToggleLayerLock: (layerId: string) => void;
   onOpenLayerMaterial?: (layerId: string) => void;
   onFocusLayer?: (layerId: string) => void;
+  onSetHiddenLayers?: (ids: Set<string>) => void;
   style?: React.CSSProperties;
 }
 
@@ -63,11 +64,57 @@ export default function LayerPanel({
   onToggleLayerLock,
   onOpenLayerMaterial,
   onFocusLayer,
+  onSetHiddenLayers,
   style,
 }: LayerPanelProps) {
   const { t, locale } = useTranslation();
   const rowRefs = useRef(new Map<string, HTMLDivElement>());
   const orderedIds = useMemo(() => layers.map((layer) => layer.id), [layers]);
+
+  const [autoplayActive, setAutoplayActive] = useState(false);
+  const [autoplayStep, setAutoplayStep] = useState(0);
+  const autoplayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const savedHiddenRef = useRef<Set<string> | null>(null);
+
+  const stopAutoplay = useCallback(() => {
+    setAutoplayActive(false);
+    if (autoplayTimerRef.current) {
+      clearTimeout(autoplayTimerRef.current);
+      autoplayTimerRef.current = null;
+    }
+    if (savedHiddenRef.current !== null) {
+      onSetHiddenLayers?.(savedHiddenRef.current);
+      savedHiddenRef.current = null;
+    }
+  }, [onSetHiddenLayers]);
+
+  const advanceAutoplay = useCallback((step: number) => {
+    if (step >= orderedIds.length) {
+      stopAutoplay();
+      return;
+    }
+    setAutoplayStep(step);
+    const hiddenIds = new Set(orderedIds.slice(step + 1));
+    onSetHiddenLayers?.(hiddenIds);
+    onSelectLayer(orderedIds[step]);
+    onFocusLayer?.(orderedIds[step]);
+    autoplayTimerRef.current = setTimeout(() => advanceAutoplay(step + 1), 3000);
+  }, [orderedIds, onSetHiddenLayers, onSelectLayer, onFocusLayer, stopAutoplay]);
+
+  const startAutoplay = useCallback(() => {
+    if (orderedIds.length === 0 || !onSetHiddenLayers) return;
+    savedHiddenRef.current = new Set(hiddenLayerIds);
+    setAutoplayActive(true);
+    setAutoplayStep(0);
+    onSetHiddenLayers(new Set(orderedIds));
+    setTimeout(() => advanceAutoplay(0), 500);
+  }, [orderedIds, hiddenLayerIds, onSetHiddenLayers, advanceAutoplay]);
+
+  useEffect(() => {
+    return () => {
+      if (autoplayTimerRef.current) clearTimeout(autoplayTimerRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (!selectedLayerId) return;
@@ -134,10 +181,54 @@ export default function LayerPanel({
           <div className="label-mono" style={{ marginBottom: 6 }}>{t("layers.eyebrow")}</div>
           <div className="heading-display" style={{ fontSize: 18 }}>{t("layers.title")}</div>
         </div>
-        <span className="badge badge-amber" aria-label={t("layers.layerCount", { count: layers.length })}>
-          {layers.length}
-        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          {layers.length > 1 && onSetHiddenLayers && (
+            <button
+              type="button"
+              className="layer-autoplay-btn"
+              onClick={autoplayActive ? stopAutoplay : startAutoplay}
+              aria-label={autoplayActive ? t("layers.stopAutoplay") : t("layers.startAutoplay")}
+              title={autoplayActive ? t("layers.stopAutoplay") : t("layers.startAutoplay")}
+            >
+              {autoplayActive ? (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                  <rect x="6" y="5" width="4" height="14" rx="1" />
+                  <rect x="14" y="5" width="4" height="14" rx="1" />
+                </svg>
+              ) : (
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                  <polygon points="6,4 20,12 6,20" />
+                </svg>
+              )}
+            </button>
+          )}
+          <span className="badge badge-amber" aria-label={t("layers.layerCount", { count: layers.length })}>
+            {layers.length}
+          </span>
+        </div>
       </div>
+
+      {autoplayActive && (
+        <div style={{ padding: "0 14px 8px", display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{
+            flex: 1,
+            height: 3,
+            background: "var(--border)",
+            borderRadius: 2,
+            overflow: "hidden",
+          }}>
+            <div style={{
+              width: `${((autoplayStep + 1) / layers.length) * 100}%`,
+              height: "100%",
+              background: "var(--amber)",
+              transition: "width 0.4s ease-out",
+            }} />
+          </div>
+          <span className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)", whiteSpace: "nowrap" }}>
+            {autoplayStep + 1}/{layers.length}
+          </span>
+        </div>
+      )}
 
       {layers.length === 0 ? (
         <div

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -917,6 +917,8 @@ const translations = {
       costApprox: 'Arvioitu kustannus',
       noCost: 'Ei hintaa',
       viewportHint: 'Klikkaa objektia valitaksesi sen tason',
+      startAutoplay: 'Toista rakennusjärjestys',
+      stopAutoplay: 'Pysäytä toisto',
     },
     commandPalette: {
       title: 'Komentovalikko',
@@ -2557,6 +2559,8 @@ const translations = {
       costApprox: 'Approximate cost',
       noCost: 'No cost',
       viewportHint: 'Click a mesh to select its layer',
+      startAutoplay: 'Play build sequence',
+      stopAutoplay: 'Stop playback',
     },
     commandPalette: {
       title: 'Command palette',
@@ -4112,6 +4116,8 @@ const translations = {
       costApprox: 'Ungefärlig kostnad',
       noCost: 'Ingen kostnad',
       viewportHint: 'Klicka på en mesh för att välja dess lager',
+      startAutoplay: 'Spela byggsekvens',
+      stopAutoplay: 'Stoppa uppspelning',
     },
     commandPalette: {
       title: 'Kommandopalett',


### PR DESCRIPTION
## Summary
- Adds play/pause button to LayerPanel header for auto-playing through layers sequentially (3s per step)
- Camera auto-focuses on each layer as it appears, using the existing focus-on-object feature
- Progress bar shows current step and total count
- Original layer visibility state is restored when playback stops
- New `onSetHiddenLayers` prop enables batch visibility control for smooth autoplay

## Test plan
- [ ] Click play button → layers reveal one at a time from first to last
- [ ] Camera animates to frame each newly revealed layer
- [ ] Progress bar updates with each step
- [ ] Click pause → playback stops, original visibility restored
- [ ] Play button hidden when fewer than 2 layers
- [ ] No button shown when `onSetHiddenLayers` prop is not provided

Fixes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)