### PR TITLE
feat: add IFC permit preview validation

### DIFF
--- a/web/src/__tests__/ifc-preview-panel.test.tsx
+++ b/web/src/__tests__/ifc-preview-panel.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import IfcPreviewPanel from "@/components/IfcPreviewPanel";
+import { api } from "@/lib/api";
+import { IFC_READINESS_STORAGE_KEY } from "@/lib/ifc-preview";
+
+const VALID_IFC = `ISO-10303-21;
+HEADER;
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('p',$,'Project',$,$,$,$,$);
+#2=IFCLOCALPLACEMENT($,$);
+#3=IFCSITE('s',$,'Site',$,$,#2,$,$,.ELEMENT.,$,$,$,$,$);
+#4=IFCBUILDING('b',$,'Building',$,$,#2,$,$,.ELEMENT.,$,$,$);
+#5=IFCBUILDINGSTOREY('st',$,'Ground floor',$,$,#2,$,$,.ELEMENT.,0.);
+#6=IFCWALL('w',$,'Wall',$,$,#2,#20,$,$);
+#7=IFCBOUNDINGBOX(#2,5.000,2.800,0.200);
+#8=IFCSLAB('sl',$,'Floor',$,$,#2,#21,$,$);
+#9=IFCBOUNDINGBOX(#2,5.000,0.200,4.000);
+#10=IFCROOF('r',$,'Roof',$,$,#2,#22,$,$);
+#11=IFCBOUNDINGBOX(#2,5.000,0.300,4.000);
+#12=IFCDOOR('d',$,'Door',$,$,#2,#23,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getIFC: vi.fn(),
+    exportIFC: vi.fn(),
+  },
+}));
+
+describe("IfcPreviewPanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(api.getIFC).mockReset();
+    vi.mocked(api.exportIFC).mockReset();
+  });
+
+  it("generates an IFC preview with object counts and checklist", async () => {
+    vi.mocked(api.getIFC).mockResolvedValue(VALID_IFC);
+
+    render(<IfcPreviewPanel projectId="project-1" projectName="Sauna" />);
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    expect(await screen.findByText("Ready for Lupapiste")).toBeInTheDocument();
+    expect(screen.getByText("IFC4X3_ADD2")).toBeInTheDocument();
+    expect(screen.getByText("Walls")).toBeInTheDocument();
+    expect(screen.getByText("Slabs / floors")).toBeInTheDocument();
+    expect(screen.getByText("Project / site / building / storey")).toBeInTheDocument();
+    expect(api.getIFC).toHaveBeenCalledWith("project-1");
+    expect(localStorage.getItem(IFC_READINESS_STORAGE_KEY)).toContain("project-1");
+  });
+
+  it("downloads the same IFC export from the panel", async () => {
+    vi.mocked(api.exportIFC).mockResolvedValue(undefined);
+
+    render(<IfcPreviewPanel projectId="project-1" projectName="Sauna" />);
+    fireEvent.click(screen.getByRole("button", { name: "Download IFC" }));
+
+    await waitFor(() => expect(api.exportIFC).toHaveBeenCalledWith("project-1", "Sauna"));
+  });
+
+  it("shows an inline error when the preview cannot be generated", async () => {
+    vi.mocked(api.getIFC).mockRejectedValue(new Error("No scene"));
+
+    render(<IfcPreviewPanel projectId="project-1" projectName="Sauna" />);
+    fireEvent.click(screen.getByRole("button", { name: "Generate preview" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("No scene");
+  });
+});

--- a/web/src/__tests__/project-card.test.tsx
+++ b/web/src/__tests__/project-card.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/components/LocaleProvider", () => ({
 }));
 
 import ProjectCard from "@/components/ProjectCard";
+import { IFC_READINESS_STORAGE_KEY } from "@/lib/ifc-preview";
 import type { Project } from "@/types";
 
 const mockProject: Project = {
@@ -36,7 +37,10 @@ const mockProject: Project = {
 const mockOnDuplicate = vi.fn();
 const mockOnDelete = vi.fn();
 
-beforeEach(() => { vi.clearAllMocks(); });
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
 
 describe("ProjectCard", () => {
   it("renders project name as link", () => {
@@ -64,6 +68,22 @@ describe("ProjectCard", () => {
     };
     render(<ProjectCard project={fundedProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
     expect(screen.getByText(/Funding 45,000/)).toBeInTheDocument();
+  });
+
+  it("renders Lupapiste readiness badge after IFC validation has passed", () => {
+    localStorage.setItem(IFC_READINESS_STORAGE_KEY, JSON.stringify({
+      [mockProject.id]: {
+        ready: true,
+        schema: "IFC4X3_ADD2",
+        checkedAt: "2026-04-23T00:00:00.000Z",
+        warningCount: 0,
+        blockingIssueCount: 0,
+      },
+    }));
+
+    render(<ProjectCard project={mockProject} index={0} onDuplicate={mockOnDuplicate} onDelete={mockOnDelete} />);
+
+    expect(screen.getByText("Ready for Lupapiste")).toBeInTheDocument();
   });
 
   it("hides cost badge when estimated_cost is 0", () => {

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -17,6 +17,7 @@ import RenovationFinancingPanel from "@/components/RenovationFinancingPanel";
 import EuEnergyGrantPrecheckPanel from "@/components/EuEnergyGrantPrecheckPanel";
 import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
+import IfcPreviewPanel from "@/components/IfcPreviewPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
 import PhotoEstimatePanel from "@/components/PhotoEstimatePanel";
 import PermitCheckerPanel from "@/components/PermitCheckerPanel";
@@ -2766,6 +2767,9 @@ export default function BomPanel({
         )}
         {bom.length > 0 && projectId && (
           <WasteEstimatePanel projectId={projectId} bomCount={bom.length} buildingInfo={buildingInfo} />
+        )}
+        {projectId && (
+          <IfcPreviewPanel projectId={projectId} projectName={projectName} />
         )}
         {projectId && (
           <RyhtiSubmissionPanel projectId={projectId} bomCount={bom.length} buildingInfo={buildingInfo} />

--- a/web/src/components/IfcPreviewPanel.tsx
+++ b/web/src/components/IfcPreviewPanel.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { api } from "@/lib/api";
+import { analyzeIfcStep, rememberIfcReadiness, type IfcPreviewAnalysis, type IfcValidationStatus } from "@/lib/ifc-preview";
+
+const COPY = {
+  en: {
+    title: "IFC 4.3 permit preview",
+    subtitle: "Generate the Lupapiste export, inspect the object tree, and catch blocking IFC issues before you download.",
+    generate: "Generate preview",
+    refresh: "Refresh preview",
+    generating: "Generating...",
+    download: "Download IFC",
+    downloading: "Downloading...",
+    empty: "No IFC preview yet. Generate one from the current saved project.",
+    ready: "Ready for Lupapiste",
+    blocked: "Needs fixes",
+    warning: "Warnings",
+    schema: "Schema",
+    largestSpan: "Largest span",
+    boxes: "Bounding boxes",
+    objects: "Object tree",
+    checklist: "Validation checklist",
+    failed: "Could not generate IFC preview.",
+    noObjects: "No previewable building objects found.",
+    meters: "m",
+  },
+  fi: {
+    title: "IFC 4.3 -lupamallin esikatselu",
+    subtitle: "Luo Lupapiste-vienti, tarkista objektipuu ja poimi estavat IFC-virheet ennen latausta.",
+    generate: "Luo esikatselu",
+    refresh: "Paivita esikatselu",
+    generating: "Luodaan...",
+    download: "Lataa IFC",
+    downloading: "Ladataan...",
+    empty: "IFC-esikatselua ei ole viela. Luo se nykyisesta tallennetusta projektista.",
+    ready: "Valmis Lupapisteeseen",
+    blocked: "Korjattavaa",
+    warning: "Varoituksia",
+    schema: "Skeema",
+    largestSpan: "Suurin mitta",
+    boxes: "Rajauslaatikot",
+    objects: "Objektipuu",
+    checklist: "Tarkistuslista",
+    failed: "IFC-esikatselua ei voitu luoda.",
+    noObjects: "Esikatseltavia rakennusobjekteja ei loytynyt.",
+    meters: "m",
+  },
+} as const;
+
+function statusTone(status: IfcValidationStatus): { color: string; background: string; border: string; mark: string } {
+  if (status === "pass") {
+    return { color: "var(--forest)", background: "var(--forest-dim)", border: "rgba(74,124,89,0.24)", mark: "OK" };
+  }
+  if (status === "warning") {
+    return { color: "var(--amber)", background: "var(--amber-glow)", border: "var(--amber-border)", mark: "WARN" };
+  }
+  return { color: "var(--danger)", background: "rgba(239,68,68,0.08)", border: "rgba(239,68,68,0.25)", mark: "FIX" };
+}
+
+export default function IfcPreviewPanel({
+  projectId,
+  projectName,
+}: {
+  projectId?: string;
+  projectName?: string;
+}) {
+  const { locale } = useTranslation();
+  const copy = locale === "fi" ? COPY.fi : COPY.en;
+  const [analysis, setAnalysis] = useState<IfcPreviewAnalysis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!projectId) return null;
+
+  const generatePreview = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const ifcText = await api.getIFC(projectId);
+      const nextAnalysis = analyzeIfcStep(ifcText);
+      rememberIfcReadiness(projectId, nextAnalysis);
+      setAnalysis(nextAnalysis);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : copy.failed);
+      setAnalysis(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const downloadIfc = async () => {
+    setDownloading(true);
+    try {
+      await api.exportIFC(projectId, projectName || "project");
+    } finally {
+      setDownloading(false);
+    }
+  };
+
+  const ready = analysis?.readyForLupapiste ?? false;
+
+  return (
+    <section
+      aria-labelledby="ifc-preview-heading"
+      style={{
+        marginTop: 12,
+        padding: "14px 16px",
+        borderRadius: "var(--radius-md)",
+        border: "1px solid var(--border)",
+        background: "linear-gradient(135deg, color-mix(in srgb, var(--bg-tertiary) 92%, var(--forest) 8%), var(--bg-tertiary))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <div id="ifc-preview-heading" className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)" }}>
+            {copy.title}
+          </div>
+          <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--text-secondary)", lineHeight: 1.45 }}>
+            {copy.subtitle}
+          </p>
+        </div>
+        {analysis && (
+          <span
+            style={{
+              padding: "3px 7px",
+              borderRadius: 999,
+              border: ready ? "1px solid rgba(74,124,89,0.24)" : "1px solid var(--amber-border)",
+              color: ready ? "var(--forest)" : "var(--amber)",
+              background: ready ? "var(--forest-dim)" : "var(--amber-glow)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {ready ? copy.ready : copy.blocked}
+          </span>
+        )}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginTop: 12 }}>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={() => { void generatePreview(); }}
+          disabled={loading}
+          style={{ minHeight: 36, fontSize: 12 }}
+        >
+          {loading ? copy.generating : analysis ? copy.refresh : copy.generate}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost"
+          onClick={() => { void downloadIfc(); }}
+          disabled={downloading}
+          style={{ minHeight: 36, fontSize: 12 }}
+        >
+          {downloading ? copy.downloading : copy.download}
+        </button>
+      </div>
+
+      {error && (
+        <div role="alert" style={{ marginTop: 10, color: "var(--danger)", fontSize: 12 }}>
+          {error || copy.failed}
+        </div>
+      )}
+
+      {!analysis && !error && (
+        <div style={{ marginTop: 12, color: "var(--text-muted)", fontSize: 12, lineHeight: 1.45 }}>
+          {copy.empty}
+        </div>
+      )}
+
+      {analysis && (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8, marginTop: 12 }}>
+            <Metric label={copy.schema} value={analysis.schema ?? "Unknown"} />
+            <Metric
+              label={copy.largestSpan}
+              value={analysis.largestSpanMeters === null ? "-" : `${analysis.largestSpanMeters.toFixed(1)} ${copy.meters}`}
+            />
+            <Metric label={copy.boxes} value={String(analysis.boundingBoxes.length)} />
+          </div>
+
+          <div
+            style={{
+              marginTop: 12,
+              padding: 10,
+              borderRadius: "var(--radius-sm)",
+              border: "1px solid var(--border)",
+              background: "rgba(255,255,255,0.04)",
+            }}
+          >
+            <div className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 8 }}>
+              {copy.objects}
+            </div>
+            {analysis.previewElements.length === 0 ? (
+              <div style={{ fontSize: 12, color: "var(--text-muted)" }}>{copy.noObjects}</div>
+            ) : (
+              <div style={{ display: "grid", gap: 6 }}>
+                {analysis.previewElements.map((element, index) => (
+                  <div
+                    key={element.id}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "72px 1fr auto",
+                      alignItems: "center",
+                      gap: 8,
+                      fontSize: 11,
+                    }}
+                  >
+                    <span style={{ color: "var(--text-secondary)" }}>{element.label}</span>
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        height: 12,
+                        borderRadius: 999,
+                        background: `linear-gradient(90deg, ${element.color}, color-mix(in srgb, ${element.color} 42%, transparent))`,
+                        transform: `translateX(${index * 3}px)`,
+                        width: `${Math.max(18, Math.min(100, element.count * 18))}%`,
+                        boxShadow: "0 8px 18px rgba(0,0,0,0.14)",
+                      }}
+                    />
+                    <span style={{ color: "var(--text-primary)", fontFamily: "var(--font-mono)" }}>
+                      {element.count}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div style={{ marginTop: 12 }}>
+            <div className="label-mono" style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 8 }}>
+              {copy.checklist}
+            </div>
+            <div style={{ display: "grid", gap: 7 }}>
+              {analysis.checks.map((check) => {
+                const tone = statusTone(check.status);
+                return (
+                  <div
+                    key={check.id}
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "46px 1fr",
+                      gap: 8,
+                      padding: "8px 9px",
+                      borderRadius: "var(--radius-sm)",
+                      border: `1px solid ${tone.border}`,
+                      background: tone.background,
+                    }}
+                  >
+                    <span style={{ color: tone.color, fontFamily: "var(--font-mono)", fontSize: 10, fontWeight: 700 }}>
+                      {tone.mark}
+                    </span>
+                    <span>
+                      <span style={{ display: "block", color: "var(--text-primary)", fontSize: 12, fontWeight: 600 }}>
+                        {check.label}
+                      </span>
+                      <span style={{ display: "block", color: "var(--text-secondary)", fontSize: 11, lineHeight: 1.35, marginTop: 2 }}>
+                        {check.message}
+                      </span>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {analysis.warningCount > 0 && (
+            <div style={{ marginTop: 10, color: "var(--amber)", fontSize: 11, fontFamily: "var(--font-mono)" }}>
+              {copy.warning}: {analysis.warningCount}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        padding: "8px 9px",
+        borderRadius: "var(--radius-sm)",
+        background: "rgba(0,0,0,0.05)",
+        border: "1px solid var(--border)",
+        minWidth: 0,
+      }}
+    >
+      <div className="label-mono" style={{ fontSize: 9, color: "var(--text-muted)", marginBottom: 3 }}>
+        {label}
+      </div>
+      <div style={{ color: "var(--text-primary)", fontSize: 12, fontWeight: 650, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ProjectCard.tsx
+++ b/web/src/components/ProjectCard.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useTranslation } from "@/components/LocaleProvider";
 import type { Project, ProjectStatus } from "@/types";
 import AchievementBadges from "@/components/AchievementBadges";
 import { buildEuEnergyGrantPrecheck } from "@/lib/eu-energy-grants";
+import { readIfcReadinessBadge, type IfcReadinessBadge } from "@/lib/ifc-preview";
 
 const STATUS_COLORS: Record<ProjectStatus, string> = {
   planning: "var(--amber, #e5a04b)",
@@ -58,6 +59,11 @@ export default function ProjectCard({
     }).fundingBadge,
     [project.bom, project.building_info, project.estimated_cost],
   );
+  const [ifcReadiness, setIfcReadiness] = useState<IfcReadinessBadge>(() => readIfcReadinessBadge(project.id, project.updated_at));
+
+  useEffect(() => {
+    setIfcReadiness(readIfcReadinessBadge(project.id, project.updated_at));
+  }, [project.id, project.updated_at]);
 
   return (
     <div
@@ -144,6 +150,11 @@ export default function ProjectCard({
             {fundingSignal.show && (
               <span className="badge" style={{ borderColor: "rgba(74,124,89,0.36)", color: "var(--forest)" }}>
                 {locale === "fi" ? "Tukia" : "Funding"} {fundingSignal.amount.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} &euro;
+              </span>
+            )}
+            {ifcReadiness.show && (
+              <span className="badge" style={{ borderColor: "rgba(37,99,235,0.28)", color: "var(--info, #2563eb)" }}>
+                {locale === "fi" ? "Lupapiste valmis" : ifcReadiness.label}
               </span>
             )}
             {Number(project.view_count || 0) > 0 && (

--- a/web/src/lib/__tests__/api-client.test.ts
+++ b/web/src/lib/__tests__/api-client.test.ts
@@ -128,4 +128,22 @@ describe("blob-backed downloads", () => {
     vi.advanceTimersByTime(30_000);
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:pdf-download");
   });
+
+  it("returns generated IFC text for preview without triggering a download", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      text: async () => "ISO-10303-21; IFC4X3_ADD2;",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const ifcText = await api.getIFC("project-1");
+
+    expect(ifcText).toBe("ISO-10303-21; IFC4X3_ADD2;");
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:3001/ifc-export/generate?projectId=project-1", {
+      headers: { Authorization: "Bearer download-token" },
+    });
+    expect(document.querySelector("a[download]")).toBeNull();
+  });
 });

--- a/web/src/lib/__tests__/ifc-preview.test.ts
+++ b/web/src/lib/__tests__/ifc-preview.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  IFC_READINESS_STORAGE_KEY,
+  analyzeIfcStep,
+  readIfcReadinessBadge,
+  rememberIfcReadiness,
+} from "@/lib/ifc-preview";
+
+const VALID_IFC = `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION(('Helscoop permit export'),'2;1');
+FILE_NAME('test.ifc','2026-04-23T00:00:00',('Helscoop'),('Helscoop'),'Helscoop','Helscoop','');
+FILE_SCHEMA(('IFC4X3_ADD2'));
+ENDSEC;
+DATA;
+#1=IFCPROJECT('p',$,'Project',$,$,$,$,$);
+#2=IFCLOCALPLACEMENT($,$);
+#3=IFCSITE('s',$,'Testikatu 1',$,$,#2,$,$,.ELEMENT.,$,$,$,$,$);
+#4=IFCBUILDING('b',$,'Building',$,$,#2,$,$,.ELEMENT.,$,$,$);
+#5=IFCBUILDINGSTOREY('st',$,'Ground floor',$,$,#2,$,$,.ELEMENT.,0.);
+#6=IFCWALL('w',$,'Wall',$,$,#2,#20,$,$);
+#7=IFCBOUNDINGBOX(#2,5.000,2.800,0.200);
+#8=IFCSLAB('sl',$,'Floor',$,$,#2,#21,$,$);
+#9=IFCBOUNDINGBOX(#2,5.000,0.200,4.000);
+#10=IFCROOF('r',$,'Roof',$,$,#2,#22,$,$);
+#11=IFCBOUNDINGBOX(#2,5.000,0.300,4.000);
+#12=IFCDOOR('d',$,'Door',$,$,#2,#23,$,$);
+#13=IFCWINDOW('win',$,'Window',$,$,#2,#24,$,$);
+ENDSEC;
+END-ISO-10303-21;`;
+
+describe("analyzeIfcStep", () => {
+  it("marks a complete IFC4x3 permit export as ready", () => {
+    const analysis = analyzeIfcStep(VALID_IFC);
+
+    expect(analysis.schema).toBe("IFC4X3_ADD2");
+    expect(analysis.readyForLupapiste).toBe(true);
+    expect(analysis.blockingIssueCount).toBe(0);
+    expect(analysis.elementCounts.walls).toBe(1);
+    expect(analysis.elementCounts.slabs).toBe(1);
+    expect(analysis.elementCounts.roofs).toBe(1);
+    expect(analysis.boundingBoxes).toHaveLength(3);
+    expect(analysis.largestSpanMeters).toBe(5);
+  });
+
+  it("fails older IFC schemas", () => {
+    const analysis = analyzeIfcStep(VALID_IFC.replace("IFC4X3_ADD2", "IFC2X3"));
+
+    expect(analysis.readyForLupapiste).toBe(false);
+    expect(analysis.checks.find((check) => check.id === "ifc-schema")?.status).toBe("fail");
+  });
+
+  it("fails models without required spatial containers", () => {
+    const analysis = analyzeIfcStep(VALID_IFC.replace("#3=IFCSITE", "#3=IFCBUILDINGELEMENTPROXY"));
+
+    expect(analysis.readyForLupapiste).toBe(false);
+    expect(analysis.checks.find((check) => check.id === "spatial-structure")?.message).toContain("site");
+  });
+
+  it("blocks impossible bounding dimensions", () => {
+    const analysis = analyzeIfcStep(VALID_IFC.replace("IFCBOUNDINGBOX(#2,5.000,2.800,0.200)", "IFCBOUNDINGBOX(#2,0,2.800,999)"));
+
+    expect(analysis.readyForLupapiste).toBe(false);
+    expect(analysis.checks.find((check) => check.id === "dimensions")?.status).toBe("fail");
+  });
+});
+
+describe("IFC readiness storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the Lupapiste badge only after a validator pass is stored", () => {
+    const analysis = analyzeIfcStep(VALID_IFC);
+
+    rememberIfcReadiness("project-1", analysis);
+
+    const ready = readIfcReadinessBadge("project-1");
+    const missing = readIfcReadinessBadge("project-2");
+
+    expect(ready.show).toBe(true);
+    expect(ready.reasons).toEqual(expect.arrayContaining(["IFC4X3_ADD2", "no blocking issues"]));
+    expect(missing.show).toBe(false);
+    expect(localStorage.getItem(IFC_READINESS_STORAGE_KEY)).toContain("project-1");
+  });
+
+  it("hides the badge when the latest stored validation has blockers", () => {
+    const failed = analyzeIfcStep(VALID_IFC.replace("IFC4X3_ADD2", "IFC2X3"));
+
+    rememberIfcReadiness("project-1", failed);
+
+    expect(readIfcReadinessBadge("project-1").show).toBe(false);
+  });
+
+  it("hides stale readiness after the project has been edited", () => {
+    const analysis = analyzeIfcStep(VALID_IFC);
+
+    rememberIfcReadiness("project-1", analysis);
+
+    expect(readIfcReadinessBadge("project-1", "2099-01-01T00:00:00.000Z").show).toBe(false);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -514,6 +514,20 @@ export const api = {
     const blob = await res.blob();
     downloadBlob(blob, `helscoop_permit_${projectName.replace(/\s+/g, '_')}.ifc`);
   },
+  getIFC: async (projectId: string): Promise<string> => {
+    const t = getToken();
+    const res = await fetch(`${API_URL}/ifc-export/generate?projectId=${encodeURIComponent(projectId)}`, {
+      headers: { Authorization: `Bearer ${t}` },
+    });
+    if (!res.ok) {
+      throw new ApiError(
+        ERROR_MESSAGES[res.status] || `Virhe ${res.status} / Error ${res.status}`,
+        res.status,
+        res.statusText
+      );
+    }
+    return res.text();
+  },
   exportPermitPack: async (projectId: string, projectName: string) => {
     const t = getToken();
     const res = await fetch(`${API_URL}/permit-pack/projects/${encodeURIComponent(projectId)}/export`, {

--- a/web/src/lib/ifc-preview.ts
+++ b/web/src/lib/ifc-preview.ts
@@ -1,0 +1,329 @@
+export type IfcValidationStatus = "pass" | "warning" | "fail";
+
+export interface IfcBoundingBox {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface IfcPreviewElement {
+  id: string;
+  label: string;
+  entityNames: string[];
+  count: number;
+  color: string;
+}
+
+export interface IfcValidationCheck {
+  id: string;
+  label: string;
+  status: IfcValidationStatus;
+  blocking: boolean;
+  message: string;
+}
+
+export interface IfcPreviewAnalysis {
+  schema: string | null;
+  entityCounts: Record<string, number>;
+  elementCounts: Record<string, number>;
+  previewElements: IfcPreviewElement[];
+  boundingBoxes: IfcBoundingBox[];
+  largestSpanMeters: number | null;
+  spatialStructure: {
+    project: number;
+    site: number;
+    building: number;
+    storey: number;
+  };
+  checks: IfcValidationCheck[];
+  blockingIssueCount: number;
+  warningCount: number;
+  readyForLupapiste: boolean;
+}
+
+export interface IfcReadinessBadge {
+  show: boolean;
+  label: string;
+  reasons: string[];
+  checkedAt?: string;
+  schema?: string | null;
+}
+
+interface StoredIfcReadiness {
+  ready: boolean;
+  schema: string | null;
+  checkedAt: string;
+  warningCount: number;
+  blockingIssueCount: number;
+}
+
+type StoredIfcReadinessMap = Record<string, StoredIfcReadiness>;
+
+const ELEMENT_GROUPS: Omit<IfcPreviewElement, "count">[] = [
+  { id: "walls", label: "Walls", entityNames: ["IFCWALL", "IFCWALLSTANDARDCASE"], color: "#b7791f" },
+  { id: "slabs", label: "Slabs / floors", entityNames: ["IFCSLAB"], color: "#64748b" },
+  { id: "roofs", label: "Roofs", entityNames: ["IFCROOF"], color: "#7c2d12" },
+  { id: "doors", label: "Doors", entityNames: ["IFCDOOR"], color: "#2563eb" },
+  { id: "windows", label: "Windows", entityNames: ["IFCWINDOW"], color: "#0891b2" },
+  { id: "proxies", label: "Other objects", entityNames: ["IFCBUILDINGELEMENTPROXY"], color: "#6b7280" },
+];
+
+const BUILDING_ELEMENT_ENTITIES = [
+  "IFCWALL",
+  "IFCWALLSTANDARDCASE",
+  "IFCSLAB",
+  "IFCROOF",
+  "IFCDOOR",
+  "IFCWINDOW",
+  "IFCBUILDINGELEMENTPROXY",
+  "IFCSTAIR",
+  "IFCRAILING",
+  "IFCCOLUMN",
+  "IFCBEAM",
+];
+
+const NUMBER_PATTERN = "[-+]?\\d*\\.?\\d+(?:[Ee][-+]?\\d+)?";
+const BOUNDING_BOX_RE = new RegExp(
+  `IFCBOUNDINGBOX\\s*\\(\\s*[^,]+\\s*,\\s*(${NUMBER_PATTERN})\\s*,\\s*(${NUMBER_PATTERN})\\s*,\\s*(${NUMBER_PATTERN})\\s*\\)`,
+  "gi",
+);
+export const IFC_READINESS_STORAGE_KEY = "helscoop_ifc_readiness_v1";
+
+function countEntities(ifcText: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  const entityRe = /=\s*(IFC[A-Z0-9]+)\s*\(/gi;
+  let match: RegExpExecArray | null;
+  while ((match = entityRe.exec(ifcText)) !== null) {
+    const entity = match[1].toUpperCase();
+    counts[entity] = (counts[entity] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function countOf(entityCounts: Record<string, number>, entities: string | string[]): number {
+  const keys = Array.isArray(entities) ? entities : [entities];
+  return keys.reduce((sum, key) => sum + (entityCounts[key] ?? 0), 0);
+}
+
+function parseSchema(ifcText: string): string | null {
+  const match = ifcText.match(/FILE_SCHEMA\s*\(\s*\(\s*['"]([^'"]+)['"]/i);
+  return match?.[1]?.toUpperCase() ?? null;
+}
+
+function parseBoundingBoxes(ifcText: string): IfcBoundingBox[] {
+  const boxes: IfcBoundingBox[] = [];
+  BOUNDING_BOX_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = BOUNDING_BOX_RE.exec(ifcText)) !== null) {
+    boxes.push({
+      x: Number.parseFloat(match[1]),
+      y: Number.parseFloat(match[2]),
+      z: Number.parseFloat(match[3]),
+    });
+  }
+  return boxes;
+}
+
+function isIfc43Schema(schema: string | null): boolean {
+  if (!schema) return false;
+  return schema.includes("IFC4X3") || schema.includes("IFC4.3");
+}
+
+function hasStepEnvelope(ifcText: string): boolean {
+  return /ISO-10303-21/i.test(ifcText)
+    && /HEADER\s*;/i.test(ifcText)
+    && /DATA\s*;/i.test(ifcText)
+    && /END-ISO-10303-21\s*;/i.test(ifcText);
+}
+
+function buildCheck(
+  id: string,
+  label: string,
+  status: IfcValidationStatus,
+  blocking: boolean,
+  message: string,
+): IfcValidationCheck {
+  return { id, label, status, blocking, message };
+}
+
+export function analyzeIfcStep(ifcText: string): IfcPreviewAnalysis {
+  const schema = parseSchema(ifcText);
+  const entityCounts = countEntities(ifcText);
+  const boundingBoxes = parseBoundingBoxes(ifcText);
+  const previewElements = ELEMENT_GROUPS.map((group) => ({
+    ...group,
+    count: countOf(entityCounts, group.entityNames),
+  })).filter((group) => group.count > 0);
+  const elementCounts = Object.fromEntries(previewElements.map((group) => [group.id, group.count]));
+  const buildingElementCount = BUILDING_ELEMENT_ENTITIES.reduce((sum, entity) => sum + countOf(entityCounts, entity), 0);
+  const hasShapeGeometry = countOf(entityCounts, "IFCSHAPEREPRESENTATION") > 0 || boundingBoxes.length > 0;
+  const largestSpanMeters = boundingBoxes.length > 0
+    ? Math.max(...boundingBoxes.flatMap((box) => [box.x, box.y, box.z]))
+    : null;
+  const spatialStructure = {
+    project: countOf(entityCounts, "IFCPROJECT"),
+    site: countOf(entityCounts, "IFCSITE"),
+    building: countOf(entityCounts, "IFCBUILDING"),
+    storey: countOf(entityCounts, "IFCBUILDINGSTOREY"),
+  };
+  const requiredSpatialMissing = Object.entries(spatialStructure)
+    .filter(([, count]) => count === 0)
+    .map(([key]) => key);
+  const dimensionsArePlausible = boundingBoxes.length > 0
+    && boundingBoxes.every((box) => [box.x, box.y, box.z].every((value) => Number.isFinite(value) && value >= 0.01 && value <= 120));
+  const dimensionsAreExtreme = boundingBoxes.some((box) => [box.x, box.y, box.z].some((value) => !Number.isFinite(value) || value <= 0 || value > 120));
+  const hasEnvelopeElements = countOf(entityCounts, ["IFCWALL", "IFCWALLSTANDARDCASE"]) > 0
+    && (countOf(entityCounts, "IFCSLAB") > 0 || countOf(entityCounts, "IFCROOF") > 0);
+  const openingCount = countOf(entityCounts, ["IFCDOOR", "IFCWINDOW"]);
+
+  const checks: IfcValidationCheck[] = [
+    buildCheck(
+      "step-envelope",
+      "STEP file envelope",
+      hasStepEnvelope(ifcText) ? "pass" : "fail",
+      true,
+      hasStepEnvelope(ifcText)
+        ? "The file has the expected ISO-10303-21 header, data section, and terminator."
+        : "The file is missing the standard IFC STEP wrapper.",
+    ),
+    buildCheck(
+      "ifc-schema",
+      "IFC 4.3 schema",
+      isIfc43Schema(schema) ? "pass" : "fail",
+      true,
+      schema
+        ? `${schema} ${isIfc43Schema(schema) ? "is accepted for IFC 4.3 permit exchange." : "is older than the required IFC 4.3 family."}`
+        : "The IFC schema header is missing.",
+    ),
+    buildCheck(
+      "spatial-structure",
+      "Project / site / building / storey",
+      requiredSpatialMissing.length === 0 ? "pass" : "fail",
+      true,
+      requiredSpatialMissing.length === 0
+        ? "Required spatial containers are present."
+        : `Missing required spatial containers: ${requiredSpatialMissing.join(", ")}.`,
+    ),
+    buildCheck(
+      "site-reference",
+      "Site and terrain reference",
+      spatialStructure.site > 0 && countOf(entityCounts, "IFCLOCALPLACEMENT") > 0 ? "pass" : spatialStructure.site > 0 ? "warning" : "fail",
+      spatialStructure.site === 0,
+      spatialStructure.site > 0 && countOf(entityCounts, "IFCLOCALPLACEMENT") > 0
+        ? "The model includes an IfcSite with local placement."
+        : spatialStructure.site > 0
+          ? "IfcSite exists, but placement/georeferencing should be confirmed before authority submission."
+          : "IfcSite is missing, so the model cannot be tied to a parcel or terrain reference.",
+    ),
+    buildCheck(
+      "geometry",
+      "Previewable building geometry",
+      buildingElementCount > 0 && hasShapeGeometry ? "pass" : "fail",
+      true,
+      buildingElementCount > 0 && hasShapeGeometry
+        ? `${buildingElementCount} building elements have geometry references.`
+        : "No previewable building elements or shape representations were found.",
+    ),
+    buildCheck(
+      "dimensions",
+      "Plausible dimensions",
+      dimensionsArePlausible ? "pass" : dimensionsAreExtreme ? "fail" : "warning",
+      dimensionsAreExtreme,
+      dimensionsArePlausible
+        ? `Bounding dimensions are within 0.01-120 m; largest span is ${largestSpanMeters?.toFixed(1)} m.`
+        : dimensionsAreExtreme
+          ? "At least one bounding dimension is zero, negative, non-numeric, or above 120 m."
+          : "No bounding boxes were found; inspect dimensions in a native IFC viewer before submission.",
+    ),
+    buildCheck(
+      "enclosure",
+      "Enclosed-space signal",
+      hasEnvelopeElements ? "pass" : "warning",
+      false,
+      hasEnvelopeElements
+        ? "Walls plus slab/roof elements suggest an enclosed building envelope."
+        : "The model lacks enough wall, slab, or roof elements to infer enclosed spaces.",
+    ),
+    buildCheck(
+      "openings",
+      "Doors and windows",
+      openingCount > 0 ? "pass" : "warning",
+      false,
+      openingCount > 0
+        ? `${openingCount} door/window openings are present.`
+        : "No doors or windows were detected; this may be fine for early massing but weak for permit review.",
+    ),
+  ];
+
+  const blockingIssueCount = checks.filter((check) => check.blocking && check.status === "fail").length;
+  const warningCount = checks.filter((check) => check.status === "warning").length;
+
+  return {
+    schema,
+    entityCounts,
+    elementCounts,
+    previewElements,
+    boundingBoxes,
+    largestSpanMeters,
+    spatialStructure,
+    checks,
+    blockingIssueCount,
+    warningCount,
+    readyForLupapiste: blockingIssueCount === 0,
+  };
+}
+
+function emptyIfcBadge(): IfcReadinessBadge {
+  return {
+    show: false,
+    label: "Ready for Lupapiste",
+    reasons: [],
+  };
+}
+
+function readStoredReadinessMap(): StoredIfcReadinessMap {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(IFC_READINESS_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as StoredIfcReadinessMap
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function rememberIfcReadiness(projectId: string, analysis: IfcPreviewAnalysis): void {
+  if (typeof window === "undefined") return;
+  try {
+    const current = readStoredReadinessMap();
+    current[projectId] = {
+      ready: analysis.readyForLupapiste,
+      schema: analysis.schema,
+      checkedAt: new Date().toISOString(),
+      warningCount: analysis.warningCount,
+      blockingIssueCount: analysis.blockingIssueCount,
+    };
+    window.localStorage.setItem(IFC_READINESS_STORAGE_KEY, JSON.stringify(current));
+  } catch {
+    // Local storage is advisory only; validation still works without it.
+  }
+}
+
+export function readIfcReadinessBadge(projectId: string, projectUpdatedAt?: string | null): IfcReadinessBadge {
+  const record = readStoredReadinessMap()[projectId];
+  if (!record || !record.ready || record.blockingIssueCount > 0) return emptyIfcBadge();
+  if (projectUpdatedAt && Date.parse(record.checkedAt) < Date.parse(projectUpdatedAt)) return emptyIfcBadge();
+  return {
+    show: true,
+    label: "Ready for Lupapiste",
+    schema: record.schema,
+    checkedAt: record.checkedAt,
+    reasons: [
+      record.schema ? record.schema : "IFC 4.3",
+      record.warningCount > 0 ? `${record.warningCount} warnings` : "no blocking issues",
+    ],
+  };
+}


### PR DESCRIPTION
Fixes #396.

Summary:
- Adds a dependency-light IFC STEP analyzer for schema, spatial structure, site placement, geometry, dimension, enclosure, and opening checks.
- Adds a project-side IFC preview panel with object counts, simplified visual object tree, checklist, refresh, and download actions.
- Stores successful validator results locally so project cards show Ready for Lupapiste only after validation passes, and hides stale badges after project edits.

Validation:
- npm test -- --run src/lib/__tests__/ifc-preview.test.ts src/__tests__/ifc-preview-panel.test.tsx src/__tests__/project-card.test.tsx src/lib/__tests__/api-client.test.ts
- npx tsc --noEmit
- npm test -- --run
- npm run build

Note: npm run build still prints the pre-existing Next warning for experimental.viewTransition.