### PR TITLE
feat: add EU energy grant pre-check

### DIFF
--- a/web/src/__tests__/eu-energy-grant-precheck-panel.test.tsx
+++ b/web/src/__tests__/eu-energy-grant-precheck-panel.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import EuEnergyGrantPrecheckPanel from "@/components/EuEnergyGrantPrecheckPanel";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+const materials: Material[] = [
+  {
+    id: "solar-panel",
+    name: "Solar panel",
+    name_fi: "Aurinkopaneeli",
+    name_en: "Solar panel",
+    category_name: "solar",
+    category_name_fi: "aurinko",
+    image_url: null,
+    tags: ["solar", "energy community"],
+    pricing: [{ unit_price: 250, unit: "pcs", supplier_name: "Test", is_primary: true }],
+  },
+  {
+    id: "smart-control",
+    name: "Smart heating control",
+    name_fi: "Alyohjaus",
+    name_en: "Smart heating control",
+    category_name: "controls",
+    category_name_fi: "ohjaus",
+    image_url: null,
+    tags: ["smart controls"],
+    pricing: [{ unit_price: 1200, unit: "pcs", supplier_name: "Test", is_primary: true }],
+  },
+];
+
+const bom: BomItem[] = [
+  { material_id: "solar-panel", quantity: 80, unit: "pcs" },
+  { material_id: "smart-control", quantity: 1, unit: "pcs" },
+];
+
+const buildingInfo: BuildingInfo = { type: "kerrostalo", units: 24, year_built: 1975, address: "Testikatu 1, Helsinki" };
+
+describe("EuEnergyGrantPrecheckPanel", () => {
+  it("renders official-source grant programs with funding badge", () => {
+    render(<EuEnergyGrantPrecheckPanel bom={bom} materials={materials} buildingInfo={buildingInfo} totalCost={60000} />);
+
+    expect(screen.getByRole("heading", { name: "EU and energy grant pre-check" })).toBeInTheDocument();
+    expect(screen.getByText(/Potential funding: 45,000 EUR/)).toBeInTheDocument();
+    expect(screen.getByText("Business Finland Energy Aid")).toBeInTheDocument();
+    expect(screen.getByText("EU Energy Communities Facility")).toBeInTheDocument();
+    expect(screen.getByText("Motiva energy advice")).toBeInTheDocument();
+    expect(screen.getByText(/exclude housing associations/)).toBeInTheDocument();
+  });
+
+  it("removes the EU cash signal when community scopes are unchecked", () => {
+    render(<EuEnergyGrantPrecheckPanel bom={bom} materials={materials} buildingInfo={buildingInfo} totalCost={60000} />);
+
+    fireEvent.click(screen.getByLabelText("Solar"));
+    fireEvent.click(screen.getByLabelText("Smart controls"));
+
+    expect(screen.getByText("No automatic cash signal")).toBeInTheDocument();
+  });
+
+  it("marks already-started projects as blocked for the EU facility", () => {
+    render(<EuEnergyGrantPrecheckPanel bom={bom} materials={materials} buildingInfo={buildingInfo} totalCost={60000} />);
+
+    fireEvent.change(screen.getByLabelText("Stage"), { target: { value: "ordered_or_started" } });
+
+    expect(screen.getByText(/before implementation/)).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/project-card.test.tsx
+++ b/web/src/__tests__/project-card.test.tsx
@@ -55,6 +55,17 @@ describe("ProjectCard", () => {
     expect(screen.getByText(/8500/)).toBeInTheDocument();
   });
 
+  it("renders funding badge for community energy projects", () => {
+    const fundedProject: Project = {
+      ...mockProject,
+      estimated_cost: 60000,
+      building_info: { type: "kerrostalo", units: 24 },
+      bom: [{ material_id: "solar-panel", material_name: "Solar panel", category_name: "solar", quantity: 80, unit: "pcs" }],
+    };
+    render(<ProjectCard project={fundedProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+    expect(screen.getByText(/Funding 45,000/)).toBeInTheDocument();
+  });
+
   it("hides cost badge when estimated_cost is 0", () => {
     const noCost = { ...mockProject, estimated_cost: 0 };
     const { container } = render(<ProjectCard project={noCost} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -14,6 +14,7 @@ import QuoteRequestModal from "@/components/QuoteRequestModal";
 import HouseholdDeductionPanel from "@/components/HouseholdDeductionPanel";
 import RenovationRoiPanel from "@/components/RenovationRoiPanel";
 import RenovationFinancingPanel from "@/components/RenovationFinancingPanel";
+import EuEnergyGrantPrecheckPanel from "@/components/EuEnergyGrantPrecheckPanel";
 import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
@@ -2717,6 +2718,14 @@ export default function BomPanel({
             bom={bom}
             materials={materials}
             buildingInfo={buildingInfo}
+          />
+        )}
+        {bom.length > 0 && (
+          <EuEnergyGrantPrecheckPanel
+            bom={bom}
+            materials={materials}
+            buildingInfo={buildingInfo}
+            totalCost={total}
           />
         )}
         <button

--- a/web/src/components/EuEnergyGrantPrecheckPanel.tsx
+++ b/web/src/components/EuEnergyGrantPrecheckPanel.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import {
+  buildEuEnergyGrantPrecheck,
+  type EuEnergyGrantAnswers,
+  type EuGrantApplicantType,
+  type EuGrantProjectStage,
+  type EuGrantScope,
+  type EuGrantStatus,
+} from "@/lib/eu-energy-grants";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+interface EuEnergyGrantPrecheckPanelProps {
+  bom: BomItem[];
+  materials: Material[];
+  buildingInfo?: BuildingInfo | null;
+  totalCost?: number;
+}
+
+const SCOPES: EuGrantScope[] = ["heating", "insulation", "windows", "solar", "smart_controls", "storage", "ev_charging"];
+
+const COPY = {
+  fi: {
+    eyebrow: "Rahoituspolku",
+    title: "EU- ja energiatukien esitarkistus",
+    subtitle: "Tarkista Business Finland, EU Energy Communities Facility ja Motivan neuvonta ennen kuin tyot tilataan.",
+    applicant: "Hakija",
+    building: "Rakennus",
+    year: "Rakennusvuosi",
+    location: "Sijainti",
+    stage: "Vaihe",
+    scopes: "Remontin sisalto",
+    badge: "Mahdollinen tuki",
+    noCash: "Ei automaattista rahasignaalia",
+    source: "Virallinen lahde",
+    next: "Seuraavat askeleet",
+    blockers: "Esteet",
+    disclaimerPrefix: "Huomio",
+    applicantTypes: {
+      private_owner: "Yksityinen omistaja",
+      housing_company: "Taloyhtio",
+      energy_community: "Energiayhteiso",
+      company_or_municipality: "Yritys / kunta",
+    },
+    buildingTypes: {
+      omakotitalo: "Omakotitalo",
+      rivitalo: "Rivi- tai paritalo",
+      kerrostalo: "Kerrostalo",
+      non_residential: "Ei-asuinrakennus",
+      unknown: "Ei tiedossa",
+    },
+    stages: {
+      planning: "Suunnittelu, ei tilattu",
+      ordered_or_started: "Tilattu tai aloitettu",
+    },
+    scopeLabels: {
+      heating: "Lammitys",
+      insulation: "Eristys",
+      windows: "Ikkunat",
+      solar: "Aurinkoenergia",
+      smart_controls: "Alyohjaus",
+      storage: "Varastointi",
+      ev_charging: "Lataus",
+    },
+    status: {
+      eligible: "Sopiva",
+      maybe: "Mahdollinen",
+      not_eligible: "Ei sovi",
+      info: "Neuvonta",
+    },
+  },
+  en: {
+    eyebrow: "Funding path",
+    title: "EU and energy grant pre-check",
+    subtitle: "Screen Business Finland, EU Energy Communities Facility, and Motiva advice before work is ordered.",
+    applicant: "Applicant",
+    building: "Building",
+    year: "Building year",
+    location: "Location",
+    stage: "Stage",
+    scopes: "Renovation scope",
+    badge: "Potential funding",
+    noCash: "No automatic cash signal",
+    source: "Official source",
+    next: "Next steps",
+    blockers: "Blockers",
+    disclaimerPrefix: "Note",
+    applicantTypes: {
+      private_owner: "Private owner",
+      housing_company: "Housing company",
+      energy_community: "Energy community",
+      company_or_municipality: "Company / municipality",
+    },
+    buildingTypes: {
+      omakotitalo: "Detached house",
+      rivitalo: "Row or semi-detached",
+      kerrostalo: "Apartment building",
+      non_residential: "Non-residential",
+      unknown: "Unknown",
+    },
+    stages: {
+      planning: "Planning, not ordered",
+      ordered_or_started: "Ordered or started",
+    },
+    scopeLabels: {
+      heating: "Heating",
+      insulation: "Insulation",
+      windows: "Windows",
+      solar: "Solar",
+      smart_controls: "Smart controls",
+      storage: "Storage",
+      ev_charging: "EV charging",
+    },
+    status: {
+      eligible: "Eligible",
+      maybe: "Potential",
+      not_eligible: "Blocked",
+      info: "Advice",
+    },
+  },
+} as const;
+
+function formatEur(value: number, locale: string): string {
+  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} EUR`;
+}
+
+function statusTone(status: EuGrantStatus): { border: string; background: string; color: string } {
+  if (status === "eligible" || status === "maybe") {
+    return { border: "rgba(74,124,89,0.36)", background: "rgba(74,124,89,0.12)", color: "var(--forest)" };
+  }
+  if (status === "not_eligible") {
+    return { border: "rgba(229,160,75,0.38)", background: "rgba(229,160,75,0.10)", color: "var(--amber)" };
+  }
+  return { border: "var(--border)", background: "rgba(255,255,255,0.025)", color: "var(--text-muted)" };
+}
+
+export default function EuEnergyGrantPrecheckPanel({
+  bom,
+  materials,
+  buildingInfo,
+  totalCost = 0,
+}: EuEnergyGrantPrecheckPanelProps) {
+  const { locale } = useTranslation();
+  const grantLocale: "fi" | "en" = locale === "fi" ? "fi" : "en";
+  const copy = COPY[grantLocale];
+  const inferred = useMemo(
+    () => buildEuEnergyGrantPrecheck({ bom, materials, buildingInfo, totalCost }),
+    [bom, buildingInfo, materials, totalCost],
+  );
+  const [answers, setAnswers] = useState<EuEnergyGrantAnswers>(inferred.answers);
+
+  const result = useMemo(
+    () => buildEuEnergyGrantPrecheck({ bom, materials, buildingInfo, totalCost, answers }),
+    [answers, bom, buildingInfo, materials, totalCost],
+  );
+
+  const updateScope = (scope: EuGrantScope, checked: boolean) => {
+    setAnswers((prev) => ({
+      ...prev,
+      scopes: checked
+        ? Array.from(new Set([...prev.scopes, scope]))
+        : prev.scopes.filter((item) => item !== scope),
+    }));
+  };
+
+  return (
+    <section
+      data-testid="eu-energy-grant-precheck"
+      aria-labelledby="eu-energy-grant-title"
+      style={{
+        marginTop: 12,
+        padding: 14,
+        borderRadius: "var(--radius-md)",
+        border: "1px solid rgba(74,124,89,0.28)",
+        background: "linear-gradient(150deg, rgba(74,124,89,0.12), rgba(91,127,145,0.08))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 10 }}>
+        <div>
+          <div className="label-mono" style={{ color: "var(--forest)", fontSize: 10, marginBottom: 4 }}>
+            {copy.eyebrow}
+          </div>
+          <h4 id="eu-energy-grant-title" style={{ margin: 0, color: "var(--text-primary)", fontSize: 15 }}>
+            {copy.title}
+          </h4>
+          <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+            {copy.subtitle}
+          </p>
+        </div>
+        <span
+          style={{
+            borderRadius: 999,
+            padding: "4px 7px",
+            border: "1px solid rgba(74,124,89,0.36)",
+            background: "rgba(74,124,89,0.12)",
+            color: "var(--forest)",
+            fontSize: 10,
+            fontWeight: 800,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {result.fundingBadge.show
+            ? `${copy.badge}: ${formatEur(result.fundingBadge.amount, locale)}`
+            : copy.noCash}
+        </span>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(135px, 1fr))", gap: 8, marginTop: 12 }}>
+        <label style={{ display: "grid", gap: 4, color: "var(--text-muted)", fontSize: 10 }}>
+          <span className="label-mono">{copy.applicant}</span>
+          <select
+            aria-label={copy.applicant}
+            value={answers.applicantType}
+            onChange={(event) => setAnswers((prev) => ({ ...prev, applicantType: event.target.value as EuGrantApplicantType }))}
+            className="input"
+            style={{ minHeight: 34 }}
+          >
+            {Object.entries(copy.applicantTypes).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
+        <label style={{ display: "grid", gap: 4, color: "var(--text-muted)", fontSize: 10 }}>
+          <span className="label-mono">{copy.building}</span>
+          <select
+            aria-label={copy.building}
+            value={answers.buildingType}
+            onChange={(event) => setAnswers((prev) => ({ ...prev, buildingType: event.target.value as EuEnergyGrantAnswers["buildingType"] }))}
+            className="input"
+            style={{ minHeight: 34 }}
+          >
+            {Object.entries(copy.buildingTypes).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
+        <label style={{ display: "grid", gap: 4, color: "var(--text-muted)", fontSize: 10 }}>
+          <span className="label-mono">{copy.year}</span>
+          <input
+            aria-label={copy.year}
+            type="number"
+            className="input"
+            value={answers.buildingYear ?? ""}
+            onChange={(event) => setAnswers((prev) => ({ ...prev, buildingYear: event.target.value ? Number(event.target.value) : null }))}
+            style={{ minHeight: 34 }}
+          />
+        </label>
+        <label style={{ display: "grid", gap: 4, color: "var(--text-muted)", fontSize: 10 }}>
+          <span className="label-mono">{copy.stage}</span>
+          <select
+            aria-label={copy.stage}
+            value={answers.stage}
+            onChange={(event) => setAnswers((prev) => ({ ...prev, stage: event.target.value as EuGrantProjectStage }))}
+            className="input"
+            style={{ minHeight: 34 }}
+          >
+            {Object.entries(copy.stages).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <label style={{ display: "grid", gap: 4, marginTop: 8, color: "var(--text-muted)", fontSize: 10 }}>
+        <span className="label-mono">{copy.location}</span>
+        <input
+          aria-label={copy.location}
+          className="input"
+          value={answers.location}
+          onChange={(event) => setAnswers((prev) => ({ ...prev, location: event.target.value }))}
+          style={{ minHeight: 34 }}
+        />
+      </label>
+
+      <div style={{ marginTop: 10 }}>
+        <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 10, marginBottom: 6 }}>
+          {copy.scopes}
+        </div>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {SCOPES.map((scope) => (
+            <label key={scope} className="category-chip" data-active={answers.scopes.includes(scope)}>
+              <input
+                type="checkbox"
+                checked={answers.scopes.includes(scope)}
+                onChange={(event) => updateScope(scope, event.currentTarget.checked)}
+                style={{ marginRight: 4 }}
+              />
+              {copy.scopeLabels[scope]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+        {result.programs.map((program) => {
+          const tone = statusTone(program.status);
+          return (
+            <article
+              key={program.id}
+              style={{
+                padding: "10px 11px",
+                borderRadius: "var(--radius-sm)",
+                border: `1px solid ${tone.border}`,
+                background: tone.background,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "baseline" }}>
+                <strong style={{ color: "var(--text-primary)", fontSize: 12 }}>{program.name}</strong>
+                <span style={{ color: tone.color, fontSize: 10, fontWeight: 800, textTransform: "uppercase" }}>
+                  {copy.status[program.status]}
+                </span>
+              </div>
+              <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+                {program.amountDescription} {program.applicationWindow}
+              </p>
+              {program.blockers.length > 0 && (
+                <div style={{ marginTop: 7, color: "var(--amber)", fontSize: 11, lineHeight: 1.45 }}>
+                  <strong>{copy.blockers}: </strong>{program.blockers[0]}
+                </div>
+              )}
+              {program.reasons.length > 0 && (
+                <div style={{ marginTop: 7, color: "var(--text-secondary)", fontSize: 11, lineHeight: 1.45 }}>
+                  {program.reasons[0]}
+                </div>
+              )}
+              <details style={{ marginTop: 7 }}>
+                <summary style={{ cursor: "pointer", color: "var(--text-muted)", fontSize: 11, fontWeight: 700 }}>
+                  {copy.next}
+                </summary>
+                <ul style={{ margin: "6px 0 0", paddingLeft: 16, color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+                  {program.nextSteps.map((step) => <li key={step}>{step}</li>)}
+                </ul>
+              </details>
+              <a
+                href={program.applicationUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ display: "inline-block", marginTop: 8, color: "var(--forest)", fontSize: 11, fontWeight: 700, textDecoration: "none" }}
+              >
+                {copy.source}
+              </a>
+            </article>
+          );
+        })}
+      </div>
+
+      <p style={{ margin: "9px 0 0", color: "var(--text-muted)", fontSize: 10, lineHeight: 1.45 }}>
+        <strong>{copy.disclaimerPrefix}:</strong> {result.disclaimer} Sources checked {result.sourceCheckedAt}.
+      </p>
+    </section>
+  );
+}

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useTranslation } from "@/components/LocaleProvider";
 import type { Project, ProjectStatus } from "@/types";
 import AchievementBadges from "@/components/AchievementBadges";
+import { buildEuEnergyGrantPrecheck } from "@/lib/eu-energy-grants";
 
 const STATUS_COLORS: Record<ProjectStatus, string> = {
   planning: "var(--amber, #e5a04b)",
@@ -49,6 +50,14 @@ export default function ProjectCard({
     const completed = phases.filter((p) => p.done).length;
     return { phases, completed, total: phases.length, pct: Math.round((completed / phases.length) * 100) };
   }, [project.scene_js, project.bom, project.estimated_cost, project.status]);
+  const fundingSignal = useMemo(
+    () => buildEuEnergyGrantPrecheck({
+      bom: project.bom ?? [],
+      buildingInfo: project.building_info,
+      totalCost: project.estimated_cost,
+    }).fundingBadge,
+    [project.bom, project.building_info, project.estimated_cost],
+  );
 
   return (
     <div
@@ -130,6 +139,11 @@ export default function ProjectCard({
             {project.estimated_cost > 0 && (
               <span className="badge badge-amber">
                 {Number(project.estimated_cost).toFixed(0)} &euro;
+              </span>
+            )}
+            {fundingSignal.show && (
+              <span className="badge" style={{ borderColor: "rgba(74,124,89,0.36)", color: "var(--forest)" }}>
+                {locale === "fi" ? "Tukia" : "Funding"} {fundingSignal.amount.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} &euro;
               </span>
             )}
             {Number(project.view_count || 0) > 0 && (

--- a/web/src/lib/__tests__/eu-energy-grants.test.ts
+++ b/web/src/lib/__tests__/eu-energy-grants.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEuEnergyGrantPrecheck,
+  inferEuGrantApplicantType,
+  inferEuGrantScopes,
+} from "@/lib/eu-energy-grants";
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+const materials: Material[] = [
+  {
+    id: "solar-panel",
+    name: "Solar panel",
+    name_fi: "Aurinkopaneeli",
+    name_en: "Solar panel",
+    category_name: "solar",
+    category_name_fi: "aurinko",
+    image_url: null,
+    tags: ["solar", "energy community"],
+    pricing: [{ unit_price: 250, unit: "pcs", supplier_name: "Test", is_primary: true }],
+  },
+  {
+    id: "smart-control",
+    name: "Smart heating control",
+    name_fi: "Alyohjaus",
+    name_en: "Smart heating control",
+    category_name: "controls",
+    category_name_fi: "ohjaus",
+    image_url: null,
+    tags: ["smart controls"],
+    pricing: [{ unit_price: 1200, unit: "pcs", supplier_name: "Test", is_primary: true }],
+  },
+];
+
+const solarBom: BomItem[] = [
+  { material_id: "solar-panel", quantity: 80, unit: "pcs" },
+  { material_id: "smart-control", quantity: 1, unit: "pcs" },
+];
+
+describe("eu energy grants", () => {
+  it("infers community energy scopes from BOM and material metadata", () => {
+    expect(inferEuGrantScopes(solarBom, materials)).toEqual(expect.arrayContaining(["solar", "smart_controls"]));
+  });
+
+  it("infers housing company for apartment-style building context", () => {
+    const buildingInfo: BuildingInfo = { type: "kerrostalo", units: 24 };
+    expect(inferEuGrantApplicantType(buildingInfo)).toBe("housing_company");
+  });
+
+  it("blocks Business Finland Energy Aid for residential housing companies", () => {
+    const result = buildEuEnergyGrantPrecheck({
+      bom: solarBom,
+      materials,
+      totalCost: 60000,
+      buildingInfo: { type: "kerrostalo", units: 24, year_built: 1975 },
+    });
+    const businessFinland = result.programs.find((program) => program.id === "business_finland_energy_aid");
+
+    expect(businessFinland?.status).toBe("not_eligible");
+    expect(businessFinland?.blockers.join(" ")).toContain("exclude housing associations");
+  });
+
+  it("flags EU Energy Communities Facility for housing-company solar projects", () => {
+    const result = buildEuEnergyGrantPrecheck({
+      bom: solarBom,
+      materials,
+      totalCost: 60000,
+      buildingInfo: { type: "kerrostalo", units: 24, year_built: 1975 },
+    });
+    const community = result.programs.find((program) => program.id === "eu_energy_communities_facility");
+
+    expect(community?.status).toBe("maybe");
+    expect(community?.amountMax).toBe(45000);
+    expect(community?.deadline).toBe("2026-07-05");
+    expect(result.fundingBadge.show).toBe(true);
+    expect(result.totalPotentialAmount).toBe(45000);
+  });
+
+  it("allows Business Finland screening for non-residential company projects with new technology", () => {
+    const result = buildEuEnergyGrantPrecheck({
+      bom: [{ material_id: "smart-control", quantity: 10, unit: "pcs" }],
+      materials,
+      totalCost: 100000,
+      answers: {
+        applicantType: "company_or_municipality",
+        buildingType: "non_residential",
+        scopes: ["smart_controls"],
+        stage: "planning",
+      },
+    });
+    const businessFinland = result.programs.find((program) => program.id === "business_finland_energy_aid");
+
+    expect(businessFinland?.status).toBe("maybe");
+    expect(businessFinland?.amountMax).toBe(30000);
+  });
+
+  it("always includes Motiva energy advice as an official advice path", () => {
+    const result = buildEuEnergyGrantPrecheck({ bom: [], materials: [] });
+    const motiva = result.programs.find((program) => program.id === "motiva_energy_advice");
+
+    expect(motiva?.status).toBe("info");
+    expect(motiva?.amountMax).toBeNull();
+  });
+});

--- a/web/src/lib/eu-energy-grants.ts
+++ b/web/src/lib/eu-energy-grants.ts
@@ -1,0 +1,288 @@
+import type { BomItem, BuildingInfo, Material } from "@/types";
+
+export type EuGrantApplicantType =
+  | "private_owner"
+  | "housing_company"
+  | "energy_community"
+  | "company_or_municipality";
+
+export type EuGrantBuildingType = "omakotitalo" | "rivitalo" | "kerrostalo" | "non_residential" | "unknown";
+export type EuGrantProjectStage = "planning" | "ordered_or_started";
+export type EuGrantScope = "heating" | "insulation" | "windows" | "solar" | "smart_controls" | "storage" | "ev_charging";
+export type EuGrantStatus = "eligible" | "maybe" | "not_eligible" | "info";
+
+export interface EuEnergyGrantAnswers {
+  applicantType: EuGrantApplicantType;
+  buildingType: EuGrantBuildingType;
+  buildingYear: number | null;
+  scopes: EuGrantScope[];
+  location: string;
+  stage: EuGrantProjectStage;
+}
+
+export interface EuEnergyGrantProgramResult {
+  id: "business_finland_energy_aid" | "eu_energy_communities_facility" | "motiva_energy_advice";
+  name: string;
+  status: EuGrantStatus;
+  amountMax: number | null;
+  amountDescription: string;
+  applicationWindow: string;
+  deadline: string | null;
+  sourceUrl: string;
+  applicationUrl: string;
+  reasons: string[];
+  blockers: string[];
+  nextSteps: string[];
+}
+
+export interface EuEnergyGrantPrecheck {
+  answers: EuEnergyGrantAnswers;
+  programs: EuEnergyGrantProgramResult[];
+  totalPotentialAmount: number;
+  bestProgram: EuEnergyGrantProgramResult | null;
+  fundingBadge: {
+    show: boolean;
+    label: string;
+    amount: number;
+  };
+  sourceCheckedAt: string;
+  disclaimer: string;
+}
+
+export interface BuildEuEnergyGrantPrecheckInput {
+  bom?: BomItem[];
+  materials?: Material[];
+  buildingInfo?: BuildingInfo | null;
+  totalCost?: number;
+  answers?: Partial<EuEnergyGrantAnswers>;
+}
+
+export const EU_ENERGY_GRANT_SOURCES = {
+  sourceCheckedAt: "2026-04-23",
+  businessFinlandEnergyAid: "https://www.businessfinland.fi/en/for-finnish-customers/services/funding/energy-aid",
+  energyCommunitiesFacility: "https://energycommunitiesfacility.eu/apply/applicationprocess",
+  energyCommunitiesInfoSession: "https://citizen-led-renovation.ec.europa.eu/events/info-session-apply-eu45000-grant-your-energy-community-2026-05-06_en",
+  motivaEnergyAdvice: "https://www.motiva.fi/energianeuvonta/",
+} as const;
+
+const SCOPE_PATTERNS: Array<{ scope: EuGrantScope; patterns: RegExp[] }> = [
+  { scope: "heating", patterns: [/heat[\s_-]?pump/i, /l(?:a|ä)mp(?:o|ö)/i, /heating/i, /kaukol/i, /maal/i] },
+  { scope: "insulation", patterns: [/insulation/i, /eristys/i, /villa/i] },
+  { scope: "windows", patterns: [/window/i, /ikkuna/i, /glazing/i] },
+  { scope: "solar", patterns: [/solar/i, /aurinko/i, /pv\b/i, /photovoltaic/i] },
+  { scope: "smart_controls", patterns: [/smart/i, /control/i, /automation/i, /ohjaus/i, /sensor/i] },
+  { scope: "storage", patterns: [/battery/i, /storage/i, /akku/i, /varasto/i] },
+  { scope: "ev_charging", patterns: [/ev[\s_-]?charg/i, /charging/i, /lataus/i] },
+];
+
+const COMMUNITY_SCOPES = new Set<EuGrantScope>(["solar", "smart_controls", "storage", "ev_charging"]);
+const BUSINESS_FINLAND_SCOPES = new Set<EuGrantScope>(["heating", "smart_controls", "storage"]);
+const RESIDENTIAL_BUILDINGS = new Set<EuGrantBuildingType>(["omakotitalo", "rivitalo", "kerrostalo"]);
+
+function unique<T>(items: T[]): T[] {
+  return Array.from(new Set(items));
+}
+
+function textFromBom(bom: BomItem[] = [], materials: Material[] = []): string {
+  const materialById = new Map(materials.map((material) => [material.id, material]));
+  return bom.flatMap((item) => {
+    const material = materialById.get(item.material_id);
+    return [
+      item.material_id,
+      item.material_name,
+      item.category_name,
+      material?.name,
+      material?.name_fi,
+      material?.name_en,
+      material?.category_name,
+      material?.category_name_fi,
+      ...(material?.tags ?? []),
+    ];
+  }).filter(Boolean).join(" ");
+}
+
+export function inferEuGrantScopes(bom: BomItem[] = [], materials: Material[] = []): EuGrantScope[] {
+  const haystack = textFromBom(bom, materials);
+  const scopes = SCOPE_PATTERNS
+    .filter((candidate) => candidate.patterns.some((pattern) => pattern.test(haystack)))
+    .map((candidate) => candidate.scope);
+  return unique(scopes);
+}
+
+export function normalizeEuGrantBuildingType(buildingInfo?: BuildingInfo | null): EuGrantBuildingType {
+  const raw = (buildingInfo?.type ?? "").toLowerCase();
+  if (raw.includes("omakoti") || raw.includes("detached")) return "omakotitalo";
+  if (raw.includes("rivi") || raw.includes("row") || raw.includes("pari") || raw.includes("semi")) return "rivitalo";
+  if (raw.includes("kerros") || raw.includes("apartment") || Number(buildingInfo?.units ?? 0) > 2) return "kerrostalo";
+  if (raw.includes("office") || raw.includes("industrial") || raw.includes("commercial")) return "non_residential";
+  return "unknown";
+}
+
+export function inferEuGrantApplicantType(buildingInfo?: BuildingInfo | null): EuGrantApplicantType {
+  const type = normalizeEuGrantBuildingType(buildingInfo);
+  if (type === "kerrostalo" || Number(buildingInfo?.units ?? 0) > 2) return "housing_company";
+  return "private_owner";
+}
+
+function defaultAnswers(input: BuildEuEnergyGrantPrecheckInput): EuEnergyGrantAnswers {
+  const buildingType = normalizeEuGrantBuildingType(input.buildingInfo);
+  const inferredScopes = inferEuGrantScopes(input.bom, input.materials);
+  return {
+    applicantType: inferEuGrantApplicantType(input.buildingInfo),
+    buildingType,
+    buildingYear: input.buildingInfo?.year_built ?? null,
+    location: input.buildingInfo?.address?.split(",").at(-1)?.trim() || "Finland",
+    stage: "planning",
+    ...input.answers,
+    scopes: input.answers?.scopes ?? inferredScopes,
+  };
+}
+
+function hasAnyScope(answers: EuEnergyGrantAnswers, wanted: Set<EuGrantScope>): boolean {
+  return answers.scopes.some((scope) => wanted.has(scope));
+}
+
+function businessFinlandProgram(answers: EuEnergyGrantAnswers, totalCost: number): EuEnergyGrantProgramResult {
+  const blockers: string[] = [];
+  const reasons: string[] = [];
+  const nextSteps = [
+    "Use only for non-residential company, municipality, or organization projects.",
+    "Do not order work before a funding decision.",
+    "Confirm current terms from Business Finland before promising aid.",
+  ];
+
+  if (answers.stage === "ordered_or_started") {
+    blockers.push("Project has already been ordered or started; Business Finland Energy Aid requires applying before project start.");
+  }
+
+  if (answers.applicantType !== "company_or_municipality") {
+    blockers.push("Current Business Finland Energy Aid instructions exclude housing associations and residential properties.");
+  }
+
+  if (RESIDENTIAL_BUILDINGS.has(answers.buildingType)) {
+    blockers.push("Residential property scope is excluded by the current Business Finland Energy Aid page.");
+  }
+
+  if (!hasAnyScope(answers, BUSINESS_FINLAND_SCOPES)) {
+    blockers.push("Scope does not show new technology, large heat pump, storage, smart controls, or equivalent energy-efficiency technology.");
+  } else {
+    reasons.push("Scope includes technology that can be relevant for non-residential Energy Aid screening.");
+  }
+
+  if (totalCost > 0 && totalCost < 10000) {
+    blockers.push("Energy-efficiency investment size is below the 10,000 EUR minimum described by Business Finland.");
+  }
+
+  const status: EuGrantStatus = blockers.length === 0 ? "maybe" : "not_eligible";
+  const amountMax = status === "maybe" && totalCost > 0 ? Math.round(totalCost * 0.3) : null;
+
+  return {
+    id: "business_finland_energy_aid",
+    name: "Business Finland Energy Aid",
+    status,
+    amountMax,
+    amountDescription: amountMax
+      ? `Planning estimate up to ${amountMax} EUR; official aid intensity is project-specific.`
+      : "Residential and housing-company projects are currently blocked by official Energy Aid exclusions.",
+    applicationWindow: "Continuous call",
+    deadline: null,
+    sourceUrl: EU_ENERGY_GRANT_SOURCES.businessFinlandEnergyAid,
+    applicationUrl: EU_ENERGY_GRANT_SOURCES.businessFinlandEnergyAid,
+    reasons,
+    blockers,
+    nextSteps,
+  };
+}
+
+function energyCommunitiesProgram(answers: EuEnergyGrantAnswers): EuEnergyGrantProgramResult {
+  const blockers: string[] = [];
+  const reasons: string[] = [];
+  const communityApplicant = answers.applicantType === "energy_community" || answers.applicantType === "housing_company";
+
+  if (!communityApplicant) {
+    blockers.push("The EU Energy Communities Facility is for emerging energy communities, not a single private homeowner acting alone.");
+  } else {
+    reasons.push("Applicant can plausibly organize as a housing-company or energy-community project.");
+  }
+
+  if (!hasAnyScope(answers, COMMUNITY_SCOPES)) {
+    blockers.push("Scope should include a community energy project such as shared solar, energy storage, EV charging, or demand-response controls.");
+  } else {
+    reasons.push("Scope includes a community-energy signal.");
+  }
+
+  if (answers.stage === "ordered_or_started") {
+    blockers.push("Use the Facility for business-plan development before implementation, not after the project is already committed.");
+  }
+
+  const status: EuGrantStatus = blockers.length === 0 ? "maybe" : "not_eligible";
+
+  return {
+    id: "eu_energy_communities_facility",
+    name: "EU Energy Communities Facility",
+    status,
+    amountMax: status === "maybe" ? 45000 : null,
+    amountDescription: "Lump-sum grant up to 45,000 EUR for developing a community energy business plan.",
+    applicationWindow: "Second call opens 5 May 2026 and runs until 5 July 2026.",
+    deadline: "2026-07-05",
+    sourceUrl: EU_ENERGY_GRANT_SOURCES.energyCommunitiesFacility,
+    applicationUrl: EU_ENERGY_GRANT_SOURCES.energyCommunitiesFacility,
+    reasons,
+    blockers,
+    nextSteps: [
+      "Run the official eligibility self-check when the call opens.",
+      "Prepare energy-community governance, member list, and business-plan scope.",
+      "Attend the 6 May 2026 information session or the Finnish national session when published.",
+    ],
+  };
+}
+
+function motivaProgram(): EuEnergyGrantProgramResult {
+  return {
+    id: "motiva_energy_advice",
+    name: "Motiva energy advice",
+    status: "info",
+    amountMax: null,
+    amountDescription: "Free impartial energy advice; not a cash grant.",
+    applicationWindow: "Available nationally",
+    deadline: null,
+    sourceUrl: EU_ENERGY_GRANT_SOURCES.motivaEnergyAdvice,
+    applicationUrl: EU_ENERGY_GRANT_SOURCES.motivaEnergyAdvice,
+    reasons: ["Motiva energy advice covers consumers, housing companies, municipalities, and SMEs."],
+    blockers: [],
+    nextSteps: [
+      "Use Motiva to validate grant options and local energy adviser contacts before applying.",
+      "Ask specifically about energy community, solar, and housing-company renovation support paths.",
+    ],
+  };
+}
+
+export function buildEuEnergyGrantPrecheck(input: BuildEuEnergyGrantPrecheckInput): EuEnergyGrantPrecheck {
+  const answers = defaultAnswers(input);
+  const totalCost = Math.max(0, Number(input.totalCost ?? 0));
+  const programs = [
+    businessFinlandProgram(answers, totalCost),
+    energyCommunitiesProgram(answers),
+    motivaProgram(),
+  ];
+  const potentialPrograms = programs.filter((program) => program.status === "eligible" || program.status === "maybe");
+  const totalPotentialAmount = potentialPrograms.reduce((sum, program) => sum + (program.amountMax ?? 0), 0);
+  const bestProgram = potentialPrograms
+    .filter((program) => (program.amountMax ?? 0) > 0)
+    .sort((a, b) => (b.amountMax ?? 0) - (a.amountMax ?? 0))[0] ?? null;
+
+  return {
+    answers,
+    programs,
+    totalPotentialAmount,
+    bestProgram,
+    fundingBadge: {
+      show: totalPotentialAmount > 0,
+      label: bestProgram ? "Funding available" : "Grant advice available",
+      amount: totalPotentialAmount,
+    },
+    sourceCheckedAt: EU_ENERGY_GRANT_SOURCES.sourceCheckedAt,
+    disclaimer:
+      "Preliminary funding screen only. Verify eligibility, deadlines, de minimis/state-aid limits, and required attachments from official sources before making customer promises.",
+  };
+}


### PR DESCRIPTION
## Summary
- add an official-source EU energy grant pre-check covering Business Finland Energy Aid, EU Energy Communities Facility, and Motiva energy advice
- mount a 6-question grant quiz in the BOM flow and show project-dashboard funding badges for community-energy projects
- add tests for eligibility logic, the grant panel, and dashboard badge rendering

## Accuracy note
The issue text assumed Business Finland Energy Aid is available to taloyhtiot. Current Business Finland Energy Aid guidance says aid is not granted to housing associations or residential properties, so the pre-check explicitly blocks that path and routes housing-company/community solar projects toward the EU Energy Communities Facility instead.

Sources checked 2026-04-23:
- Business Finland Energy Aid: https://www.businessfinland.fi/en/for-finnish-customers/services/funding/energy-aid
- EU Energy Communities Facility: https://energycommunitiesfacility.eu/apply/applicationprocess
- EU info session / second call dates: https://citizen-led-renovation.ec.europa.eu/events/info-session-apply-eu45000-grant-your-energy-community-2026-05-06_en
- Motiva energy advice: https://www.motiva.fi/energianeuvonta/

## Validation
- npm test -- --run src/lib/__tests__/eu-energy-grants.test.ts src/__tests__/eu-energy-grant-precheck-panel.test.tsx src/__tests__/project-card.test.tsx
- npx tsc --noEmit
- npm test -- --run
- npm run build

Note: build still prints the existing Next warning for experimental.viewTransition.

Fixes #399