### PR TITLE
feat: add K-Rauta PRO partner package

### DIFF
--- a/web/src/__tests__/krauta-pro-partner-panel.test.tsx
+++ b/web/src/__tests__/krauta-pro-partner-panel.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import KrautaProPartnerPanel from "@/components/KrautaProPartnerPanel";
+import { api } from "@/lib/api";
+import type { BomItem, Material } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    recordAffiliateClick: vi.fn().mockResolvedValue({ id: "click-1" }),
+  },
+}));
+
+const materials: Material[] = [
+  {
+    id: "osb_18mm",
+    name: "OSB 18mm",
+    name_fi: "OSB 18mm",
+    name_en: "OSB 18mm",
+    category_name: "interior",
+    category_name_fi: "sisatyot",
+    image_url: null,
+    pricing: [{ unit_price: 32, unit: "sheet", supplier_name: "K-Rauta", link: "https://www.k-rauta.fi/tuote/osb", is_primary: true }],
+  },
+];
+
+const bom: BomItem[] = [
+  { material_id: "osb_18mm", material_name: "OSB 18mm", quantity: 10, unit: "sheet" },
+];
+
+beforeEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+describe("KrautaProPartnerPanel", () => {
+  it("renders PRO package metrics and order lines", () => {
+    render(<KrautaProPartnerPanel bom={bom} materials={materials} projectName="Sauna" />);
+
+    expect(screen.getByRole("heading", { name: "K-Rauta PRO contractor package" })).toBeInTheDocument();
+    expect(screen.getByText("PRO order estimate")).toBeInTheDocument();
+    expect(screen.getByText("Referral potential")).toBeInTheDocument();
+    expect(screen.getAllByText("OSB 18mm").length).toBeGreaterThan(0);
+  });
+
+  it("copies the contractor package", async () => {
+    render(<KrautaProPartnerPanel bom={bom} materials={materials} projectName="Sauna" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy PRO package" }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining("Helscoop K-Rauta PRO order package"));
+    });
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+
+  it("records an affiliate click when opening K-Rauta PRO", async () => {
+    render(<KrautaProPartnerPanel bom={bom} materials={materials} projectName="Sauna" />);
+
+    fireEvent.click(screen.getByRole("link", { name: "Open K-Rauta PRO" }));
+
+    await waitFor(() => {
+      expect(api.recordAffiliateClick).toHaveBeenCalledWith(expect.objectContaining({
+        material_id: "osb_18mm",
+        supplier_id: "k-rauta",
+      }));
+    });
+    expect(screen.getByText("Click recorded in affiliate ledger.")).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no K-Rauta lines are present", () => {
+    render(
+      <KrautaProPartnerPanel
+        bom={[{ material_id: "other", material_name: "Other", quantity: 1, unit: "pcs" }]}
+        materials={[]}
+      />,
+    );
+
+    expect(screen.getByText("No K-Rauta BOM lines yet.")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -17,6 +17,7 @@ import RenovationFinancingPanel from "@/components/RenovationFinancingPanel";
 import EuEnergyGrantPrecheckPanel from "@/components/EuEnergyGrantPrecheckPanel";
 import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
 import PhasedRenovationPlannerPanel from "@/components/PhasedRenovationPlannerPanel";
+import KrautaProPartnerPanel from "@/components/KrautaProPartnerPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import IfcPreviewPanel from "@/components/IfcPreviewPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
@@ -2731,6 +2732,14 @@ export default function BomPanel({
             bom={bom}
             materials={materials}
             buildingInfo={buildingInfo}
+          />
+        )}
+        {bom.length > 0 && (
+          <KrautaProPartnerPanel
+            bom={bom}
+            materials={materials}
+            projectName={projectName}
+            projectDescription={projectDescription}
           />
         )}
         {bom.length > 0 && (

--- a/web/src/components/KrautaProPartnerPanel.tsx
+++ b/web/src/components/KrautaProPartnerPanel.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { api } from "@/lib/api";
+import {
+  buildKrautaProPackage,
+  formatKrautaProPackage,
+  KRAUTA_PRO_CONFIG,
+  type KrautaProLine,
+  type KrautaProPackage,
+} from "@/lib/krauta-pro";
+import type { BomItem, Material } from "@/types";
+
+interface KrautaProPartnerPanelProps {
+  bom: BomItem[];
+  materials: Material[];
+  projectName?: string;
+  projectDescription?: string;
+}
+
+type PanelLocale = "fi" | "en" | "sv";
+
+const COPY = {
+  fi: {
+    eyebrow: "Kumppanikanava",
+    title: "K-Rauta PRO urakoitsijapaketti",
+    subtitle: "Valmistele asiakkaalle jaettava tarjous, urakoitsijan ostolista ja Helscoopin affiliate-signaali.",
+    badge: "PRO API pending",
+    coverage: "K-Rauta-kattavuus",
+    orderValue: "PRO ostokoriarvio",
+    tradeSavings: "Urakoitsijan hintaetu",
+    referral: "Referral-potentiaali",
+    clientQuote: "Asiakkaan tarjous",
+    contractorMargin: "Urakoitsijamarginaali",
+    lines: "Ostolista",
+    assumptions: "Rehelliset oletukset",
+    uncovered: "Hankittava muualta",
+    shareHint: "Jaa projekti -linkki antaa asiakkaalle katselu- ja kommentointinäkymän; tämä paketti pysyy urakoitsijan sisäisenä.",
+    copy: "Kopioi PRO-paketti",
+    copied: "Kopioitu",
+    openPro: "Avaa K-Rauta PRO",
+    noLines: "BOMissa ei ole vielä K-Rauta-rivejä.",
+    tracked: "Klikki kirjattu affiliate-ledgeriin.",
+    untracked: "Klikkiä ei voitu kirjata, mutta linkki avataan silti.",
+  },
+  en: {
+    eyebrow: "Partner channel",
+    title: "K-Rauta PRO contractor package",
+    subtitle: "Prepare a client quote, contractor order list, and Helscoop referral signal from the BOM.",
+    badge: "PRO API pending",
+    coverage: "K-Rauta coverage",
+    orderValue: "PRO order estimate",
+    tradeSavings: "Contractor trade savings",
+    referral: "Referral potential",
+    clientQuote: "Client quote",
+    contractorMargin: "Contractor margin",
+    lines: "Order list",
+    assumptions: "Honest assumptions",
+    uncovered: "Source separately",
+    shareHint: "Use Share project for the client read-only/commenting view; this package stays contractor-internal.",
+    copy: "Copy PRO package",
+    copied: "Copied",
+    openPro: "Open K-Rauta PRO",
+    noLines: "No K-Rauta BOM lines yet.",
+    tracked: "Click recorded in affiliate ledger.",
+    untracked: "Click could not be recorded, but the link still opens.",
+  },
+  sv: {
+    eyebrow: "Partnerkanal",
+    title: "K-Rauta PRO entreprenorpaket",
+    subtitle: "Forbered kundoffert, entreprenorens inkopslista och Helscoops referral-signal fran materiallistan.",
+    badge: "PRO API pending",
+    coverage: "K-Rauta-tackning",
+    orderValue: "PRO orderestimat",
+    tradeSavings: "Entreprenorens prisfordel",
+    referral: "Referral-potential",
+    clientQuote: "Kundoffert",
+    contractorMargin: "Entreprenormarginal",
+    lines: "Inkopslista",
+    assumptions: "Arliga antaganden",
+    uncovered: "Kop separat",
+    shareHint: "Anvand Share project for kundens las- och kommentarsvy; detta paket stannar internt hos entreprenoren.",
+    copy: "Kopiera PRO-paket",
+    copied: "Kopierat",
+    openPro: "Oppna K-Rauta PRO",
+    noLines: "Inga K-Rauta-rader i materiallistan annu.",
+    tracked: "Klick registrerat i affiliate-ledgern.",
+    untracked: "Klicket kunde inte registreras, men lanken oppnas anda.",
+  },
+} as const;
+
+function panelLocale(locale: string): PanelLocale {
+  if (locale === "fi" || locale === "sv") return locale;
+  return "en";
+}
+
+function formatEur(value: number, locale: string): string {
+  const numberLocale = locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB";
+  return `${Math.round(value).toLocaleString(numberLocale)} EUR`;
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
+}
+
+export default function KrautaProPartnerPanel({
+  bom,
+  materials,
+  projectName,
+}: KrautaProPartnerPanelProps) {
+  const { locale } = useTranslation();
+  const activeLocale = panelLocale(locale);
+  const copy = COPY[activeLocale];
+  const [copied, setCopied] = useState(false);
+  const [clickStatus, setClickStatus] = useState<"idle" | "tracked" | "untracked">("idle");
+
+  const plan = useMemo(
+    () => buildKrautaProPackage({ bom, materials, projectName }),
+    [bom, materials, projectName],
+  );
+
+  if (bom.length === 0) return null;
+
+  const copyPackage = async () => {
+    const text = formatKrautaProPackage(plan, projectName, activeLocale === "fi" ? "fi" : "en");
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      await navigator.clipboard.writeText(text);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  const recordProClick = async () => {
+    const firstLine = plan.lines[0];
+    if (!firstLine) return;
+    try {
+      await api.recordAffiliateClick({
+        material_id: firstLine.materialId,
+        supplier_id: KRAUTA_PRO_CONFIG.supplierId,
+        click_url: plan.orderUrl,
+      });
+      setClickStatus("tracked");
+    } catch {
+      setClickStatus("untracked");
+    }
+  };
+
+  return (
+    <section
+      data-testid="krauta-pro-partner-panel"
+      aria-labelledby="krauta-pro-partner-title"
+      style={{
+        marginTop: 12,
+        padding: 14,
+        borderRadius: "var(--radius-md)",
+        border: "1px solid rgba(229,160,75,0.32)",
+        background: "linear-gradient(150deg, rgba(229,160,75,0.15), rgba(74,124,89,0.11) 54%, rgba(22,27,31,0.5))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+        <div>
+          <div className="label-mono" style={{ color: "var(--amber)", fontSize: 10, marginBottom: 4 }}>
+            {copy.eyebrow}
+          </div>
+          <h4 id="krauta-pro-partner-title" style={{ margin: 0, color: "var(--text-primary)", fontSize: 15 }}>
+            {copy.title}
+          </h4>
+          <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+            {copy.subtitle}
+          </p>
+        </div>
+        <span
+          style={{
+            borderRadius: 999,
+            padding: "4px 7px",
+            border: "1px solid rgba(229,160,75,0.42)",
+            background: "rgba(229,160,75,0.12)",
+            color: "var(--amber)",
+            fontSize: 9,
+            fontWeight: 900,
+            whiteSpace: "nowrap",
+            textTransform: "uppercase",
+          }}
+        >
+          {copy.badge}
+        </span>
+      </div>
+
+      {plan.eligible ? (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: 8, marginTop: 12 }}>
+            <Metric label={copy.coverage} value={`${plan.lineCount}/${plan.totalBomLines} (${formatPercent(plan.coveragePercent)})`} />
+            <Metric label={copy.orderValue} value={formatEur(plan.proMaterialEstimate, locale)} strong />
+            <Metric label={copy.tradeSavings} value={formatEur(plan.estimatedTradeSavings, locale)} strong={plan.estimatedTradeSavings > 0} />
+            <Metric label={copy.referral} value={formatEur(plan.estimatedReferralRevenue, locale)} />
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 8 }}>
+            <Metric label={copy.clientQuote} value={formatEur(plan.clientQuoteTotal, locale)} />
+            <Metric label={copy.contractorMargin} value={formatEur(plan.contractorMargin, locale)} />
+          </div>
+
+          <p style={{ margin: "10px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+            {copy.shareHint}
+          </p>
+
+          <div style={{ marginTop: 12 }}>
+            <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 10, marginBottom: 6 }}>
+              {copy.lines}
+            </div>
+            <div style={{ display: "grid", gap: 6 }}>
+              {plan.lines.slice(0, 5).map((line) => (
+                <OrderLine key={line.materialId} line={line} locale={locale} />
+              ))}
+            </div>
+          </div>
+
+          {plan.uncoveredLines.length > 0 && (
+            <details style={{ marginTop: 10 }}>
+              <summary style={{ cursor: "pointer", color: "var(--text-muted)", fontSize: 10, fontWeight: 800 }}>
+                {copy.uncovered}: {plan.uncoveredLines.length}
+              </summary>
+              <ul style={{ margin: "6px 0 0", paddingLeft: 16, color: "var(--text-muted)", fontSize: 10, lineHeight: 1.35 }}>
+                {plan.uncoveredLines.slice(0, 8).map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            </details>
+          )}
+
+          <details style={{ marginTop: 10 }}>
+            <summary style={{ cursor: "pointer", color: "var(--text-muted)", fontSize: 10, fontWeight: 800 }}>
+              {copy.assumptions}
+            </summary>
+            <ul style={{ margin: "6px 0 0", paddingLeft: 16, color: "var(--text-muted)", fontSize: 10, lineHeight: 1.35 }}>
+              {plan.assumptions.map((assumption) => (
+                <li key={assumption}>{assumption}</li>
+              ))}
+            </ul>
+          </details>
+
+          {clickStatus !== "idle" && (
+            <p style={{ margin: "10px 0 0", color: clickStatus === "tracked" ? "var(--forest)" : "var(--amber)", fontSize: 10 }}>
+              {clickStatus === "tracked" ? copy.tracked : copy.untracked}
+            </p>
+          )}
+
+          <div style={{ display: "flex", gap: 8, marginTop: 12 }}>
+            <button type="button" className="material-btn" onClick={copyPackage} style={{ flex: 1, justifyContent: "center" }}>
+              {copied ? copy.copied : copy.copy}
+            </button>
+            <a
+              href={plan.orderUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="material-btn"
+              onClick={() => void recordProClick()}
+              style={{ flex: 1, justifyContent: "center", textDecoration: "none" }}
+            >
+              {copy.openPro}
+            </a>
+          </div>
+        </>
+      ) : (
+        <p style={{ margin: "12px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+          {copy.noLines}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function OrderLine({ line, locale }: { line: KrautaProLine; locale: string }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr auto",
+        gap: 8,
+        alignItems: "center",
+        padding: "7px 8px",
+        borderRadius: "var(--radius-sm)",
+        border: "1px solid rgba(255,255,255,0.08)",
+        background: "rgba(255,255,255,0.025)",
+      }}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div style={{ color: "var(--text-primary)", fontSize: 11, fontWeight: 800, overflow: "hidden", textOverflow: "ellipsis" }}>
+          {line.name}
+        </div>
+        <div style={{ color: "var(--text-muted)", fontSize: 10, marginTop: 2 }}>
+          {line.quantity.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB")} {line.unit} · retail {formatEur(line.retailTotal, locale)}
+        </div>
+      </div>
+      <strong style={{ color: "var(--forest)", fontSize: 11 }}>
+        {formatEur(line.proEstimate, locale)}
+      </strong>
+    </div>
+  );
+}
+
+function Metric({ label, value, strong = false }: { label: string; value: string; strong?: boolean }) {
+  return (
+    <div style={{ padding: "8px 9px", borderRadius: "var(--radius-sm)", border: "1px solid var(--border)", background: "var(--bg-tertiary)", minWidth: 0 }}>
+      <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 9, marginBottom: 3 }}>
+        {label}
+      </div>
+      <div style={{ color: strong ? "var(--forest)" : "var(--text-primary)", fontSize: 12, fontWeight: 900, lineHeight: 1.2, overflowWrap: "anywhere" }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/__tests__/krauta-pro.test.ts
+++ b/web/src/lib/__tests__/krauta-pro.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { buildKrautaProPackage, formatKrautaProPackage } from "@/lib/krauta-pro";
+import type { BomItem, Material } from "@/types";
+
+const materials: Material[] = [
+  {
+    id: "osb_18mm",
+    name: "OSB 18mm",
+    name_fi: "OSB 18mm",
+    name_en: "OSB 18mm",
+    category_name: "interior",
+    category_name_fi: "sisatyot",
+    image_url: null,
+    pricing: [{ unit_price: 32, unit: "sheet", supplier_name: "K-Rauta", link: "https://www.k-rauta.fi/tuote/osb", is_primary: true }],
+  },
+  {
+    id: "paint",
+    name: "Paint",
+    name_fi: "Maali",
+    name_en: "Paint",
+    category_name: "finish",
+    category_name_fi: "pinta",
+    image_url: null,
+    pricing: [{ unit_price: 18, unit: "l", supplier_name: "Other", is_primary: true }],
+  },
+];
+
+const bom: BomItem[] = [
+  { material_id: "osb_18mm", material_name: "OSB 18mm", quantity: 10, unit: "sheet" },
+  { material_id: "paint", material_name: "Paint", quantity: 5, unit: "l" },
+];
+
+describe("K-Rauta PRO package", () => {
+  it("builds a contractor package from K-Rauta BOM lines", () => {
+    const plan = buildKrautaProPackage({ bom, materials });
+
+    expect(plan.eligible).toBe(true);
+    expect(plan.supplierId).toBe("k-rauta");
+    expect(plan.lineCount).toBe(1);
+    expect(plan.coveragePercent).toBe(0.5);
+    expect(plan.retailMaterialTotal).toBe(320);
+    expect(plan.proMaterialEstimate).toBe(294);
+    expect(plan.estimatedTradeSavings).toBe(26);
+    expect(plan.estimatedReferralRevenue).toBe(12);
+    expect(plan.uncoveredLines).toEqual(["Paint"]);
+    expect(plan.orderUrl).toContain("hsc_source=k_rauta_pro_package");
+  });
+
+  it("uses explicit K-Rauta BOM pricing when available", () => {
+    const plan = buildKrautaProPackage({
+      bom: [{ material_id: "manual", material_name: "Manual line", quantity: 2, unit: "pcs", unit_price: 50, supplier: "K-Rauta" }],
+      materials: [],
+    });
+
+    expect(plan.eligible).toBe(true);
+    expect(plan.retailMaterialTotal).toBe(100);
+  });
+
+  it("formats a copyable order package", () => {
+    const plan = buildKrautaProPackage({ bom, materials });
+    const text = formatKrautaProPackage(plan, "Sauna renovation", "en");
+
+    expect(text).toContain("Helscoop K-Rauta PRO order package");
+    expect(text).toContain("Sauna renovation");
+    expect(text).toContain("osb_18mm");
+    expect(text).toContain("Non K-Rauta lines");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -377,6 +377,16 @@ export const api = {
 
   getSuppliers: () => apiFetch("/suppliers"),
   getSupplier: (id: string) => apiFetch(`/suppliers/${id}`),
+  recordAffiliateClick: (data: {
+    material_id: string;
+    supplier_id: string;
+    click_url: string;
+    partner_id?: string | null;
+  }) =>
+    apiFetch("/affiliates/click", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
 
   comparePrices: (materialId: string) =>
     apiFetch(`/pricing/compare/${materialId}`),

--- a/web/src/lib/krauta-pro.ts
+++ b/web/src/lib/krauta-pro.ts
@@ -1,0 +1,203 @@
+import { buildAffiliateRetailerUrl } from "@/lib/material-affiliate";
+import { calculateQuote, defaultQuoteConfig } from "@/lib/quote-engine";
+import type { BomItem, Material } from "@/types";
+
+export const KRAUTA_PRO_CONFIG = {
+  supplierId: "k-rauta",
+  supplierName: "K-Rauta",
+  proPortalUrl: "https://www.k-rauta.fi/pro",
+  planningTradeDiscountPercent: 0.08,
+  referralRatePercent: 0.04,
+  contractorMarginPercent: 0.15,
+} as const;
+
+export interface KrautaProLine {
+  materialId: string;
+  name: string;
+  quantity: number;
+  unit: string;
+  unitPrice: number;
+  retailTotal: number;
+  proEstimate: number;
+  estimatedSavings: number;
+  link: string | null;
+}
+
+export interface KrautaProPackage {
+  eligible: boolean;
+  orderUrl: string;
+  supplierId: string;
+  supplierName: string;
+  lineCount: number;
+  totalBomLines: number;
+  coveragePercent: number;
+  retailMaterialTotal: number;
+  proMaterialEstimate: number;
+  estimatedTradeSavings: number;
+  estimatedReferralRevenue: number;
+  clientQuoteTotal: number;
+  contractorMargin: number;
+  lines: KrautaProLine[];
+  uncoveredLines: string[];
+  assumptions: string[];
+}
+
+interface BuildKrautaProPackageInput {
+  bom: BomItem[];
+  materials: Material[];
+  projectName?: string;
+  tradeDiscountPercent?: number;
+  referralRatePercent?: number;
+  contractorMarginPercent?: number;
+}
+
+function roundEuro(value: number): number {
+  return Math.round(value);
+}
+
+function isKrautaSupplier(value?: string | null): boolean {
+  return /k-?rauta|kesko/i.test(value ?? "");
+}
+
+function getMaterialName(material: Material | null, item: BomItem): string {
+  return material?.name_en || material?.name_fi || material?.name || item.material_name || item.material_id;
+}
+
+function findKrautaPricing(material: Material | null, item: BomItem) {
+  const pricing = material?.pricing ?? [];
+  const explicitKrauta = isKrautaSupplier(item.supplier) || isKrautaSupplier(item.supplier_name);
+  const krautaPrice = pricing.find((price) => isKrautaSupplier(price.supplier_name) || isKrautaSupplier(price.link));
+  const primaryPrice = pricing.find((price) => price.is_primary) ?? pricing[0];
+
+  if (explicitKrauta && item.unit_price != null) {
+    return {
+      unitPrice: Number(item.unit_price),
+      link: item.link ?? krautaPrice?.link ?? null,
+      unit: item.unit || krautaPrice?.unit || primaryPrice?.unit || "unit",
+    };
+  }
+
+  if (krautaPrice) {
+    return {
+      unitPrice: Number(krautaPrice.unit_price),
+      link: item.link ?? krautaPrice.link ?? null,
+      unit: item.unit || krautaPrice.unit,
+    };
+  }
+
+  return null;
+}
+
+function buildOrderUrl(firstLine: KrautaProLine | null): string {
+  return buildAffiliateRetailerUrl(KRAUTA_PRO_CONFIG.proPortalUrl, {
+    materialId: firstLine?.materialId ?? "bom",
+    supplier: KRAUTA_PRO_CONFIG.supplierName,
+    source: "k_rauta_pro_package",
+  }) ?? KRAUTA_PRO_CONFIG.proPortalUrl;
+}
+
+export function buildKrautaProPackage({
+  bom,
+  materials,
+  tradeDiscountPercent = KRAUTA_PRO_CONFIG.planningTradeDiscountPercent,
+  referralRatePercent = KRAUTA_PRO_CONFIG.referralRatePercent,
+  contractorMarginPercent = KRAUTA_PRO_CONFIG.contractorMarginPercent,
+}: BuildKrautaProPackageInput): KrautaProPackage {
+  const materialMap = new Map(materials.map((material) => [material.id, material]));
+  const lines: KrautaProLine[] = [];
+  const uncoveredLines: string[] = [];
+
+  for (const item of bom) {
+    const material = materialMap.get(item.material_id) ?? null;
+    const krautaPricing = findKrautaPricing(material, item);
+    const name = getMaterialName(material, item);
+
+    if (!krautaPricing) {
+      uncoveredLines.push(name);
+      continue;
+    }
+
+    const quantity = Number(item.quantity) || 0;
+    const retailTotal = roundEuro(Number(item.total) || quantity * krautaPricing.unitPrice);
+    const proEstimate = roundEuro(retailTotal * (1 - tradeDiscountPercent));
+
+    lines.push({
+      materialId: item.material_id,
+      name,
+      quantity,
+      unit: krautaPricing.unit,
+      unitPrice: krautaPricing.unitPrice,
+      retailTotal,
+      proEstimate,
+      estimatedSavings: Math.max(0, retailTotal - proEstimate),
+      link: buildAffiliateRetailerUrl(krautaPricing.link, {
+        materialId: item.material_id,
+        supplier: KRAUTA_PRO_CONFIG.supplierName,
+        source: "k_rauta_pro_package_line",
+      }),
+    });
+  }
+
+  const contractorQuote = calculateQuote(bom, materials, {
+    ...defaultQuoteConfig("contractor"),
+    contractorMarginPercent,
+  });
+  const retailMaterialTotal = roundEuro(lines.reduce((sum, line) => sum + line.retailTotal, 0));
+  const proMaterialEstimate = roundEuro(lines.reduce((sum, line) => sum + line.proEstimate, 0));
+  const estimatedTradeSavings = Math.max(0, retailMaterialTotal - proMaterialEstimate);
+  const estimatedReferralRevenue = roundEuro(proMaterialEstimate * referralRatePercent);
+
+  return {
+    eligible: lines.length > 0,
+    orderUrl: buildOrderUrl(lines[0] ?? null),
+    supplierId: KRAUTA_PRO_CONFIG.supplierId,
+    supplierName: KRAUTA_PRO_CONFIG.supplierName,
+    lineCount: lines.length,
+    totalBomLines: bom.length,
+    coveragePercent: bom.length > 0 ? lines.length / bom.length : 0,
+    retailMaterialTotal,
+    proMaterialEstimate,
+    estimatedTradeSavings,
+    estimatedReferralRevenue,
+    clientQuoteTotal: roundEuro(contractorQuote.grandTotal),
+    contractorMargin: roundEuro(contractorQuote.contractorMargin ?? 0),
+    lines,
+    uncoveredLines,
+    assumptions: [
+      "PRO price is a planning estimate until K-Rauta/Kesko provides authenticated trade pricing.",
+      "Referral revenue is modelled from PRO material order value and requires a signed partner agreement.",
+      "Client-facing quote includes the contractor margin; trade savings are contractor-only by default.",
+    ],
+  };
+}
+
+export function formatKrautaProPackage(plan: KrautaProPackage, projectName = "Helscoop project", locale: "fi" | "en" = "en"): string {
+  const numberLocale = locale === "fi" ? "fi-FI" : "en-GB";
+  const eur = (value: number) => `${Math.round(value).toLocaleString(numberLocale)} EUR`;
+  const lines = [
+    "Helscoop K-Rauta PRO order package",
+    `Project: ${projectName}`,
+    `Supplier: ${plan.supplierName}`,
+    `Client quote total: ${eur(plan.clientQuoteTotal)}`,
+    `Retail material total: ${eur(plan.retailMaterialTotal)}`,
+    `Estimated PRO material total: ${eur(plan.proMaterialEstimate)}`,
+    `Estimated contractor trade savings: ${eur(plan.estimatedTradeSavings)}`,
+    `Estimated Helscoop referral revenue: ${eur(plan.estimatedReferralRevenue)}`,
+    "",
+    "Order lines:",
+  ];
+
+  for (const line of plan.lines) {
+    lines.push(`${line.materialId}; ${line.name}; ${line.quantity}; ${line.unit}; retail ${eur(line.retailTotal)}; pro-estimate ${eur(line.proEstimate)}`);
+  }
+
+  if (plan.uncoveredLines.length > 0) {
+    lines.push("", "Non K-Rauta lines to source separately:");
+    for (const name of plan.uncoveredLines) lines.push(`- ${name}`);
+  }
+
+  lines.push("", "Assumptions:");
+  for (const assumption of plan.assumptions) lines.push(`- ${assumption}`);
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
Fixes #124.

Summary:
- Adds a K-Rauta PRO package builder that turns BOM rows into a contractor order estimate, client quote total, contractor margin, trade-savings assumption, referral estimate, uncovered-line list, and copyable order package.
- Adds a BOM-sidebar K-Rauta PRO contractor panel with coverage metrics, order-list preview, honest assumptions, share-project guidance, copy package action, and K-Rauta PRO CTA.
- Records the PRO CTA through the existing affiliate click ledger and reuses existing K-Rauta affiliate URL tracking parameters.

Validation:
- npm test -- --run src/lib/__tests__/krauta-pro.test.ts src/__tests__/krauta-pro-partner-panel.test.tsx
- npx tsc --noEmit (web)
- npm test -- --run (web; existing unrelated act warnings)
- npm run build (web; existing experimental.viewTransition warning only)