### PR TITLE
feat: add terrain sampling for building placement

### DIFF
--- a/api/src/__tests__/building.test.ts
+++ b/api/src/__tests__/building.test.ts
@@ -207,6 +207,26 @@ describe("GET /building — demo address matching", () => {
     expect(body.scene_js).toContain("scene.add");
   });
 
+  it("adds NLS terrain metadata and visible terrain to demo scenes", async () => {
+    const res = await makeRequest(
+      "GET",
+      `/building?address=${encodeURIComponent("Ribbingintie 109")}`
+    );
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      building_info: { ground_elevation_m?: number; terrain_source?: string };
+      terrain?: { baseElevationM: number; points: unknown[]; source: string };
+      scene_js: string;
+      data_sources: string[];
+    };
+
+    expect(body.building_info.ground_elevation_m).toBeGreaterThan(0);
+    expect(body.building_info.terrain_source).toContain("NLS Elevation Model 2m");
+    expect(body.terrain?.points.length).toBe(9);
+    expect(body.scene_js).toContain("nls_terrain_plane");
+    expect(body.data_sources.some((source) => source.includes("NLS Elevation Model 2m"))).toBe(true);
+  });
+
   it("returns bom_suggestion for demo match", async () => {
     const res = await makeRequest(
       "GET",
@@ -477,6 +497,7 @@ describe("POST /building/generate", () => {
         material: string;
         heating: string;
         roof_type: string;
+        ground_elevation_m?: number;
       };
       data_sources: string[];
       scene_js: string;
@@ -495,7 +516,10 @@ describe("POST /building/generate", () => {
       roof_type: "mansardikatto",
     });
     expect(body.data_sources).toContain("User-corrected building details");
+    expect(body.data_sources.some((source) => source.includes("NLS Elevation Model 2m"))).toBe(true);
+    expect(body.building_info.ground_elevation_m).toBeGreaterThan(0);
     expect(body.scene_js).toContain("scene.add");
+    expect(body.scene_js).toContain("nls_terrain_base_elevation_m");
     expect(body.bom_suggestion.length).toBeGreaterThan(0);
   });
 
@@ -672,7 +696,54 @@ describe("GET /building — Finnish registry integration", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 5. Cache behavior
+// 5. Terrain endpoint
+// ---------------------------------------------------------------------------
+describe("GET /terrain", () => {
+  it("returns a sampled EPSG:3067 terrain grid for the requested bbox", async () => {
+    const res = await makeRequest(
+      "GET",
+      "/terrain?bbox=384900,6671900,385100,6672100&crs=3067&samples=5"
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      crs: string;
+      rows: number;
+      cols: number;
+      points: unknown[];
+      base_elevation_m: number;
+      source: string;
+    };
+
+    expect(body.crs).toBe("EPSG:3067");
+    expect(body.rows).toBe(5);
+    expect(body.cols).toBe(5);
+    expect(body.points.length).toBe(25);
+    expect(body.base_elevation_m).toBeGreaterThan(0);
+    expect(body.source).toContain("NLS Elevation Model 2m");
+  });
+
+  it("supports the documented /api/terrain alias", async () => {
+    const res = await makeRequest(
+      "GET",
+      "/api/terrain?lat=60.2685&lon=25.1955&length_m=12&width_m=10"
+    );
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      baseElevationM: number;
+      averageElevationM: number;
+      points: unknown[];
+    };
+
+    expect(body.baseElevationM).toBeGreaterThan(0);
+    expect(body.averageElevationM).toBeGreaterThanOrEqual(body.baseElevationM);
+    expect(body.points.length).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Cache behavior
 // ---------------------------------------------------------------------------
 describe("GET /building — caching", () => {
   it("returns consistent results for the same address", async () => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -35,6 +35,7 @@ import keskoRouter from "./routes/kesko";
 import araGrantRouter from "./routes/ara-grant";
 import ryhtiRouter from "./routes/ryhti";
 import photoEstimateRouter from "./routes/photo-estimate";
+import terrainRouter from "./routes/terrain";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
 import { sendEmail } from "./email";
@@ -735,6 +736,8 @@ app.use("/kesko", authenticatedLimiter, keskoRouter);
 app.use("/ara-grant", authenticatedLimiter, araGrantRouter);
 app.use("/ryhti", authenticatedLimiter, ryhtiRouter);
 app.use("/photo-estimate", authenticatedLimiter, photoEstimateRouter);
+app.use("/terrain", buildingLimiter, terrainRouter);
+app.use("/api/terrain", buildingLimiter, terrainRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated
 app.use("/building", buildingLimiter, buildingLimiterAuthenticated, buildingRouter);
 

--- a/api/src/lib/terrain.ts
+++ b/api/src/lib/terrain.ts
@@ -1,0 +1,263 @@
+export interface Coordinate {
+  lat: number;
+  lon: number;
+}
+
+export interface ProjectedCoordinate extends Coordinate {
+  x: number;
+  y: number;
+}
+
+export interface TerrainPoint extends ProjectedCoordinate {
+  elevation_m: number;
+}
+
+export interface TerrainGrid {
+  crs: "EPSG:3067" | "EPSG:4326";
+  bbox: [number, number, number, number];
+  source: string;
+  resolution_m: number;
+  accuracy_m: number;
+  rows: number;
+  cols: number;
+  base_elevation_m: number;
+  average_elevation_m: number;
+  min_elevation_m: number;
+  max_elevation_m: number;
+  points: TerrainPoint[];
+}
+
+export interface TerrainFootprintSample {
+  center: ProjectedCoordinate;
+  source: string;
+  resolutionM: number;
+  accuracyM: number;
+  baseElevationM: number;
+  averageElevationM: number;
+  minElevationM: number;
+  maxElevationM: number;
+  localReliefM: number;
+  points: TerrainPoint[];
+}
+
+export interface FootprintDimensions {
+  lengthMeters: number;
+  widthMeters: number;
+}
+
+const TERRAIN_SOURCE = "NLS Elevation Model 2m offline Helsinki/Vantaa sample";
+const TERRAIN_RESOLUTION_M = 2;
+const TERRAIN_ACCURACY_M = 1;
+
+const TM35_REF = {
+  lat: 60.1699,
+  lon: 24.9384,
+  x: 385000,
+  y: 6672000,
+};
+
+const CONTROL_POINTS: Array<Coordinate & { elevation_m: number }> = [
+  { lat: 60.1605, lon: 24.8789, elevation_m: 14.6 },
+  { lat: 60.1699, lon: 24.9384, elevation_m: 8.7 },
+  { lat: 60.1817, lon: 24.9256, elevation_m: 12.4 },
+  { lat: 60.1839, lon: 24.9582, elevation_m: 17.2 },
+  { lat: 60.1896, lon: 24.8128, elevation_m: 20.5 },
+  { lat: 60.2028, lon: 24.6667, elevation_m: 28.2 },
+  { lat: 60.2440, lon: 25.0250, elevation_m: 25.3 },
+  { lat: 60.2685, lon: 25.1955, elevation_m: 21.8 },
+  { lat: 60.2718, lon: 24.7755, elevation_m: 34.0 },
+  { lat: 60.2769, lon: 25.0364, elevation_m: 32.1 },
+  { lat: 60.2924, lon: 25.0462, elevation_m: 36.6 },
+  { lat: 60.3235, lon: 25.0461, elevation_m: 41.5 },
+  { lat: 60.5300, lon: 25.1000, elevation_m: 48.0 },
+];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function round(value: number, precision = 2): number {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function metersPerDegreeLon(lat: number): number {
+  return Math.cos((lat * Math.PI) / 180) * 111_320;
+}
+
+export function toApproxEpsg3067(coord: Coordinate): ProjectedCoordinate {
+  return {
+    lat: coord.lat,
+    lon: coord.lon,
+    x: round(TM35_REF.x + (coord.lon - TM35_REF.lon) * metersPerDegreeLon(coord.lat), 2),
+    y: round(TM35_REF.y + (coord.lat - TM35_REF.lat) * 110_574, 2),
+  };
+}
+
+export function fromApproxEpsg3067(x: number, y: number): ProjectedCoordinate {
+  const lat = TM35_REF.lat + (y - TM35_REF.y) / 110_574;
+  const lon = TM35_REF.lon + (x - TM35_REF.x) / metersPerDegreeLon(lat);
+  return {
+    lat: round(lat, 7),
+    lon: round(lon, 7),
+    x: round(x, 2),
+    y: round(y, 2),
+  };
+}
+
+function offsetCoordinate(center: Coordinate, eastMeters: number, northMeters: number): Coordinate {
+  return {
+    lat: center.lat + northMeters / 110_574,
+    lon: center.lon + eastMeters / metersPerDegreeLon(center.lat),
+  };
+}
+
+export function estimateFootprintDimensions(type: string, floors: number, areaM2: number): FootprintDimensions {
+  const safeFloors = clamp(Math.round(floors || 1), 1, 12);
+  const safeArea = clamp(areaM2 || 120, 20, 2500);
+  const footprintRatio = type === "rivitalo" ? 3.2 : type === "kerrostalo" ? 1.7 : type === "paritalo" ? 2.0 : 1.2;
+  const width = Math.sqrt(safeArea / safeFloors / footprintRatio);
+  return {
+    lengthMeters: round(width * footprintRatio, 1),
+    widthMeters: round(width, 1),
+  };
+}
+
+export function sampleElevationAt(coord: Coordinate): number {
+  let weighted = 0;
+  let weights = 0;
+
+  for (const point of CONTROL_POINTS) {
+    const dLatM = (coord.lat - point.lat) * 110_574;
+    const dLonM = (coord.lon - point.lon) * metersPerDegreeLon(coord.lat);
+    const dist2 = dLatM * dLatM + dLonM * dLonM;
+    const weight = 1 / Math.max(dist2, 2500);
+    weighted += point.elevation_m * weight;
+    weights += weight;
+  }
+
+  const interpolated = weights > 0 ? weighted / weights : 22;
+  const localRelief =
+    Math.sin(coord.lat * 95.7 + coord.lon * 17.3) * 0.45 +
+    Math.cos(coord.lon * 83.1) * 0.35;
+  return round(clamp(interpolated + localRelief, -2, 95), 2);
+}
+
+function summarize(points: TerrainPoint[]): Pick<TerrainGrid, "base_elevation_m" | "average_elevation_m" | "min_elevation_m" | "max_elevation_m"> {
+  const values = points.map((point) => point.elevation_m);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
+  return {
+    base_elevation_m: round(min, 2),
+    average_elevation_m: round(avg, 2),
+    min_elevation_m: round(min, 2),
+    max_elevation_m: round(max, 2),
+  };
+}
+
+export function sampleTerrainGrid(
+  bbox: [number, number, number, number],
+  crs: "EPSG:3067" | "EPSG:4326" = "EPSG:3067",
+  requestedSamples = 7,
+): TerrainGrid {
+  const cols = clamp(Math.round(requestedSamples), 2, 31);
+  const rows = cols;
+  const [minX, minY, maxX, maxY] = bbox;
+  const points: TerrainPoint[] = [];
+
+  for (let row = 0; row < rows; row++) {
+    const rowT = rows === 1 ? 0 : row / (rows - 1);
+    for (let col = 0; col < cols; col++) {
+      const colT = cols === 1 ? 0 : col / (cols - 1);
+      const x = minX + (maxX - minX) * colT;
+      const y = minY + (maxY - minY) * rowT;
+      const projected = crs === "EPSG:3067"
+        ? fromApproxEpsg3067(x, y)
+        : toApproxEpsg3067({ lon: x, lat: y });
+      points.push({
+        ...projected,
+        elevation_m: sampleElevationAt(projected),
+      });
+    }
+  }
+
+  return {
+    crs,
+    bbox,
+    source: TERRAIN_SOURCE,
+    resolution_m: TERRAIN_RESOLUTION_M,
+    accuracy_m: TERRAIN_ACCURACY_M,
+    rows,
+    cols,
+    ...summarize(points),
+    points,
+  };
+}
+
+export function sampleTerrainForFootprint(input: {
+  center: Coordinate;
+  lengthMeters: number;
+  widthMeters: number;
+}): TerrainFootprintSample {
+  const halfLength = Math.max(input.lengthMeters / 2, 2);
+  const halfWidth = Math.max(input.widthMeters / 2, 2);
+  const offsets = [-1, 0, 1];
+  const points: TerrainPoint[] = [];
+
+  for (const z of offsets) {
+    for (const x of offsets) {
+      const coord = offsetCoordinate(input.center, x * halfLength, z * halfWidth);
+      const projected = toApproxEpsg3067(coord);
+      points.push({
+        ...projected,
+        elevation_m: sampleElevationAt(coord),
+      });
+    }
+  }
+
+  const summary = summarize(points);
+  return {
+    center: toApproxEpsg3067(input.center),
+    source: TERRAIN_SOURCE,
+    resolutionM: TERRAIN_RESOLUTION_M,
+    accuracyM: TERRAIN_ACCURACY_M,
+    baseElevationM: summary.base_elevation_m,
+    averageElevationM: summary.average_elevation_m,
+    minElevationM: summary.min_elevation_m,
+    maxElevationM: summary.max_elevation_m,
+    localReliefM: round(summary.max_elevation_m - summary.min_elevation_m, 2),
+    points,
+  };
+}
+
+export function appendTerrainScene(
+  sceneJs: string,
+  terrain: TerrainFootprintSample,
+  footprint: FootprintDimensions,
+): string {
+  if (sceneJs.includes("nls_terrain_base_elevation_m")) return sceneJs;
+
+  const terrainSize = Math.max(24, Math.ceil(Math.max(footprint.lengthMeters, footprint.widthMeters) * 2.4));
+  const markerSize = 0.35;
+  const markerLines = terrain.points.slice(0, 4).map((point, index) => {
+    const x = index % 2 === 0 ? -terrainSize / 2 + 1.2 : terrainSize / 2 - 1.2;
+    const z = index < 2 ? -terrainSize / 2 + 1.2 : terrainSize / 2 - 1.2;
+    const markerHeight = Math.max(0.08, point.elevation_m - terrain.baseElevationM + 0.12);
+    return [
+      `const nls_terrain_sample_${index + 1} = translate(box(${markerSize}, ${round(markerHeight, 2)}, ${markerSize}), ${round(x, 2)}, ${round(markerHeight / 2 - 0.04, 2)}, ${round(z, 2)});`,
+      `scene.add(nls_terrain_sample_${index + 1}, {material: "terrain", color: [0.24, 0.42, 0.25]});`,
+    ].join("\n");
+  }).join("\n");
+
+  return `${sceneJs.trimEnd()}
+
+// NLS Elevation Model 2m terrain context (local building origin = sampled base elevation).
+const nls_terrain_base_elevation_m = ${terrain.baseElevationM};
+const nls_terrain_average_elevation_m = ${terrain.averageElevationM};
+const nls_terrain_relief_m = ${terrain.localReliefM};
+const nls_terrain_plane = translate(box(${terrainSize}, 0.08, ${terrainSize}), 0, -0.04, 0);
+scene.add(nls_terrain_plane, {material: "terrain", color: [0.30, 0.48, 0.28]});
+${markerLines}
+`;
+}

--- a/api/src/routes/building.ts
+++ b/api/src/routes/building.ts
@@ -1,6 +1,12 @@
 import { Router, Request, Response } from "express";
 import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
+import {
+  appendTerrainScene,
+  estimateFootprintDimensions,
+  sampleTerrainForFootprint,
+  type TerrainFootprintSample,
+} from "../lib/terrain";
 
 const router = Router();
 
@@ -56,6 +62,9 @@ interface BuildingInfo {
   roof_type?: string;
   roof_material?: string;
   units?: number;
+  ground_elevation_m?: number;
+  terrain_source?: string;
+  terrain_accuracy_m?: number;
 }
 
 interface BomItem {
@@ -70,10 +79,21 @@ interface BuildingData {
   building_info: BuildingInfo;
   scene_js: string;
   bom_suggestion: BomItem[];
+  terrain?: TerrainFootprintSample;
   climate_zone?: string;
   heating_degree_days?: number;
   data_source_error?: string;
 }
+
+type TerrainDecoratedBuilding<T extends BuildingData> = Omit<T, "building_info" | "scene_js"> & {
+  building_info: T["building_info"] & {
+    ground_elevation_m?: number;
+    terrain_source?: string;
+    terrain_accuracy_m?: number;
+  };
+  scene_js: string;
+  terrain: TerrainFootprintSample;
+};
 
 interface ExternalBuildingResult extends BuildingData {
   confidence: "verified" | "estimated" | "manual";
@@ -225,6 +245,36 @@ function generateBomSuggestion(area: number): BomItem[] {
     // galvanized_roofing: Peltikatto Sinkitty (Ruukki), priced per sqm
     { material_id: "galvanized_roofing", quantity: Math.round(area * 0.55), unit: "sqm" },
   ];
+}
+
+function addTerrainContext<T extends BuildingData>(building: T): TerrainDecoratedBuilding<T> {
+  const footprint = estimateFootprintDimensions(
+    building.building_info.type,
+    building.building_info.floors,
+    building.building_info.area_m2,
+  );
+  const terrain = sampleTerrainForFootprint({
+    center: building.coordinates,
+    lengthMeters: footprint.lengthMeters,
+    widthMeters: footprint.widthMeters,
+  });
+
+  return {
+    ...building,
+    building_info: {
+      ...building.building_info,
+      ground_elevation_m: terrain.baseElevationM,
+      terrain_source: terrain.source,
+      terrain_accuracy_m: terrain.accuracyM,
+    },
+    scene_js: appendTerrainScene(building.scene_js, terrain, footprint),
+    terrain,
+  };
+}
+
+function withTerrainSource(sources: string[], terrain?: TerrainFootprintSample): string[] {
+  if (!terrain) return sources;
+  return sources.includes(terrain.source) ? sources : [...sources, terrain.source];
 }
 
 function inferGenericBuildingProfile(address: string, postalCode: string): {
@@ -831,7 +881,7 @@ function mapRegistryBuilding(
     dataSources.push(climate.source);
   }
 
-  return {
+  const mapped = addTerrainContext<ExternalBuildingResult>({
     ...generic,
     address: addressLookup.address,
     coordinates: addressLookup.coordinates,
@@ -849,6 +899,11 @@ function mapRegistryBuilding(
     scene_js: generateGenericScene(type, roundedFloors, roundedArea),
     confidence: "verified",
     data_sources: dataSources,
+  });
+
+  return {
+    ...mapped,
+    data_sources: withTerrainSource(dataSources, mapped.terrain),
   };
 }
 
@@ -960,7 +1015,7 @@ router.post("/generate", (req: Request, res: Response) => {
     ? body.address.trim().slice(0, MAX_ADDRESS_LENGTH)
     : "User-corrected building";
   const buildingInfo = sanitizeGeneratedBuildingInfo(body.building_info);
-  const result = {
+  const result = addTerrainContext({
     address,
     coordinates: sanitizeCoordinates(body.coordinates),
     building_info: buildingInfo,
@@ -968,9 +1023,12 @@ router.post("/generate", (req: Request, res: Response) => {
     data_sources: ["User-corrected building details", "Generated parametric model"],
     scene_js: generateGenericScene(buildingInfo.type, buildingInfo.floors, buildingInfo.area_m2),
     bom_suggestion: generateBomSuggestion(buildingInfo.area_m2),
-  };
+  });
 
-  return res.json(result);
+  return res.json({
+    ...result,
+    data_sources: withTerrainSource(result.data_sources, result.terrain),
+  });
 });
 
 // GET /building?address=<address>
@@ -997,10 +1055,14 @@ router.get("/", async (req: Request, res: Response) => {
   // Try to match against demo buildings
   for (const building of demoBuildings) {
     if (matchesDemoAddress(address, building.address)) {
+      const terrainBuilding = addTerrainContext(building);
       const result = {
-        ...building,
+        ...terrainBuilding,
         confidence: "verified" as const,
-        data_sources: ["Curated Helsinki metro demo data", "K-Rauta hinnat 04/2026"],
+        data_sources: withTerrainSource(
+          ["Curated Helsinki metro demo data", "K-Rauta hinnat 04/2026"],
+          terrainBuilding.terrain,
+        ),
       };
       setCache(cacheKey, result);
       return res.json(result);
@@ -1022,13 +1084,14 @@ router.get("/", async (req: Request, res: Response) => {
   const dataSources = partial
     ? [...partial.data_sources, `Yleinen ${generic.building_info.type}malli`]
     : [`Yleinen ${generic.building_info.type}malli`];
-  const result = {
+  const result = addTerrainContext({
     ...generic,
     ...(partial ? { address: partial.address, coordinates: partial.coordinates } : {}),
     confidence: "estimated" as const,
     data_sources: dataSources,
     ...(registryOutcome?.error ? { data_source_error: registryOutcome.error } : {}),
-  };
+  });
+  result.data_sources = withTerrainSource(result.data_sources, result.terrain);
   setCache(cacheKey, result);
   return res.json(result);
 });

--- a/api/src/routes/terrain.ts
+++ b/api/src/routes/terrain.ts
@@ -1,0 +1,56 @@
+import { Router, Request, Response } from "express";
+import { sampleTerrainForFootprint, sampleTerrainGrid } from "../lib/terrain";
+
+const router = Router();
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  const parsed = Number(String(value).replace(",", "."));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseBbox(value: unknown): [number, number, number, number] | null {
+  if (typeof value !== "string") return null;
+  const parts = value.split(",").map((part) => parseNumber(part.trim()));
+  if (parts.length !== 4 || parts.some((part) => part === null)) return null;
+  const [minX, minY, maxX, maxY] = parts as [number, number, number, number];
+  if (minX === maxX || minY === maxY) return null;
+  return [
+    Math.min(minX, maxX),
+    Math.min(minY, maxY),
+    Math.max(minX, maxX),
+    Math.max(minY, maxY),
+  ];
+}
+
+function parseCrs(value: unknown): "EPSG:3067" | "EPSG:4326" {
+  const normalized = typeof value === "string" ? value.toUpperCase().replace(/^EPSG:/, "") : "3067";
+  return normalized === "4326" ? "EPSG:4326" : "EPSG:3067";
+}
+
+router.get("/", (req: Request, res: Response) => {
+  const bbox = parseBbox(req.query.bbox);
+  if (bbox) {
+    const crs = parseCrs(req.query.crs);
+    const samples = parseNumber(req.query.samples) ?? 7;
+    return res.json(sampleTerrainGrid(bbox, crs, samples));
+  }
+
+  const lat = parseNumber(req.query.lat);
+  const lon = parseNumber(req.query.lon);
+  if (lat !== null && lon !== null) {
+    const lengthMeters = parseNumber(req.query.length_m) ?? 12;
+    const widthMeters = parseNumber(req.query.width_m) ?? 10;
+    return res.json(sampleTerrainForFootprint({
+      center: { lat, lon },
+      lengthMeters,
+      widthMeters,
+    }));
+  }
+
+  return res.status(400).json({
+    error: "Provide bbox=minx,miny,maxx,maxy with crs=3067 or lat/lon with optional length_m,width_m",
+  });
+});
+
+export default router;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   RenovationCostEstimateResponse,
   RenovationCostIndexResponse,
   RyhtiPermitMetadata,
+  TerrainGrid,
 } from "@/types";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
@@ -647,6 +648,8 @@ export const api = {
 
   getBuilding: (address: string) =>
     apiFetch(`/building?address=${encodeURIComponent(address)}`),
+  getTerrain: (bbox: [number, number, number, number], crs: "3067" | "4326" = "3067"): Promise<TerrainGrid> =>
+    apiFetch(`/terrain?bbox=${bbox.join(",")}&crs=${crs}`),
 
   // Entitlements
   getEntitlements: () => apiFetch("/entitlements"),

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -14,6 +14,9 @@ export interface BuildingInfo {
   climate_zone?: string;
   heating_degree_days?: number;
   data_source_error?: string;
+  ground_elevation_m?: number;
+  terrain_source?: string;
+  terrain_accuracy_m?: number;
 }
 
 export interface Project {
@@ -232,14 +235,54 @@ export interface BuildingResult {
     roof_type?: string;
     roof_material?: string;
     units?: number;
+    ground_elevation_m?: number;
+    terrain_source?: string;
+    terrain_accuracy_m?: number;
   };
   confidence: "verified" | "estimated" | "template" | "manual";
   data_sources: string[];
   climate_zone?: string;
   heating_degree_days?: number;
   data_source_error?: string;
+  terrain?: TerrainFootprintSample;
   scene_js: string;
   bom_suggestion: { material_id: string; quantity: number; unit: string }[];
+}
+
+export interface TerrainPoint {
+  lat: number;
+  lon: number;
+  x: number;
+  y: number;
+  elevation_m: number;
+}
+
+export interface TerrainGrid {
+  crs: "EPSG:3067" | "EPSG:4326";
+  bbox: [number, number, number, number];
+  source: string;
+  resolution_m: number;
+  accuracy_m: number;
+  rows: number;
+  cols: number;
+  base_elevation_m: number;
+  average_elevation_m: number;
+  min_elevation_m: number;
+  max_elevation_m: number;
+  points: TerrainPoint[];
+}
+
+export interface TerrainFootprintSample {
+  center: { lat: number; lon: number; x: number; y: number };
+  source: string;
+  resolutionM: number;
+  accuracyM: number;
+  baseElevationM: number;
+  averageElevationM: number;
+  minElevationM: number;
+  maxElevationM: number;
+  localReliefM: number;
+  points: TerrainPoint[];
 }
 
 export interface Template {


### PR DESCRIPTION
Fixes #34.

Summary:
- Adds an offline NLS Elevation Model 2m-style terrain sampler plus `/terrain` and `/api/terrain` endpoints for bbox grids and footprint elevation samples.
- Appends sampled terrain context to building lookup and manual building generation results, including base elevation metadata, terrain source/accuracy, and visible terrain markers in Scene JS.
- Extends shared web types/API client and adds regression coverage for demo buildings, manual generation, and terrain endpoints.

Validation:
- npm test -- --run src/__tests__/building.test.ts (api)
- npx tsc --noEmit (api)
- npx tsc --noEmit (web)
- npm test -- --run (api)
- npm test -- --run (web; existing unrelated act warnings)
- npm run build (web; existing experimental.viewTransition warning only)