### PR TITLE
fix(i18n): Swedish diacritics and sv-SE formatting in 4 components

### DIFF
--- a/web/src/components/GuidedRenovationWizard.tsx
+++ b/web/src/components/GuidedRenovationWizard.tsx
@@ -84,22 +84,22 @@ const COPY = {
   },
   sv: {
     title: "Guidad renoveringsguide",
-    subtitle: "Valj 3-5 saker i taget. Helscoop skapar modell, BOM och kostnadsvag.",
-    total: "Lopande uppskattning",
-    preview: "Live 3D-forhandsvisning",
+    subtitle: "Välj 3–5 saker i taget. Helscoop skapar modell, BOM och kostnadsväg.",
+    total: "Löpande uppskattning",
+    preview: "Live 3D-förhandsvisning",
     showMore: "Visa fler alternativ",
-    showLess: "Dolj extra alternativ",
+    showLess: "Dölj extra alternativ",
     customize: "Anpassa mer",
     back: "Tillbaka",
-    next: "Nasta",
-    close: "Stang",
+    next: "Nästa",
+    close: "Stäng",
     apply: "Skapa plan",
-    applyAdvanced: "Skapa och oppna avancerat lage",
+    applyAdvanced: "Skapa och öppna avancerat läge",
     bom: "BOM-rader",
     scene: "Scene script",
     cost: "Uppskattad totalbudget",
-    energy: "Energitillagg",
-    noEnergy: "Inget tillagg",
+    energy: "Energitillägg",
+    noEnergy: "Inget tillägg",
   },
 } as const;
 
@@ -109,7 +109,7 @@ function localeKey(locale: string): keyof typeof COPY {
 }
 
 function formatEuro(value: number, locale: string): string {
-  return `${value.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB", { maximumFractionDigits: 0 })} EUR`;
+  return `${value.toLocaleString(locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB", { maximumFractionDigits: 0 })} EUR`;
 }
 
 function OptionGrid<T extends string>({

--- a/web/src/components/PriceSummaryBar.tsx
+++ b/web/src/components/PriceSummaryBar.tsx
@@ -33,7 +33,7 @@ export default function PriceSummaryBar({ bom, onViewBom }: PriceSummaryBarProps
 
   if (bom.length === 0) return null;
 
-  const fmtLocale = locale === "fi" ? "fi-FI" : "en-GB";
+  const fmtLocale = locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB";
 
   return (
     <div className="price-summary-bar">
@@ -63,7 +63,7 @@ export default function PriceSummaryBar({ bom, onViewBom }: PriceSummaryBarProps
           color: "var(--text-muted)",
           fontFamily: "var(--font-mono)",
         }}>
-          {bom.length} {locale === "fi" ? "kpl" : "items"}
+          {bom.length} {locale === "fi" ? "kpl" : locale === "sv" ? "st" : "items"}
         </span>
       </div>
       {onViewBom && (

--- a/web/src/components/RenovationCostIndexPanel.tsx
+++ b/web/src/components/RenovationCostIndexPanel.tsx
@@ -6,7 +6,7 @@ import { api } from "@/lib/api";
 import type { RenovationCostIndexResponse, RenovationCostUnit } from "@/types";
 
 function formatEur(value: number, locale: string): string {
-  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} €`;
+  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB")} €`;
 }
 
 function formatPeriod(period: string): string {
@@ -18,8 +18,8 @@ function formatPeriod(period: string): string {
 function localizeUnit(unit: RenovationCostUnit, locale: string): string {
   if (unit === "m2") return "m²";
   if (unit === "m") return locale === "fi" ? "jm" : "m";
-  if (unit === "unit") return locale === "fi" ? "kpl" : "unit";
-  return locale === "fi" ? "projekti" : "project";
+  if (unit === "unit") return locale === "fi" ? "kpl" : locale === "sv" ? "st" : "unit";
+  return locale === "fi" ? "projekti" : locale === "sv" ? "projekt" : "project";
 }
 
 export default function RenovationCostIndexPanel() {

--- a/web/src/components/RenovationRoiPanel.tsx
+++ b/web/src/components/RenovationRoiPanel.tsx
@@ -13,12 +13,14 @@ interface RenovationRoiPanelProps {
 }
 
 function formatEur(value: number, locale: string): string {
-  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} €`;
+  return `${Math.round(value).toLocaleString(locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB")} €`;
 }
 
 function formatYears(value: number | null, locale: string): string {
-  if (value == null) return locale === "fi" ? "Ei energiasäästöarviota" : "No energy payback";
-  return locale === "fi" ? `${value.toLocaleString("fi-FI")} vuotta` : `${value.toLocaleString("en-GB")} years`;
+  if (value == null) return locale === "fi" ? "Ei energiasäästöarviota" : locale === "sv" ? "Ingen energibesparingsuppskattning" : "No energy payback";
+  const tag = locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB";
+  const unit = locale === "fi" ? "vuotta" : locale === "sv" ? "år" : "years";
+  return `${value.toLocaleString(tag)} ${unit}`;
 }
 
 export default function RenovationRoiPanel({


### PR DESCRIPTION
## Summary
- Fixes 10 broken Swedish diacritics in `GuidedRenovationWizard` (e.g. "Valj" → "Välj", "Nästa", "Stäng", "öppna", "läge", "tillägg")
- Adds `sv-SE` number formatting to `formatEuro`/`formatEur` helpers in 4 components
- Adds Swedish unit labels: "st" (pieces), "projekt", "år" (years)
- Adds Swedish "No energy payback" text to `RenovationRoiPanel`

**Components touched:** GuidedRenovationWizard, RenovationCostIndexPanel, RenovationRoiPanel, PriceSummaryBar

## Test plan
- [x] TypeScript compiles cleanly (only pre-existing errors)
- [ ] Verify Swedish wizard shows proper diacritics
- [ ] Verify Swedish number formatting uses space as thousands separator

🤖 Generated with [Claude Code](https://claude.com/claude-code)