### PR TITLE
feat: add blueprint-to-3d draft generator

### DIFF
--- a/web/src/__tests__/blueprint-to-scene-panel.test.tsx
+++ b/web/src/__tests__/blueprint-to-scene-panel.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import BlueprintToScenePanel from "@/components/BlueprintToScenePanel";
+
+const toast = vi.fn();
+const track = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast }),
+}));
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ track }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+});
+
+describe("BlueprintToScenePanel", () => {
+  it("generates and applies an editable blueprint scene", () => {
+    const onApplyScene = vi.fn();
+    render(
+      <BlueprintToScenePanel
+        projectName="Owner house"
+        buildingInfo={{ area_m2: 118, floors: 1 }}
+        onApplyScene={onApplyScene}
+      />,
+    );
+
+    const file = new File(["floor plan"], "sauna-khh-plan.pdf", { type: "application/pdf" });
+    fireEvent.change(screen.getByLabelText("Blueprint file"), { target: { files: [file] } });
+    fireEvent.change(screen.getByLabelText("Known width (m)"), { target: { value: "10.5" } });
+    fireEvent.change(screen.getByLabelText("Room notes"), { target: { value: "sauna, utility, kitchen" } });
+    fireEvent.click(screen.getByRole("button", { name: "Generate editable draft" }));
+
+    expect(screen.getByText("Footprint")).toBeInTheDocument();
+    expect(screen.getByText("Scale")).toBeInTheDocument();
+    expect(screen.getByText(/Draft only/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Apply to 3D scene" }));
+
+    expect(onApplyScene).toHaveBeenCalledWith(expect.stringContaining("blueprint_wall_north"));
+    expect(onApplyScene).toHaveBeenCalledWith(expect.stringContaining("scene.add"));
+    expect(track).toHaveBeenCalledWith("blueprint_scene_generated", expect.objectContaining({ room_count: expect.any(Number) }));
+    expect(track).toHaveBeenCalledWith("blueprint_scene_applied", expect.objectContaining({ confidence: expect.any(Number) }));
+  });
+
+  it("copies generated scene code", async () => {
+    render(<BlueprintToScenePanel projectName="Owner house" />);
+
+    const file = new File(["floor plan"], "floor-plan.png", { type: "image/png" });
+    fireEvent.change(screen.getByLabelText("Blueprint file"), { target: { files: [file] } });
+    fireEvent.click(screen.getByRole("button", { name: "Generate editable draft" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy scene JS" }));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining("Helscoop blueprint-to-3D draft"));
+    });
+    expect(screen.getByRole("button", { name: "Copied" })).toBeInTheDocument();
+  });
+});

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -1072,6 +1072,18 @@ export default function ProjectPage() {
     if (mode === "advanced") markCodeEditor();
   }, [markCodeEditor, track]);
 
+  const handleBlueprintSceneApply = useCallback(
+    (code: string) => {
+      queueSceneAnnouncement("editor.sceneUpdatedFromEditor");
+      setSceneJs(code);
+      pushHistory(code);
+      handleEditorModeChange("advanced");
+      setShowCode(true);
+      if (isMobileEditor) setActiveMobilePanel("code");
+    },
+    [handleEditorModeChange, isMobileEditor, pushHistory, queueSceneAnnouncement],
+  );
+
   const applyGuidedPlan = useCallback(
     (plan: GuidedRenovationPlan, state: RenovationWizardState, advanced = false) => {
       track("renovation_wizard_completed", {
@@ -4006,6 +4018,7 @@ export default function ProjectPage() {
               projectId={projectId}
               householdDeductionJoint={householdDeductionJoint}
               onHouseholdDeductionJointChange={updateHouseholdDeductionMode}
+              onApplyScene={handleBlueprintSceneApply}
             />
           </>
         )}

--- a/web/src/components/BlueprintToScenePanel.tsx
+++ b/web/src/components/BlueprintToScenePanel.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { useToast } from "@/components/ToastProvider";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import {
+  formatBlueprintHandoff,
+  recognizeBlueprintFromMetadata,
+  type BlueprintRecognitionResult,
+} from "@/lib/blueprint-to-scene";
+import type { BuildingInfo } from "@/types";
+
+const COPY = {
+  en: {
+    eyebrow: "AI-ready floor plan intake",
+    title: "Blueprint-to-3D draft",
+    subtitle: "Upload a floor plan image or PDF, add scale hints, and generate editable room, wall, door, and window geometry.",
+    dropHint: "Choose floor plan image or PDF",
+    selected: "Selected",
+    fileInput: "Blueprint file",
+    floor: "Floor label",
+    width: "Known width (m)",
+    depth: "Known depth (m)",
+    notes: "Room notes",
+    notesPlaceholder: "Example: sauna, KHH, 2 bedrooms, kitchen opens to living room",
+    generate: "Generate editable draft",
+    regenerate: "Regenerate draft",
+    apply: "Apply to 3D scene",
+    copy: "Copy scene JS",
+    copied: "Copied",
+    copyHandoff: "Copy handoff",
+    handoffCopied: "Handoff copied",
+    noFile: "Choose a blueprint file first.",
+    applied: "Blueprint scene applied",
+    generated: "Blueprint draft generated",
+    confidence: "Confidence",
+    footprint: "Footprint",
+    rooms: "Rooms",
+    openings: "Openings",
+    assumptions: "Assumptions",
+    doors: "doors",
+    windows: "windows",
+    verify: "Draft only: verify scale and openings before quote requests or permits.",
+    scale: "Scale",
+    fallback: "fallback",
+    buildingArea: "building area",
+    userDimensions: "owner dimensions",
+    partialArea: "owner hint + area",
+  },
+  fi: {
+    eyebrow: "Tekoalyvalmis pohjakuva",
+    title: "Pohjakuvasta 3D-luonnos",
+    subtitle: "Lataa pohjakuva tai PDF, anna mittavihjeet ja luo muokattava huone-, seina-, ovi- ja ikkunaluonnos.",
+    dropHint: "Valitse pohjakuva tai PDF",
+    selected: "Valittu",
+    fileInput: "Pohjakuvatiedosto",
+    floor: "Kerroksen nimi",
+    width: "Tunnettu leveys (m)",
+    depth: "Tunnettu syvyys (m)",
+    notes: "Huomioita huoneista",
+    notesPlaceholder: "Esim. sauna, KHH, 2 makuuhuonetta, keittio olohuoneen yhteydessa",
+    generate: "Luo muokattava luonnos",
+    regenerate: "Luo luonnos uudelleen",
+    apply: "Vie 3D-nakymaan",
+    copy: "Kopioi Scene JS",
+    copied: "Kopioitu",
+    copyHandoff: "Kopioi yhteenveto",
+    handoffCopied: "Yhteenveto kopioitu",
+    noFile: "Valitse ensin pohjakuva.",
+    applied: "Pohjakuvaluonnos otettu kayttoon",
+    generated: "Pohjakuvaluonnos luotu",
+    confidence: "Varmuus",
+    footprint: "Pohjan koko",
+    rooms: "Huoneet",
+    openings: "Aukot",
+    assumptions: "Oletukset",
+    doors: "ovea",
+    windows: "ikkunaa",
+    verify: "Luonnos: tarkista mittakaava ja aukot ennen tarjous- tai lupakayttoa.",
+    scale: "Mittakaava",
+    fallback: "oletus",
+    buildingArea: "rakennuksen ala",
+    userDimensions: "omistajan mitat",
+    partialArea: "mittavihje + ala",
+  },
+  sv: {
+    eyebrow: "AI-redo planintag",
+    title: "Planritning till 3D-utkast",
+    subtitle: "Ladda upp en planbild eller PDF, ange skalhintar och skapa redigerbara rum, vaggar, dorrar och fonster.",
+    dropHint: "Valj planbild eller PDF",
+    selected: "Vald",
+    fileInput: "Planritningsfil",
+    floor: "Vaningsnamn",
+    width: "Kand bredd (m)",
+    depth: "Kant djup (m)",
+    notes: "Rumsanteckningar",
+    notesPlaceholder: "Exempel: bastu, grovkok, 2 sovrum, kok mot vardagsrum",
+    generate: "Skapa redigerbart utkast",
+    regenerate: "Skapa utkast igen",
+    apply: "Applicera i 3D-scenen",
+    copy: "Kopiera Scene JS",
+    copied: "Kopierat",
+    copyHandoff: "Kopiera sammanfattning",
+    handoffCopied: "Sammanfattning kopierad",
+    noFile: "Valj en planfil forst.",
+    applied: "Planutkast applicerat",
+    generated: "Planutkast skapat",
+    confidence: "Konfidens",
+    footprint: "Fotavtryck",
+    rooms: "Rum",
+    openings: "Oppningar",
+    assumptions: "Antaganden",
+    doors: "dorrar",
+    windows: "fonster",
+    verify: "Endast utkast: verifiera skala och oppningar fore offerter eller lov.",
+    scale: "Skala",
+    fallback: "standard",
+    buildingArea: "byggnadsarea",
+    userDimensions: "agarens matt",
+    partialArea: "matthint + area",
+  },
+} as const;
+
+type BlueprintCopy = Record<keyof typeof COPY.en, string>;
+
+function parseNumber(value: string): number | null {
+  const normalized = value.replace(",", ".").trim();
+  if (!normalized) return null;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function scaleLabel(result: BlueprintRecognitionResult, labels: BlueprintCopy): string {
+  if (result.scaleSource === "user_dimensions") return labels.userDimensions;
+  if (result.scaleSource === "building_area") return labels.buildingArea;
+  if (result.scaleSource === "user_width_area" || result.scaleSource === "user_depth_area") return labels.partialArea;
+  return labels.fallback;
+}
+
+function formatMeters(value: number, locale: string): string {
+  return value.toLocaleString(locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-US", {
+    maximumFractionDigits: 1,
+  });
+}
+
+export default function BlueprintToScenePanel({
+  buildingInfo,
+  projectName,
+  onApplyScene,
+}: {
+  buildingInfo?: BuildingInfo | null;
+  projectName?: string;
+  onApplyScene?: (sceneJs: string) => void;
+}) {
+  const { locale } = useTranslation();
+  const { toast } = useToast();
+  const { track } = useAnalytics();
+  const inputId = useId();
+  const labels = COPY[locale] ?? COPY.en;
+  const [file, setFile] = useState<File | null>(null);
+  const [floorLabel, setFloorLabel] = useState("Main floor");
+  const [width, setWidth] = useState("");
+  const [depth, setDepth] = useState("");
+  const [notes, setNotes] = useState("");
+  const [result, setResult] = useState<BlueprintRecognitionResult | null>(null);
+  const [copied, setCopied] = useState<"scene" | "handoff" | null>(null);
+
+  const accepted = "image/jpeg,image/png,image/webp,application/pdf";
+  const openingSummary = useMemo(() => {
+    if (!result) return null;
+    return {
+      doors: result.openings.filter((opening) => opening.type === "door").length,
+      windows: result.openings.filter((opening) => opening.type === "window").length,
+    };
+  }, [result]);
+
+  function generateDraft() {
+    if (!file) {
+      toast(labels.noFile, "warning");
+      return;
+    }
+
+    const next = recognizeBlueprintFromMetadata({
+      fileName: file.name,
+      mimeType: file.type,
+      projectName,
+      floorLabel,
+      notes,
+      widthMeters: parseNumber(width),
+      depthMeters: parseNumber(depth),
+      buildingInfo,
+    });
+    setResult(next);
+    setCopied(null);
+    toast(labels.generated, "success");
+    track("blueprint_scene_generated", {
+      file_type: file.type || "unknown",
+      room_count: next.rooms.length,
+      confidence: next.confidence,
+    });
+  }
+
+  function applyDraft() {
+    if (!result || !onApplyScene) return;
+    onApplyScene(result.sceneJs);
+    toast(labels.applied, "success");
+    track("blueprint_scene_applied", {
+      room_count: result.rooms.length,
+      confidence: result.confidence,
+    });
+  }
+
+  async function copyScene() {
+    if (!result || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(result.sceneJs);
+    setCopied("scene");
+    toast(labels.copied, "success");
+  }
+
+  async function copyHandoff() {
+    if (!result || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(formatBlueprintHandoff(result));
+    setCopied("handoff");
+    toast(labels.handoffCopied, "success");
+  }
+
+  return (
+    <section
+      aria-labelledby={`${inputId}-title`}
+      style={{
+        marginTop: 12,
+        padding: 12,
+        border: "1px solid rgba(45, 95, 109, 0.28)",
+        borderRadius: "var(--radius-md)",
+        background: "linear-gradient(135deg, rgba(45,95,109,0.1), rgba(229,160,75,0.07))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "flex-start" }}>
+        <div>
+          <div className="label-mono" style={{ color: "var(--accent)", marginBottom: 4 }}>
+            {labels.eyebrow}
+          </div>
+          <h4 id={`${inputId}-title`} style={{ margin: 0, fontSize: 13, color: "var(--text-primary)" }}>
+            {labels.title}
+          </h4>
+          <p style={{ margin: "5px 0 0", color: "var(--text-muted)", fontSize: 11, lineHeight: 1.45 }}>
+            {labels.subtitle}
+          </p>
+        </div>
+        <span className="badge badge-muted">PDF/JPG/PNG</span>
+      </div>
+
+      <label
+        htmlFor={`${inputId}-file`}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          marginTop: 10,
+          minHeight: 58,
+          border: "1px dashed var(--border-strong)",
+          borderRadius: "var(--radius-sm)",
+          background: "var(--bg-secondary)",
+          color: "var(--text-secondary)",
+          fontSize: 12,
+          cursor: "pointer",
+          textAlign: "center",
+          padding: "8px 10px",
+        }}
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M4 4h16v16H4z" />
+          <path d="M8 12h8" />
+          <path d="M12 8v8" />
+        </svg>
+        {file ? `${labels.selected}: ${file.name}` : labels.dropHint}
+      </label>
+      <input
+        id={`${inputId}-file`}
+        aria-label={labels.fileInput}
+        type="file"
+        accept={accepted}
+        style={{ display: "none" }}
+        onChange={(event) => {
+          const selected = event.target.files?.[0] ?? null;
+          if (selected && (selected.type.startsWith("image/") || selected.type === "application/pdf")) {
+            setFile(selected);
+            setResult(null);
+            setCopied(null);
+          }
+        }}
+      />
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 10 }}>
+        <label style={{ display: "grid", gap: 4, fontSize: 11, color: "var(--text-secondary)" }}>
+          {labels.floor}
+          <input
+            className="input"
+            value={floorLabel}
+            onChange={(event) => setFloorLabel(event.target.value)}
+            style={{ fontSize: 12 }}
+          />
+        </label>
+        <div />
+        <label style={{ display: "grid", gap: 4, fontSize: 11, color: "var(--text-secondary)" }}>
+          {labels.width}
+          <input
+            className="input"
+            inputMode="decimal"
+            value={width}
+            onChange={(event) => setWidth(event.target.value)}
+            placeholder={buildingInfo?.area_m2 ? "" : "9.2"}
+            style={{ fontSize: 12 }}
+          />
+        </label>
+        <label style={{ display: "grid", gap: 4, fontSize: 11, color: "var(--text-secondary)" }}>
+          {labels.depth}
+          <input
+            className="input"
+            inputMode="decimal"
+            value={depth}
+            onChange={(event) => setDepth(event.target.value)}
+            placeholder={buildingInfo?.area_m2 ? "" : "7.4"}
+            style={{ fontSize: 12 }}
+          />
+        </label>
+      </div>
+
+      <label style={{ display: "grid", gap: 4, marginTop: 8, fontSize: 11, color: "var(--text-secondary)" }}>
+        {labels.notes}
+        <textarea
+          className="input"
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder={labels.notesPlaceholder}
+          rows={3}
+          style={{ fontSize: 12, resize: "vertical" }}
+        />
+      </label>
+
+      <button
+        type="button"
+        className="btn btn-primary"
+        onClick={generateDraft}
+        style={{ width: "100%", marginTop: 10, fontSize: 12, opacity: file ? 1 : 0.65 }}
+      >
+        {result ? labels.regenerate : labels.generate}
+      </button>
+
+      {result && openingSummary && (
+        <div style={{ marginTop: 12, display: "grid", gap: 10 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 6 }}>
+            <div style={{ padding: 8, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", background: "var(--bg-elevated)" }}>
+              <div className="label-mono" style={{ color: "var(--text-muted)", marginBottom: 3 }}>{labels.confidence}</div>
+              <strong style={{ color: "var(--text-primary)", fontSize: 13 }}>{Math.round(result.confidence * 100)}%</strong>
+            </div>
+            <div style={{ padding: 8, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", background: "var(--bg-elevated)" }}>
+              <div className="label-mono" style={{ color: "var(--text-muted)", marginBottom: 3 }}>{labels.rooms}</div>
+              <strong style={{ color: "var(--text-primary)", fontSize: 13 }}>{result.rooms.length}</strong>
+            </div>
+            <div style={{ padding: 8, border: "1px solid var(--border)", borderRadius: "var(--radius-sm)", background: "var(--bg-elevated)" }}>
+              <div className="label-mono" style={{ color: "var(--text-muted)", marginBottom: 3 }}>{labels.openings}</div>
+              <strong style={{ color: "var(--text-primary)", fontSize: 13 }}>
+                {openingSummary.doors}/{openingSummary.windows}
+              </strong>
+            </div>
+          </div>
+
+          <div style={{ padding: 10, borderRadius: "var(--radius-sm)", background: "var(--bg-secondary)", border: "1px solid var(--border)" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: 11, color: "var(--text-muted)" }}>
+              <span>{labels.footprint}</span>
+              <strong style={{ color: "var(--text-primary)" }}>
+                {formatMeters(result.widthMeters, locale)} m x {formatMeters(result.depthMeters, locale)} m
+              </strong>
+            </div>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginTop: 5, fontSize: 11, color: "var(--text-muted)" }}>
+              <span>{labels.scale}</span>
+              <strong style={{ color: "var(--text-primary)" }}>{scaleLabel(result, labels)}</strong>
+            </div>
+          </div>
+
+          <div style={{ display: "grid", gap: 5 }}>
+            {result.rooms.slice(0, 6).map((room) => (
+              <div key={room.id} style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: 11, color: "var(--text-secondary)" }}>
+                <span>{room.name}</span>
+                <span>{formatMeters(room.areaM2, locale)} m2</span>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ padding: 9, borderRadius: "var(--radius-sm)", background: "rgba(229,160,75,0.1)", color: "var(--text-muted)", fontSize: 10, lineHeight: 1.45 }}>
+            <strong style={{ color: "var(--text-primary)" }}>{labels.verify}</strong>
+            <ul style={{ margin: "6px 0 0", paddingLeft: 16 }}>
+              {result.assumptions.slice(0, 3).map((assumption) => (
+                <li key={assumption}>{assumption}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: onApplyScene ? "1fr 1fr" : "1fr", gap: 8 }}>
+            {onApplyScene && (
+              <button type="button" className="btn btn-primary" onClick={applyDraft} style={{ fontSize: 12 }}>
+                {labels.apply}
+              </button>
+            )}
+            <button type="button" className="btn btn-secondary" onClick={() => { void copyScene(); }} style={{ fontSize: 12 }}>
+              {copied === "scene" ? labels.copied : labels.copy}
+            </button>
+          </div>
+          <button type="button" className="btn btn-secondary" onClick={() => { void copyHandoff(); }} style={{ fontSize: 12 }}>
+            {copied === "handoff" ? labels.handoffCopied : labels.copyHandoff}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -21,6 +21,7 @@ import KrautaProPartnerPanel from "@/components/KrautaProPartnerPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import IfcPreviewPanel from "@/components/IfcPreviewPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
+import BlueprintToScenePanel from "@/components/BlueprintToScenePanel";
 import PhotoEstimatePanel from "@/components/PhotoEstimatePanel";
 import PermitCheckerPanel from "@/components/PermitCheckerPanel";
 import ShoppingListModal from "@/components/ShoppingListModal";
@@ -1892,6 +1893,7 @@ export default function BomPanel({
   projectId,
   householdDeductionJoint = false,
   onHouseholdDeductionJointChange,
+  onApplyScene,
 }: {
   bom: BomItem[];
   materials: Material[];
@@ -1919,6 +1921,8 @@ export default function BomPanel({
   householdDeductionJoint?: boolean;
   /** Persist household deduction claimant mode on the project */
   onHouseholdDeductionJointChange?: (joint: boolean) => void;
+  /** Apply generated scene code from blueprint/floor-plan tooling */
+  onApplyScene?: (sceneJs: string) => void;
 }) {
   const glow = useCursorGlow();
   const [compareMaterial, setCompareMaterial] = useState<{ id: string; name: string } | null>(null);
@@ -2515,6 +2519,13 @@ export default function BomPanel({
             projectName={projectName}
             buildingInfo={buildingInfo}
             onImportBom={onImportBom}
+          />
+        )}
+        {onApplyScene && (
+          <BlueprintToScenePanel
+            projectName={projectName}
+            buildingInfo={buildingInfo}
+            onApplyScene={onApplyScene}
           />
         )}
         <PermitCheckerPanel buildingInfo={buildingInfo} />

--- a/web/src/hooks/useAnalytics.ts
+++ b/web/src/hooks/useAnalytics.ts
@@ -28,6 +28,8 @@ export type AnalyticsEvent =
   | "bom_aggregated"
   | "photo_estimate_generated"
   | "photo_estimate_imported"
+  | "blueprint_scene_generated"
+  | "blueprint_scene_applied"
   | "project_photo_overlay_uploaded"
   | "bom_package_material_replaced"
   | "bom_optimization_applied"
@@ -73,6 +75,8 @@ export interface AnalyticsEventProps {
   bom_aggregated: { project_count: number; item_count: number };
   photo_estimate_generated: { project_id: string; photo_count: number; scope_count: number; estimate_mid: number };
   photo_estimate_imported: { project_id: string; item_count: number; estimate_mid: number };
+  blueprint_scene_generated: { file_type: string; room_count: number; confidence: number };
+  blueprint_scene_applied: { room_count: number; confidence: number };
   project_photo_overlay_uploaded: { file_type: string };
   bom_package_material_replaced: { from_material_id: string; to_material_id: string; category?: string; source?: string };
   bom_optimization_applied: { type: string; material_id: string; savings_amount: number };

--- a/web/src/lib/__tests__/blueprint-to-scene.test.ts
+++ b/web/src/lib/__tests__/blueprint-to-scene.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { recognizeBlueprintFromMetadata, formatBlueprintHandoff } from "@/lib/blueprint-to-scene";
+import { interpretScene } from "@/lib/scene-interpreter";
+
+describe("blueprint-to-scene", () => {
+  it("generates editable Scene JS from owner dimensions and room notes", () => {
+    const result = recognizeBlueprintFromMetadata({
+      fileName: "omakotitalo-sauna-khh-floorplan.jpg",
+      mimeType: "image/jpeg",
+      projectName: "Espoo house",
+      widthMeters: 11,
+      depthMeters: 8.5,
+      notes: "sauna, KHH, kitchen opens to living room",
+    });
+
+    expect(result.scaleSource).toBe("user_dimensions");
+    expect(result.widthMeters).toBe(11);
+    expect(result.depthMeters).toBe(8.5);
+    expect(result.rooms.some((room) => room.type === "sauna")).toBe(true);
+    expect(result.rooms.some((room) => room.type === "utility")).toBe(true);
+    expect(result.openings.filter((opening) => opening.type === "window").length).toBeGreaterThanOrEqual(2);
+    expect(result.sceneJs).toContain("blueprint_wall_north");
+    expect(result.sceneJs).toContain("scene.add");
+
+    const interpreted = interpretScene(result.sceneJs);
+    expect(interpreted.error).toBeNull();
+    expect(interpreted.objects.length).toBeGreaterThan(10);
+  });
+
+  it("infers scale from building area when the owner does not provide dimensions", () => {
+    const result = recognizeBlueprintFromMetadata({
+      fileName: "main-floor.pdf",
+      mimeType: "application/pdf",
+      buildingInfo: { area_m2: 160, floors: 2 },
+    });
+
+    expect(result.scaleSource).toBe("building_area");
+    expect(result.areaM2).toBeGreaterThan(70);
+    expect(result.assumptions.join(" ")).toContain("PDF files are accepted");
+    expect(result.confidence).toBeGreaterThan(0.45);
+  });
+
+  it("formats a contractor/founder handoff summary", () => {
+    const result = recognizeBlueprintFromMetadata({
+      fileName: "draft-plan.png",
+      mimeType: "image/png",
+      widthMeters: 9,
+      depthMeters: 7,
+    });
+
+    const handoff = formatBlueprintHandoff(result);
+
+    expect(handoff).toContain("Helscoop blueprint-to-3D draft");
+    expect(handoff).toContain("Footprint: 9 m x 7 m");
+    expect(handoff).toContain("Rooms");
+  });
+});

--- a/web/src/lib/blueprint-to-scene.ts
+++ b/web/src/lib/blueprint-to-scene.ts
@@ -1,0 +1,532 @@
+import type { BuildingInfo } from "@/types";
+
+export type BlueprintRoomType =
+  | "entry"
+  | "living"
+  | "kitchen"
+  | "bedroom"
+  | "bath"
+  | "sauna"
+  | "utility";
+
+export type BlueprintScaleSource = "user_dimensions" | "user_width_area" | "user_depth_area" | "building_area" | "fallback";
+
+export interface BlueprintRecognitionInput {
+  fileName: string;
+  mimeType?: string;
+  projectName?: string;
+  floorLabel?: string;
+  notes?: string;
+  widthMeters?: number | null;
+  depthMeters?: number | null;
+  buildingInfo?: BuildingInfo | null;
+}
+
+export interface BlueprintRoom {
+  id: string;
+  name: string;
+  type: BlueprintRoomType;
+  x: number;
+  z: number;
+  width: number;
+  depth: number;
+  areaM2: number;
+}
+
+export interface BlueprintOpening {
+  id: string;
+  type: "door" | "window";
+  wall: "north" | "south" | "east" | "west" | "partition";
+  x: number;
+  z: number;
+  width: number;
+  connects: string[];
+}
+
+export interface BlueprintRecognitionResult {
+  sourceFileName: string;
+  sourceMimeType: string;
+  projectName?: string;
+  floorLabel: string;
+  widthMeters: number;
+  depthMeters: number;
+  areaM2: number;
+  scaleSource: BlueprintScaleSource;
+  confidence: number;
+  confidenceLabel: "low" | "medium" | "draft";
+  rooms: BlueprintRoom[];
+  openings: BlueprintOpening[];
+  partitionWallCount: number;
+  assumptions: string[];
+  sceneJs: string;
+}
+
+interface Bounds {
+  left: number;
+  right: number;
+  back: number;
+  front: number;
+}
+
+interface PartitionWall {
+  id: string;
+  orientation: "vertical" | "horizontal";
+  x: number;
+  z: number;
+  length: number;
+}
+
+interface LayoutResult {
+  rooms: BlueprintRoom[];
+  openings: BlueprintOpening[];
+  partitions: PartitionWall[];
+}
+
+const DEFAULT_WIDTH = 9.2;
+const DEFAULT_DEPTH = 7.4;
+const DEFAULT_AREA = DEFAULT_WIDTH * DEFAULT_DEPTH;
+
+const ROOM_COLORS: Record<BlueprintRoomType, [number, number, number]> = {
+  entry: [0.73, 0.68, 0.55],
+  living: [0.7, 0.76, 0.64],
+  kitchen: [0.77, 0.67, 0.52],
+  bedroom: [0.58, 0.66, 0.76],
+  bath: [0.52, 0.68, 0.78],
+  sauna: [0.69, 0.56, 0.44],
+  utility: [0.56, 0.6, 0.63],
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function safeDimension(value: number | null | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  if (value < 1.5 || value > 80) return null;
+  return value;
+}
+
+function safeFileName(name: string): string {
+  const trimmed = name.trim();
+  return trimmed.length > 0 ? trimmed : "floor-plan";
+}
+
+function normalizeText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[_-]+/g, " ");
+}
+
+function includesAny(text: string, keywords: string[]): boolean {
+  return keywords.some((keyword) => text.includes(keyword));
+}
+
+function identifier(value: string): string {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return cleaned.length > 0 ? cleaned : "blueprint_object";
+}
+
+function jsNum(value: number): string {
+  return Number(value.toFixed(2)).toString();
+}
+
+function jsColor(color: [number, number, number]): string {
+  return `[${color.map((part) => Number(part.toFixed(2))).join(", ")}]`;
+}
+
+function floorAreaFromBuildingInfo(buildingInfo?: BuildingInfo | null): number | null {
+  const rawArea = buildingInfo?.area_m2;
+  if (typeof rawArea !== "number" || !Number.isFinite(rawArea) || rawArea < 20 || rawArea > 600) {
+    return null;
+  }
+  const floors = typeof buildingInfo?.floors === "number" && Number.isFinite(buildingInfo.floors)
+    ? clamp(Math.round(buildingInfo.floors), 1, 4)
+    : 1;
+  return rawArea / floors;
+}
+
+function inferDimensions(input: BlueprintRecognitionInput): {
+  width: number;
+  depth: number;
+  area: number;
+  scaleSource: BlueprintScaleSource;
+} {
+  const userWidth = safeDimension(input.widthMeters);
+  const userDepth = safeDimension(input.depthMeters);
+  const buildingArea = floorAreaFromBuildingInfo(input.buildingInfo);
+
+  if (userWidth && userDepth) {
+    return {
+      width: round2(userWidth),
+      depth: round2(userDepth),
+      area: round2(userWidth * userDepth),
+      scaleSource: "user_dimensions",
+    };
+  }
+
+  if (userWidth && buildingArea) {
+    const depth = clamp(buildingArea / userWidth, 2.4, 40);
+    return {
+      width: round2(userWidth),
+      depth: round2(depth),
+      area: round2(userWidth * depth),
+      scaleSource: "user_width_area",
+    };
+  }
+
+  if (userDepth && buildingArea) {
+    const width = clamp(buildingArea / userDepth, 2.4, 40);
+    return {
+      width: round2(width),
+      depth: round2(userDepth),
+      area: round2(width * userDepth),
+      scaleSource: "user_depth_area",
+    };
+  }
+
+  if (buildingArea) {
+    const width = clamp(Math.sqrt(buildingArea * 1.28), 4.5, 28);
+    const depth = clamp(buildingArea / width, 4, 24);
+    return {
+      width: round2(width),
+      depth: round2(depth),
+      area: round2(width * depth),
+      scaleSource: "building_area",
+    };
+  }
+
+  return {
+    width: DEFAULT_WIDTH,
+    depth: DEFAULT_DEPTH,
+    area: round2(DEFAULT_AREA),
+    scaleSource: "fallback",
+  };
+}
+
+function detectRoomTypes(input: BlueprintRecognitionInput, area: number): Set<BlueprintRoomType> {
+  const text = normalizeText(`${input.fileName} ${input.projectName ?? ""} ${input.floorLabel ?? ""} ${input.notes ?? ""}`);
+  const types = new Set<BlueprintRoomType>(["entry", "living", "kitchen", "bedroom", "bath"]);
+
+  if (includesAny(text, ["sauna", "loyly", "pesuhuone"])) types.add("sauna");
+  if (includesAny(text, ["utility", "laundry", "kodinhoito", "khh", "technical", "tekninen"])) types.add("utility");
+  if (includesAny(text, ["wc", "bath", "kph", "shower", "pesu"])) types.add("bath");
+  if (includesAny(text, ["kitchen", "keittio", "kt"])) types.add("kitchen");
+  if (includesAny(text, ["living", "olohuone", "oh", "lounge"])) types.add("living");
+  if (area >= 95 || includesAny(text, ["mh2", "2mh", "bedroom 2", "two bedroom", "kids", "lasten"])) {
+    types.add("bedroom");
+  }
+
+  return types;
+}
+
+function roomFromBounds(id: string, name: string, type: BlueprintRoomType, bounds: Bounds): BlueprintRoom {
+  const width = round2(bounds.right - bounds.left);
+  const depth = round2(bounds.front - bounds.back);
+  return {
+    id,
+    name,
+    type,
+    x: round2(bounds.left + width / 2),
+    z: round2(bounds.back + depth / 2),
+    width,
+    depth,
+    areaM2: round2(width * depth),
+  };
+}
+
+function buildLayout(width: number, depth: number, roomTypes: Set<BlueprintRoomType>): LayoutResult {
+  const left = -width / 2;
+  const right = width / 2;
+  const back = -depth / 2;
+  const front = depth / 2;
+
+  const leftBlockWidth = clamp(width * (width * depth >= 95 ? 0.42 : 0.36), 3.1, width * 0.48);
+  const splitX = round2(left + leftBlockWidth);
+  const serviceDepth = clamp(depth * 0.34, 2.35, 3.8);
+  const serviceBack = round2(front - serviceDepth);
+  const entryWidth = clamp(leftBlockWidth * 0.36, 1.25, 2.35);
+  const kitchenBack = round2(front - clamp(depth * 0.32, 2.2, 3.4));
+  const hasSecondBedroom = width * depth >= 95;
+  const hasSauna = roomTypes.has("sauna");
+  const hasUtility = roomTypes.has("utility");
+
+  const rooms: BlueprintRoom[] = [];
+  const openings: BlueprintOpening[] = [];
+  const partitions: PartitionWall[] = [
+    { id: "private_open_partition", orientation: "vertical", x: splitX, z: 0, length: depth - 0.24 },
+    { id: "service_sleeping_partition", orientation: "horizontal", x: left + leftBlockWidth / 2, z: serviceBack, length: leftBlockWidth - 0.12 },
+  ];
+
+  if (hasSecondBedroom) {
+    const bedroomSplitZ = round2(back + (serviceBack - back) / 2);
+    rooms.push(roomFromBounds("primary_bedroom", "Primary bedroom", "bedroom", {
+      left,
+      right: splitX,
+      back,
+      front: bedroomSplitZ,
+    }));
+    rooms.push(roomFromBounds("second_bedroom", "Second bedroom", "bedroom", {
+      left,
+      right: splitX,
+      back: bedroomSplitZ,
+      front: serviceBack,
+    }));
+    partitions.push({
+      id: "bedroom_divider",
+      orientation: "horizontal",
+      x: left + leftBlockWidth / 2,
+      z: bedroomSplitZ,
+      length: leftBlockWidth - 0.12,
+    });
+  } else {
+    rooms.push(roomFromBounds("bedroom", "Bedroom", "bedroom", {
+      left,
+      right: splitX,
+      back,
+      front: serviceBack,
+    }));
+  }
+
+  const entryRight = round2(left + entryWidth);
+  rooms.push(roomFromBounds("entry", "Entry", "entry", {
+    left,
+    right: entryRight,
+    back: serviceBack,
+    front,
+  }));
+
+  const wetLeft = entryRight;
+  const wetWidth = splitX - wetLeft;
+  if (hasSauna && hasUtility) {
+    const bathRight = round2(wetLeft + wetWidth * 0.36);
+    const saunaRight = round2(wetLeft + wetWidth * 0.68);
+    rooms.push(roomFromBounds("bath", "Bath", "bath", { left: wetLeft, right: bathRight, back: serviceBack, front }));
+    rooms.push(roomFromBounds("sauna", "Sauna", "sauna", { left: bathRight, right: saunaRight, back: serviceBack, front }));
+    rooms.push(roomFromBounds("utility", "Utility", "utility", { left: saunaRight, right: splitX, back: serviceBack, front }));
+    partitions.push({ id: "bath_sauna_partition", orientation: "vertical", x: bathRight, z: serviceBack + serviceDepth / 2, length: serviceDepth - 0.12 });
+    partitions.push({ id: "sauna_utility_partition", orientation: "vertical", x: saunaRight, z: serviceBack + serviceDepth / 2, length: serviceDepth - 0.12 });
+  } else if (hasSauna) {
+    const bathRight = round2(wetLeft + wetWidth * 0.52);
+    rooms.push(roomFromBounds("bath", "Bath", "bath", { left: wetLeft, right: bathRight, back: serviceBack, front }));
+    rooms.push(roomFromBounds("sauna", "Sauna", "sauna", { left: bathRight, right: splitX, back: serviceBack, front }));
+    partitions.push({ id: "bath_sauna_partition", orientation: "vertical", x: bathRight, z: serviceBack + serviceDepth / 2, length: serviceDepth - 0.12 });
+  } else if (hasUtility) {
+    const bathRight = round2(wetLeft + wetWidth * 0.58);
+    rooms.push(roomFromBounds("bath", "Bath", "bath", { left: wetLeft, right: bathRight, back: serviceBack, front }));
+    rooms.push(roomFromBounds("utility", "Utility", "utility", { left: bathRight, right: splitX, back: serviceBack, front }));
+    partitions.push({ id: "bath_utility_partition", orientation: "vertical", x: bathRight, z: serviceBack + serviceDepth / 2, length: serviceDepth - 0.12 });
+  } else {
+    rooms.push(roomFromBounds("bath", "Bath", "bath", { left: wetLeft, right: splitX, back: serviceBack, front }));
+  }
+
+  if (roomTypes.has("kitchen")) {
+    rooms.push(roomFromBounds("living", "Living", "living", { left: splitX, right, back, front: kitchenBack }));
+    rooms.push(roomFromBounds("kitchen", "Kitchen", "kitchen", { left: splitX, right, back: kitchenBack, front }));
+    partitions.push({
+      id: "kitchen_living_soft_divider",
+      orientation: "horizontal",
+      x: splitX + (right - splitX) / 2,
+      z: kitchenBack,
+      length: right - splitX - 0.2,
+    });
+  } else {
+    rooms.push(roomFromBounds("living", "Living", "living", { left: splitX, right, back, front }));
+  }
+
+  openings.push(
+    { id: "front_entry_door", type: "door", wall: "south", x: left + entryWidth / 2, z: front, width: 1.0, connects: ["entry", "outside"] },
+    { id: "entry_living_door", type: "door", wall: "partition", x: splitX, z: serviceBack + serviceDepth * 0.55, width: 0.95, connects: ["entry", "living"] },
+    { id: "bedroom_door", type: "door", wall: "partition", x: splitX, z: serviceBack - 0.7, width: 0.9, connects: ["bedroom", "living"] },
+    { id: "bath_door", type: "door", wall: "partition", x: wetLeft + wetWidth * 0.45, z: serviceBack, width: 0.8, connects: ["bath", "entry"] },
+    { id: "living_window", type: "window", wall: "east", x: right, z: back + (kitchenBack - back) * 0.5, width: clamp(depth * 0.24, 1.2, 2.8), connects: ["living", "outside"] },
+    { id: "kitchen_window", type: "window", wall: "south", x: splitX + (right - splitX) * 0.66, z: front, width: clamp(width * 0.16, 1.0, 2.4), connects: ["kitchen", "outside"] },
+    { id: "bedroom_window", type: "window", wall: "north", x: left + leftBlockWidth * 0.48, z: back, width: clamp(leftBlockWidth * 0.45, 1.0, 2.2), connects: ["bedroom", "outside"] },
+  );
+
+  return { rooms, openings, partitions };
+}
+
+function buildAssumptions(input: BlueprintRecognitionInput, scaleSource: BlueprintScaleSource, roomTypes: Set<BlueprintRoomType>): string[] {
+  const assumptions = [
+    "Generated as an editable draft for planning, not as a permit drawing.",
+    "Wall, door, and window positions are heuristic until a human verifies the uploaded plan.",
+  ];
+
+  if (scaleSource === "user_dimensions") {
+    assumptions.push("Scale uses the owner-provided width and depth.");
+  } else if (scaleSource === "building_area") {
+    assumptions.push("Scale is inferred from building_info.area_m2 and floor count.");
+  } else if (scaleSource === "user_width_area" || scaleSource === "user_depth_area") {
+    assumptions.push("One missing dimension is inferred from building_info.area_m2.");
+  } else {
+    assumptions.push("No reliable scale was provided, so a typical omakotitalo floor footprint is used.");
+  }
+
+  if (input.mimeType?.includes("pdf")) {
+    assumptions.push("PDF files are accepted for the owner workflow; this draft uses metadata and scale hints until OCR/CV extraction is connected.");
+  }
+
+  if (roomTypes.has("sauna")) {
+    assumptions.push("Sauna/wet-room split was inferred from file name or owner notes.");
+  }
+
+  return assumptions;
+}
+
+function buildConfidence(scaleSource: BlueprintScaleSource, input: BlueprintRecognitionInput, roomTypes: Set<BlueprintRoomType>): number {
+  const searchableText = normalizeText(`${input.fileName} ${input.notes ?? ""}`);
+  let confidence = 0.38;
+  if (scaleSource === "user_dimensions") confidence += 0.22;
+  if (scaleSource === "user_width_area" || scaleSource === "user_depth_area") confidence += 0.14;
+  if (scaleSource === "building_area") confidence += 0.1;
+  if (safeFileName(input.fileName).includes(".")) confidence += 0.04;
+  if (input.mimeType?.startsWith("image/") || input.mimeType?.includes("pdf")) confidence += 0.04;
+  if (roomTypes.has("sauna") || roomTypes.has("utility")) confidence += 0.04;
+  if (includesAny(searchableText, ["kitchen", "keittio", "sauna", "bath", "kph", "mh", "bedroom"])) confidence += 0.06;
+  return round2(clamp(confidence, 0.3, 0.78));
+}
+
+function confidenceLabel(confidence: number): BlueprintRecognitionResult["confidenceLabel"] {
+  if (confidence >= 0.68) return "medium";
+  if (confidence >= 0.48) return "draft";
+  return "low";
+}
+
+function addBox(
+  lines: string[],
+  id: string,
+  width: number,
+  height: number,
+  depth: number,
+  x: number,
+  y: number,
+  z: number,
+  material: string,
+  color: [number, number, number],
+): void {
+  const safeId = identifier(id);
+  lines.push(`const ${safeId} = translate(box(${jsNum(width)}, ${jsNum(height)}, ${jsNum(depth)}), ${jsNum(x)}, ${jsNum(y)}, ${jsNum(z)});`);
+  lines.push(`scene.add(${safeId}, { material: "${material}", color: ${jsColor(color)} });`);
+}
+
+function buildSceneJs(result: Omit<BlueprintRecognitionResult, "sceneJs">, partitions: PartitionWall[]): string {
+  const wallThickness = 0.16;
+  const wallHeight = 2.7;
+  const floorThickness = 0.12;
+  const yWall = floorThickness + wallHeight / 2;
+  const width = result.widthMeters;
+  const depth = result.depthMeters;
+  const lines: string[] = [
+    "// Helscoop blueprint-to-3D draft.",
+    `// Source: ${safeFileName(result.sourceFileName)} (${result.sourceMimeType || "unknown mime"})`,
+    `// Floor: ${result.floorLabel}; confidence: ${Math.round(result.confidence * 100)}% (${result.confidenceLabel}).`,
+    "// Verify scale, wall alignment, and openings before quote requests or permits.",
+    `const blueprint_width_m = ${jsNum(width)};`,
+    `const blueprint_depth_m = ${jsNum(depth)};`,
+    `const wall_h = ${jsNum(wallHeight)};`,
+    `const wall_t = ${jsNum(wallThickness)};`,
+    "",
+  ];
+
+  addBox(lines, "blueprint_floor_slab", width, floorThickness, depth, 0, floorThickness / 2, 0, "foundation", [0.54, 0.55, 0.5]);
+  addBox(lines, "blueprint_wall_north", width, wallHeight, wallThickness, 0, yWall, -depth / 2 + wallThickness / 2, "pine_48x98_c24", [0.78, 0.68, 0.52]);
+  addBox(lines, "blueprint_wall_south", width, wallHeight, wallThickness, 0, yWall, depth / 2 - wallThickness / 2, "pine_48x98_c24", [0.78, 0.68, 0.52]);
+  addBox(lines, "blueprint_wall_west", wallThickness, wallHeight, depth, -width / 2 + wallThickness / 2, yWall, 0, "pine_48x98_c24", [0.78, 0.68, 0.52]);
+  addBox(lines, "blueprint_wall_east", wallThickness, wallHeight, depth, width / 2 - wallThickness / 2, yWall, 0, "pine_48x98_c24", [0.78, 0.68, 0.52]);
+  lines.push("");
+
+  for (const partition of partitions) {
+    if (partition.orientation === "vertical") {
+      addBox(lines, partition.id, wallThickness, wallHeight, partition.length, partition.x, yWall, partition.z, "pine_48x98_c24", [0.72, 0.62, 0.47]);
+    } else {
+      addBox(lines, partition.id, partition.length, wallHeight, wallThickness, partition.x, yWall, partition.z, "pine_48x98_c24", [0.72, 0.62, 0.47]);
+    }
+  }
+  lines.push("");
+
+  for (const room of result.rooms) {
+    const color = ROOM_COLORS[room.type];
+    addBox(lines, `${room.id}_room_zone`, room.width - 0.18, 0.045, room.depth - 0.18, room.x, floorThickness + 0.035, room.z, "blueprint_room_zone", color);
+  }
+  lines.push("");
+
+  for (const opening of result.openings) {
+    const isWindow = opening.type === "window";
+    const color: [number, number, number] = isWindow ? [0.42, 0.64, 0.85] : [0.42, 0.33, 0.24];
+    const material = isWindow ? "glass" : "door_thermal_bridge";
+    const height = isWindow ? 0.9 : 0.08;
+    const y = isWindow ? 1.45 : floorThickness + 0.12;
+    const alongX = opening.wall === "north" || opening.wall === "south" || opening.wall === "partition";
+    const markerWidth = alongX ? opening.width : 0.12;
+    const markerDepth = alongX ? 0.12 : opening.width;
+    addBox(lines, opening.id, markerWidth, height, markerDepth, opening.x, y, opening.z, material, color);
+  }
+
+  lines.push("");
+  lines.push("// Next edits: move/delete room zones and wall boxes directly, then save the project.");
+  return `${lines.join("\n")}\n`;
+}
+
+export function recognizeBlueprintFromMetadata(input: BlueprintRecognitionInput): BlueprintRecognitionResult {
+  const dimensions = inferDimensions(input);
+  const roomTypes = detectRoomTypes(input, dimensions.area);
+  const layout = buildLayout(dimensions.width, dimensions.depth, roomTypes);
+  const assumptions = buildAssumptions(input, dimensions.scaleSource, roomTypes);
+  const confidence = buildConfidence(dimensions.scaleSource, input, roomTypes);
+  const baseResult: Omit<BlueprintRecognitionResult, "sceneJs"> = {
+    sourceFileName: safeFileName(input.fileName),
+    sourceMimeType: input.mimeType || "application/octet-stream",
+    projectName: input.projectName,
+    floorLabel: input.floorLabel?.trim() || "Main floor",
+    widthMeters: dimensions.width,
+    depthMeters: dimensions.depth,
+    areaM2: dimensions.area,
+    scaleSource: dimensions.scaleSource,
+    confidence,
+    confidenceLabel: confidenceLabel(confidence),
+    rooms: layout.rooms,
+    openings: layout.openings,
+    partitionWallCount: layout.partitions.length,
+    assumptions,
+  };
+
+  return {
+    ...baseResult,
+    sceneJs: buildSceneJs(baseResult, layout.partitions),
+  };
+}
+
+export function formatBlueprintHandoff(result: BlueprintRecognitionResult): string {
+  const roomLines = result.rooms
+    .map((room) => `- ${room.name}: ${room.width} m x ${room.depth} m (${room.areaM2} m2)`)
+    .join("\n");
+  const assumptionLines = result.assumptions.map((assumption) => `- ${assumption}`).join("\n");
+
+  return [
+    "Helscoop blueprint-to-3D draft",
+    `Project: ${result.projectName || "Untitled project"}`,
+    `Source: ${result.sourceFileName}`,
+    `Floor: ${result.floorLabel}`,
+    `Footprint: ${result.widthMeters} m x ${result.depthMeters} m (${result.areaM2} m2)`,
+    `Confidence: ${Math.round(result.confidence * 100)}% (${result.confidenceLabel})`,
+    "",
+    "Rooms",
+    roomLines,
+    "",
+    "Openings",
+    `- ${result.openings.filter((opening) => opening.type === "door").length} doors`,
+    `- ${result.openings.filter((opening) => opening.type === "window").length} windows`,
+    "",
+    "Assumptions",
+    assumptionLines,
+  ].join("\n");
+}


### PR DESCRIPTION
Fixes #120.

Summary:
- Adds a blueprint-to-3D draft generator that accepts floor plan images/PDFs plus owner scale hints and produces editable Scene JS with rooms, walls, openings, assumptions, and confidence.
- Adds a BOM-side Blueprint-to-3D panel with apply/copy/handoff actions and localized owner-facing copy that is explicit about verification.
- Wires generated scenes into the project editor undo/save/code path and tracks generated/applied blueprint events.

Validation:
- npm test -- --run src/lib/__tests__/blueprint-to-scene.test.ts src/__tests__/blueprint-to-scene-panel.test.tsx
- npx tsc --noEmit (web)
- npm test -- --run (web; existing unrelated act warnings)
- npm run build (web; existing experimental.viewTransition warning only)