### PR TITLE
feat: add marketplace checkout baskets

### DIFF
--- a/api/src/__tests__/marketplace.test.ts
+++ b/api/src/__tests__/marketplace.test.ts
@@ -1,0 +1,350 @@
+process.env.NODE_ENV = "test";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+  pool: { query: vi.fn() },
+}));
+
+vi.mock("../auth", () => ({
+  requireAuth: (
+    req: import("express").Request,
+    res: import("express").Response,
+    next: import("express").NextFunction,
+  ) => {
+    const id = req.headers["x-test-user-id"] as string | undefined;
+    if (!id) return res.status(401).json({ error: "Authentication required" });
+    (req as any).user = {
+      id,
+      email: req.headers["x-test-user-email"] || "test@helscoop.fi",
+      role: req.headers["x-test-user-role"] || "user",
+    };
+    next();
+  },
+}));
+
+import express from "express";
+import { query } from "../db";
+import marketplaceRouter from "../routes/marketplace";
+
+const mockQuery = vi.mocked(query);
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/marketplace", marketplaceRouter);
+  return app;
+}
+
+function userHeaders(extra: Record<string, string> = {}) {
+  return {
+    "x-test-user-id": "user-1",
+    "x-test-user-role": "user",
+    ...extra,
+  };
+}
+
+async function request(
+  app: express.Express,
+  method: "GET" | "POST" | "PATCH",
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown } = {},
+) {
+  return new Promise<{ status: number; body: any }>((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const addr = server.address() as import("net").AddressInfo;
+      const url = `http://127.0.0.1:${addr.port}${path}`;
+      fetch(url, {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          ...(opts.headers || {}),
+        },
+        body: opts.body ? JSON.stringify(opts.body) : undefined,
+      })
+        .then(async (res) => {
+          const body = await res.json().catch(() => null);
+          resolve({ status: res.status, body });
+        })
+        .catch(reject)
+        .finally(() => server.close());
+    });
+  });
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rows: [] } as any);
+});
+
+describe("GET /marketplace/project/:projectId/orders", () => {
+  it("returns saved marketplace orders for the project owner", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "proj-1", name: "Sauna" }] } as any)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "order-1",
+            project_id: "proj-1",
+            user_id: "user-1",
+            supplier_id: "k-rauta",
+            supplier_name: "K-Rauta",
+            partner_id: null,
+            partner_name: null,
+            status: "draft",
+            currency: "EUR",
+            subtotal: "120.50",
+            estimated_commission_rate: "0.1500",
+            estimated_commission_amount: "18.08",
+            checkout_url: "https://www.k-rauta.fi/tuote/osb",
+            created_at: "2026-04-24T10:00:00.000Z",
+            updated_at: "2026-04-24T10:00:00.000Z",
+            opened_at: null,
+            ordered_at: null,
+            confirmed_at: null,
+            cancelled_at: null,
+            lines: [
+              {
+                id: "line-1",
+                material_id: "osb_18mm",
+                material_name: "OSB 18mm",
+                quantity: 4,
+                unit: "sheet",
+                unit_price: 30.125,
+                total: 120.5,
+                link: "https://www.k-rauta.fi/tuote/osb",
+                stock_level: "in_stock",
+              },
+            ],
+          },
+        ],
+      } as any);
+
+    const app = buildApp();
+    const res = await request(app, "GET", "/marketplace/project/proj-1/orders", {
+      headers: userHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]).toMatchObject({
+      id: "order-1",
+      supplier_id: "k-rauta",
+      supplier_name: "K-Rauta",
+      subtotal: 120.5,
+      estimated_commission_amount: 18.08,
+    });
+    expect(res.body[0].lines[0].material_id).toBe("osb_18mm");
+  });
+});
+
+describe("POST /marketplace/project/:projectId/checkout", () => {
+  it("creates persisted marketplace orders from supplier carts", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "proj-1", name: "Sauna" }] } as any)
+      .mockResolvedValueOnce({
+        rows: [{ id: "partner-1", name: "K-Rauta", commission_rate: "0.1200" }],
+      } as any)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "order-1",
+            project_id: "proj-1",
+            user_id: "user-1",
+            supplier_id: "k-rauta",
+            supplier_name: "K-Rauta",
+            partner_id: "partner-1",
+            status: "draft",
+            currency: "EUR",
+            subtotal: "240.00",
+            estimated_commission_rate: "0.1200",
+            estimated_commission_amount: "28.80",
+            checkout_url: "https://www.k-rauta.fi/tuote/osb",
+            created_at: "2026-04-24T10:00:00.000Z",
+            updated_at: "2026-04-24T10:00:00.000Z",
+          },
+        ],
+      } as any)
+      .mockResolvedValue({ rows: [] } as any);
+
+    const app = buildApp();
+    const res = await request(app, "POST", "/marketplace/project/proj-1/checkout", {
+      headers: userHeaders(),
+      body: {
+        supplier_carts: [
+          {
+            supplier_id: "k-rauta",
+            supplier_name: "K-Rauta",
+            subtotal: 240,
+            checkout_url: "https://www.k-rauta.fi/tuote/osb",
+            items: [
+              {
+                material_id: "osb_18mm",
+                material_name: "OSB 18mm",
+                quantity: 6,
+                unit: "sheet",
+                unit_price: 40,
+                total: 240,
+                link: "https://www.k-rauta.fi/tuote/osb",
+                stock_level: "in_stock",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.orders).toHaveLength(1);
+    expect(res.body.orders[0]).toMatchObject({
+      supplier_name: "K-Rauta",
+      subtotal: 240,
+      estimated_commission_rate: 0.12,
+      estimated_commission_amount: 28.8,
+    });
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO marketplace_orders"),
+      expect.arrayContaining(["proj-1", "user-1", "k-rauta", "K-Rauta"]),
+    );
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO marketplace_order_lines"),
+      expect.arrayContaining(["osb_18mm", "OSB 18mm"]),
+    );
+  });
+
+  it("rejects an empty supplier cart payload", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: "proj-1", name: "Sauna" }] } as any);
+
+    const app = buildApp();
+    const res = await request(app, "POST", "/marketplace/project/proj-1/checkout", {
+      headers: userHeaders(),
+      body: { supplier_carts: [] },
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("supplier_carts");
+  });
+});
+
+describe("POST /marketplace/orders/:orderId/open", () => {
+  it("records affiliate clicks and returns the checkout URL", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "order-1",
+            project_id: "proj-1",
+            user_id: "user-1",
+            supplier_id: "k-rauta",
+            supplier_name: "K-Rauta",
+            partner_id: "partner-1",
+            partner_name: "K-Rauta",
+            status: "draft",
+            currency: "EUR",
+            subtotal: "240.00",
+            estimated_commission_rate: "0.1500",
+            estimated_commission_amount: "36.00",
+            checkout_url: "https://www.k-rauta.fi/tuote/osb",
+            created_at: "2026-04-24T10:00:00.000Z",
+            updated_at: "2026-04-24T10:00:00.000Z",
+            lines: [
+              {
+                id: "line-1",
+                material_id: "osb_18mm",
+                material_name: "OSB 18mm",
+                quantity: 6,
+                unit: "sheet",
+                unit_price: 40,
+                total: 240,
+                link: "https://www.k-rauta.fi/tuote/osb",
+                stock_level: "in_stock",
+              },
+            ],
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ id: "click-1" }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "order-1",
+            project_id: "proj-1",
+            user_id: "user-1",
+            supplier_id: "k-rauta",
+            supplier_name: "K-Rauta",
+            partner_id: "partner-1",
+            partner_name: "K-Rauta",
+            status: "opened",
+            currency: "EUR",
+            subtotal: "240.00",
+            estimated_commission_rate: "0.1500",
+            estimated_commission_amount: "36.00",
+            checkout_url: "https://www.k-rauta.fi/tuote/osb",
+            created_at: "2026-04-24T10:00:00.000Z",
+            updated_at: "2026-04-24T10:01:00.000Z",
+            opened_at: "2026-04-24T10:01:00.000Z",
+            lines: [],
+          },
+        ],
+      } as any);
+
+    const app = buildApp();
+    const res = await request(app, "POST", "/marketplace/orders/order-1/open", {
+      headers: userHeaders(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.checkout_url).toBe("https://www.k-rauta.fi/tuote/osb");
+    expect(res.body.click_count).toBe(1);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO affiliate_clicks"),
+      expect.arrayContaining(["user-1", "osb_18mm", "k-rauta", "partner-1"]),
+    );
+  });
+});
+
+describe("PATCH /marketplace/orders/:orderId", () => {
+  it("updates the order status for the owner", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "order-1" }] } as any)
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "order-1",
+            project_id: "proj-1",
+            user_id: "user-1",
+            supplier_id: "k-rauta",
+            supplier_name: "K-Rauta",
+            partner_id: null,
+            partner_name: null,
+            status: "ordered",
+            currency: "EUR",
+            subtotal: "240.00",
+            estimated_commission_rate: "0.1500",
+            estimated_commission_amount: "36.00",
+            checkout_url: "https://www.k-rauta.fi/tuote/osb",
+            external_order_ref: null,
+            created_at: "2026-04-24T10:00:00.000Z",
+            updated_at: "2026-04-24T10:03:00.000Z",
+            ordered_at: "2026-04-24T10:03:00.000Z",
+            lines: [],
+          },
+        ],
+      } as any);
+
+    const app = buildApp();
+    const res = await request(app, "PATCH", "/marketplace/orders/order-1", {
+      headers: userHeaders(),
+      body: { status: "ordered" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ordered");
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE marketplace_orders"),
+      expect.arrayContaining(["ordered", null, "order-1", "user-1"]),
+    );
+  });
+});

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -35,6 +35,7 @@ import keskoRouter from "./routes/kesko";
 import araGrantRouter from "./routes/ara-grant";
 import ryhtiRouter from "./routes/ryhti";
 import photoEstimateRouter from "./routes/photo-estimate";
+import marketplaceRouter from "./routes/marketplace";
 import terrainRouter from "./routes/terrain";
 import logger from "./logger";
 import { logAuditEvent } from "./audit";
@@ -72,7 +73,7 @@ app.use(
       ? process.env.CORS_ORIGIN.split(",")
       : ["http://localhost:3000", "http://localhost:3002", "http://localhost:3052"],
     credentials: true,
-    methods: ["GET", "POST", "PUT", "DELETE"],
+    methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
     allowedHeaders: ["Content-Type", "Authorization"],
   })
 );
@@ -736,6 +737,7 @@ app.use("/kesko", authenticatedLimiter, keskoRouter);
 app.use("/ara-grant", authenticatedLimiter, araGrantRouter);
 app.use("/ryhti", authenticatedLimiter, ryhtiRouter);
 app.use("/photo-estimate", authenticatedLimiter, photoEstimateRouter);
+app.use("/marketplace", authenticatedLimiter, marketplaceRouter);
 app.use("/terrain", buildingLimiter, terrainRouter);
 app.use("/api/terrain", buildingLimiter, terrainRouter);
 // Building endpoint: stricter rate limiting with tiered limits for anon vs authenticated

--- a/api/src/routes/marketplace.ts
+++ b/api/src/routes/marketplace.ts
@@ -1,0 +1,420 @@
+import { Router } from "express";
+import { query } from "../db";
+import { requireAuth } from "../auth";
+
+const router = Router();
+
+const DEFAULT_COMMISSION_RATE = 0.15;
+const VALID_ORDER_STATUSES = new Set(["draft", "opened", "ordered", "confirmed", "cancelled"]);
+const VALID_STOCK_LEVELS = new Set(["in_stock", "low_stock", "out_of_stock", "unknown"]);
+
+interface MarketplaceOrderLineInput {
+  material_id?: unknown;
+  material_name?: unknown;
+  quantity?: unknown;
+  unit?: unknown;
+  unit_price?: unknown;
+  total?: unknown;
+  link?: unknown;
+  stock_level?: unknown;
+}
+
+interface MarketplaceSupplierCartInput {
+  supplier_id?: unknown;
+  supplier_name?: unknown;
+  subtotal?: unknown;
+  currency?: unknown;
+  checkout_url?: unknown;
+  items?: unknown;
+}
+
+type OrderRowWithLines = Record<string, unknown> & {
+  lines?: unknown;
+};
+
+function toOptionalString(value: unknown, maxLength = 2048): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+function toRequiredString(value: unknown, field: string, maxLength = 240): string {
+  const text = toOptionalString(value, maxLength);
+  if (!text) throw new Error(`${field} is required`);
+  return text;
+}
+
+function toPositiveNumber(value: unknown, field: string): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error(`${field} must be a positive number`);
+  }
+  return numeric;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function normalizeStockLevel(value: unknown): string {
+  return typeof value === "string" && VALID_STOCK_LEVELS.has(value) ? value : "unknown";
+}
+
+function normalizeCurrency(value: unknown): string {
+  const raw = typeof value === "string" ? value.trim().toUpperCase() : "";
+  return raw || "EUR";
+}
+
+async function ensureOwnedProject(projectId: string, userId: string) {
+  const result = await query(
+    `SELECT id, name
+     FROM projects
+     WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+    [projectId, userId],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function findAffiliatePartnerForSupplier(supplierName: string) {
+  const result = await query(
+    `SELECT id, name, commission_rate
+     FROM affiliate_partners
+     WHERE active = true
+       AND lower(name) = lower($1)
+     LIMIT 1`,
+    [supplierName],
+  );
+  return result.rows[0] ?? null;
+}
+
+function normalizeLines(raw: unknown) {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((line) => {
+    const row = (line ?? {}) as Record<string, unknown>;
+    return {
+      id: typeof row.id === "string" ? row.id : "",
+      material_id: typeof row.material_id === "string" ? row.material_id : "",
+      material_name: typeof row.material_name === "string" ? row.material_name : "",
+      quantity: Number(row.quantity) || 0,
+      unit: typeof row.unit === "string" ? row.unit : "kpl",
+      unit_price: Number(row.unit_price) || 0,
+      total: Number(row.total) || 0,
+      link: typeof row.link === "string" ? row.link : null,
+      stock_level: normalizeStockLevel(row.stock_level),
+    };
+  });
+}
+
+function mapOrderRow(row: OrderRowWithLines) {
+  return {
+    id: row.id,
+    project_id: row.project_id,
+    user_id: row.user_id,
+    supplier_id: row.supplier_id ?? null,
+    supplier_name: row.supplier_name,
+    partner_id: row.partner_id ?? null,
+    partner_name: row.partner_name ?? null,
+    status: row.status,
+    currency: row.currency,
+    subtotal: Number(row.subtotal) || 0,
+    estimated_commission_rate: Number(row.estimated_commission_rate) || DEFAULT_COMMISSION_RATE,
+    estimated_commission_amount: Number(row.estimated_commission_amount) || 0,
+    checkout_url: row.checkout_url ?? null,
+    external_order_ref: row.external_order_ref ?? null,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    opened_at: row.opened_at ?? null,
+    ordered_at: row.ordered_at ?? null,
+    confirmed_at: row.confirmed_at ?? null,
+    cancelled_at: row.cancelled_at ?? null,
+    lines: normalizeLines(row.lines),
+  };
+}
+
+async function loadOrder(orderId: string, userId: string) {
+  const result = await query(
+    `SELECT mo.*,
+            ap.name AS partner_name,
+            COALESCE(
+              json_agg(
+                json_build_object(
+                  'id', mol.id,
+                  'material_id', mol.material_id,
+                  'material_name', mol.material_name,
+                  'quantity', mol.quantity,
+                  'unit', mol.unit,
+                  'unit_price', mol.unit_price,
+                  'total', mol.total,
+                  'link', mol.link,
+                  'stock_level', mol.stock_level
+                )
+                ORDER BY mol.created_at ASC
+              ) FILTER (WHERE mol.id IS NOT NULL),
+              '[]'::json
+            ) AS lines
+     FROM marketplace_orders mo
+     LEFT JOIN affiliate_partners ap ON ap.id = mo.partner_id
+     LEFT JOIN marketplace_order_lines mol ON mol.order_id = mo.id
+     WHERE mo.id = $1 AND mo.user_id = $2
+     GROUP BY mo.id, ap.name`,
+    [orderId, userId],
+  );
+  return result.rows[0] ? mapOrderRow(result.rows[0] as OrderRowWithLines) : null;
+}
+
+router.get("/project/:projectId/orders", requireAuth, async (req, res) => {
+  const project = await ensureOwnedProject(req.params.projectId, req.user!.id);
+  if (!project) {
+    return res.status(404).json({ error: "Project not found" });
+  }
+
+  const result = await query(
+    `SELECT mo.*,
+            ap.name AS partner_name,
+            COALESCE(
+              json_agg(
+                json_build_object(
+                  'id', mol.id,
+                  'material_id', mol.material_id,
+                  'material_name', mol.material_name,
+                  'quantity', mol.quantity,
+                  'unit', mol.unit,
+                  'unit_price', mol.unit_price,
+                  'total', mol.total,
+                  'link', mol.link,
+                  'stock_level', mol.stock_level
+                )
+                ORDER BY mol.created_at ASC
+              ) FILTER (WHERE mol.id IS NOT NULL),
+              '[]'::json
+            ) AS lines
+     FROM marketplace_orders mo
+     LEFT JOIN affiliate_partners ap ON ap.id = mo.partner_id
+     LEFT JOIN marketplace_order_lines mol ON mol.order_id = mo.id
+     WHERE mo.project_id = $1 AND mo.user_id = $2
+     GROUP BY mo.id, ap.name
+     ORDER BY mo.created_at DESC`,
+    [req.params.projectId, req.user!.id],
+  );
+
+  res.json(result.rows.map((row) => mapOrderRow(row as OrderRowWithLines)));
+});
+
+router.post("/project/:projectId/checkout", requireAuth, async (req, res) => {
+  const project = await ensureOwnedProject(req.params.projectId, req.user!.id);
+  if (!project) {
+    return res.status(404).json({ error: "Project not found" });
+  }
+
+  const supplierCarts = Array.isArray(req.body?.supplier_carts) ? req.body.supplier_carts as MarketplaceSupplierCartInput[] : [];
+  if (supplierCarts.length === 0) {
+    return res.status(400).json({ error: "supplier_carts must contain at least one supplier basket" });
+  }
+  if (supplierCarts.length > 12) {
+    return res.status(400).json({ error: "Too many supplier baskets in one checkout" });
+  }
+
+  try {
+    const orders = [];
+
+    for (const cart of supplierCarts) {
+      const supplierName = toRequiredString(cart.supplier_name, "supplier_name", 160);
+      const supplierId = toOptionalString(cart.supplier_id, 120);
+      const currency = normalizeCurrency(cart.currency);
+      const checkoutUrl = toOptionalString(cart.checkout_url, 2048);
+      const rawItems = Array.isArray(cart.items) ? cart.items as MarketplaceOrderLineInput[] : [];
+
+      if (rawItems.length === 0) {
+        throw new Error(`items are required for supplier ${supplierName}`);
+      }
+
+      const items = rawItems.map((item, index) => {
+        const materialId = toRequiredString(item.material_id, `items[${index}].material_id`, 120);
+        const materialName = toRequiredString(
+          item.material_name ?? item.material_id,
+          `items[${index}].material_name`,
+          240,
+        );
+        const quantity = toPositiveNumber(item.quantity, `items[${index}].quantity`);
+        const unit = toRequiredString(item.unit ?? "kpl", `items[${index}].unit`, 32);
+        const unitPrice = Math.max(0, Number(item.unit_price) || 0);
+        const total = roundMoney(Math.max(0, Number(item.total) || unitPrice * quantity));
+        return {
+          materialId,
+          materialName,
+          quantity,
+          unit,
+          unitPrice,
+          total,
+          link: toOptionalString(item.link, 2048),
+          stockLevel: normalizeStockLevel(item.stock_level),
+        };
+      });
+
+      const computedSubtotal = roundMoney(items.reduce((sum, item) => sum + item.total, 0));
+      const subtotal = roundMoney(Math.max(0, Number(cart.subtotal) || computedSubtotal));
+      const partner = await findAffiliatePartnerForSupplier(supplierName);
+      const commissionRate = Number(partner?.commission_rate) || DEFAULT_COMMISSION_RATE;
+      const estimatedCommissionAmount = roundMoney(subtotal * commissionRate);
+
+      const orderInsert = await query(
+        `INSERT INTO marketplace_orders (
+           project_id,
+           user_id,
+           supplier_id,
+           supplier_name,
+           partner_id,
+           currency,
+           subtotal,
+           estimated_commission_rate,
+           estimated_commission_amount,
+           checkout_url,
+           metadata_json
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
+         RETURNING *`,
+        [
+          req.params.projectId,
+          req.user!.id,
+          supplierId,
+          supplierName,
+          partner?.id ?? null,
+          currency,
+          subtotal,
+          commissionRate,
+          estimatedCommissionAmount,
+          checkoutUrl,
+          JSON.stringify({
+            project_name: project.name,
+            source: "bom_marketplace_checkout",
+            item_count: items.length,
+          }),
+        ],
+      );
+      const orderRow = orderInsert.rows[0] as OrderRowWithLines;
+
+      for (const item of items) {
+        await query(
+          `INSERT INTO marketplace_order_lines (
+             order_id,
+             material_id,
+             material_name,
+             quantity,
+             unit,
+             unit_price,
+             total,
+             link,
+             stock_level
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+          [
+            orderRow.id,
+            item.materialId,
+            item.materialName,
+            item.quantity,
+            item.unit,
+            item.unitPrice,
+            item.total,
+            item.link,
+            item.stockLevel,
+          ],
+        );
+      }
+
+      orders.push({
+        ...mapOrderRow({
+          ...orderRow,
+          partner_name: partner?.name ?? null,
+          lines: items.map((item, index) => ({
+            id: `${orderRow.id}-${index}`,
+            material_id: item.materialId,
+            material_name: item.materialName,
+            quantity: item.quantity,
+            unit: item.unit,
+            unit_price: item.unitPrice,
+            total: item.total,
+            link: item.link,
+            stock_level: item.stockLevel,
+          })),
+        }),
+      });
+    }
+
+    res.status(201).json({ orders });
+  } catch (err) {
+    res.status(400).json({ error: err instanceof Error ? err.message : "Invalid marketplace checkout payload" });
+  }
+});
+
+router.post("/orders/:orderId/open", requireAuth, async (req, res) => {
+  const order = await loadOrder(req.params.orderId, req.user!.id);
+  if (!order) {
+    return res.status(404).json({ error: "Marketplace order not found" });
+  }
+
+  let clickCount = 0;
+  if (order.supplier_id) {
+    for (const line of order.lines) {
+      if (!line.link) continue;
+      await query(
+        `INSERT INTO affiliate_clicks (user_id, material_id, supplier_id, partner_id, click_url)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [
+          req.user!.id,
+          line.material_id,
+          order.supplier_id,
+          order.partner_id,
+          line.link,
+        ],
+      );
+      clickCount += 1;
+    }
+  }
+
+  await query(
+    `UPDATE marketplace_orders
+     SET status = CASE WHEN status = 'draft' THEN 'opened' ELSE status END,
+         opened_at = COALESCE(opened_at, now()),
+         updated_at = now()
+     WHERE id = $1 AND user_id = $2`,
+    [req.params.orderId, req.user!.id],
+  );
+
+  const updated = await loadOrder(req.params.orderId, req.user!.id);
+  res.json({
+    checkout_url: updated?.checkout_url ?? null,
+    click_count: clickCount,
+    order: updated,
+  });
+});
+
+router.patch("/orders/:orderId", requireAuth, async (req, res) => {
+  const status = typeof req.body?.status === "string" ? req.body.status : "";
+  if (!VALID_ORDER_STATUSES.has(status)) {
+    return res.status(400).json({ error: "status must be one of: draft, opened, ordered, confirmed, cancelled" });
+  }
+
+  const externalOrderRef = toOptionalString(req.body?.external_order_ref, 160);
+  const result = await query(
+    `UPDATE marketplace_orders
+     SET status = $1,
+         external_order_ref = COALESCE($2, external_order_ref),
+         opened_at = CASE WHEN $1 = 'opened' THEN COALESCE(opened_at, now()) ELSE opened_at END,
+         ordered_at = CASE WHEN $1 = 'ordered' THEN COALESCE(ordered_at, now()) ELSE ordered_at END,
+         confirmed_at = CASE WHEN $1 = 'confirmed' THEN COALESCE(confirmed_at, now()) ELSE confirmed_at END,
+         cancelled_at = CASE WHEN $1 = 'cancelled' THEN COALESCE(cancelled_at, now()) ELSE cancelled_at END,
+         updated_at = now()
+     WHERE id = $3 AND user_id = $4
+     RETURNING id`,
+    [status, externalOrderRef, req.params.orderId, req.user!.id],
+  );
+  if (result.rows.length === 0) {
+    return res.status(404).json({ error: "Marketplace order not found" });
+  }
+
+  const order = await loadOrder(req.params.orderId, req.user!.id);
+  res.json(order);
+});
+
+export default router;

--- a/db/migrations/030_marketplace_orders.sql
+++ b/db/migrations/030_marketplace_orders.sql
@@ -1,0 +1,59 @@
+-- Migration 030: Hosted marketplace checkout orders
+--
+-- Persists BOM-to-retailer checkout baskets so Helscoop can track
+-- order intent, open supplier baskets, and estimate commission revenue.
+
+CREATE TABLE IF NOT EXISTS marketplace_orders (
+  id                           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id                   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  user_id                      UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  supplier_id                  TEXT REFERENCES suppliers(id) ON DELETE SET NULL,
+  supplier_name                TEXT NOT NULL,
+  partner_id                   UUID REFERENCES affiliate_partners(id) ON DELETE SET NULL,
+  status                       TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'opened', 'ordered', 'confirmed', 'cancelled')),
+  currency                     TEXT NOT NULL DEFAULT 'EUR',
+  subtotal                     NUMERIC(12,2) NOT NULL DEFAULT 0,
+  estimated_commission_rate    NUMERIC(5,4) NOT NULL DEFAULT 0.1500,
+  estimated_commission_amount  NUMERIC(12,2) NOT NULL DEFAULT 0,
+  checkout_url                 TEXT,
+  external_order_ref           TEXT,
+  metadata_json                JSONB NOT NULL DEFAULT '{}'::jsonb,
+  opened_at                    TIMESTAMPTZ,
+  ordered_at                   TIMESTAMPTZ,
+  confirmed_at                 TIMESTAMPTZ,
+  cancelled_at                 TIMESTAMPTZ,
+  created_at                   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_orders_project_id
+  ON marketplace_orders (project_id);
+CREATE INDEX IF NOT EXISTS idx_marketplace_orders_user_id
+  ON marketplace_orders (user_id);
+CREATE INDEX IF NOT EXISTS idx_marketplace_orders_supplier_id
+  ON marketplace_orders (supplier_id);
+CREATE INDEX IF NOT EXISTS idx_marketplace_orders_status
+  ON marketplace_orders (status);
+CREATE INDEX IF NOT EXISTS idx_marketplace_orders_created_at
+  ON marketplace_orders (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS marketplace_order_lines (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id      UUID NOT NULL REFERENCES marketplace_orders(id) ON DELETE CASCADE,
+  material_id   TEXT NOT NULL REFERENCES materials(id) ON DELETE CASCADE,
+  material_name TEXT NOT NULL,
+  quantity      NUMERIC(12,3) NOT NULL,
+  unit          TEXT NOT NULL,
+  unit_price    NUMERIC(12,2) NOT NULL DEFAULT 0,
+  total         NUMERIC(12,2) NOT NULL DEFAULT 0,
+  link          TEXT,
+  stock_level   TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (stock_level IN ('in_stock', 'low_stock', 'out_of_stock', 'unknown')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_order_lines_order_id
+  ON marketplace_order_lines (order_id);
+CREATE INDEX IF NOT EXISTS idx_marketplace_order_lines_material_id
+  ON marketplace_order_lines (material_id);

--- a/web/src/__tests__/marketplace-checkout-panel.test.tsx
+++ b/web/src/__tests__/marketplace-checkout-panel.test.tsx
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import MarketplaceCheckoutPanel from "@/components/MarketplaceCheckoutPanel";
+import { api } from "@/lib/api";
+import type { BomItem, MarketplaceOrder, Material } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getMarketplaceOrders: vi.fn().mockResolvedValue([]),
+    createMarketplaceCheckout: vi.fn().mockResolvedValue({ orders: [] }),
+    openMarketplaceOrder: vi.fn().mockResolvedValue({ checkout_url: null, click_count: 0, order: null }),
+    updateMarketplaceOrder: vi.fn(),
+  },
+}));
+
+const materials: Material[] = [
+  {
+    id: "osb_18mm",
+    name: "OSB 18mm",
+    name_fi: "OSB 18mm",
+    name_en: "OSB 18mm",
+    category_name: "Interior",
+    category_name_fi: "Sisä",
+    image_url: null,
+    pricing: [
+      {
+        supplier_id: "k-rauta",
+        supplier_name: "K-Rauta",
+        unit_price: 32,
+        unit: "sheet",
+        link: "https://www.k-rauta.fi/tuote/osb",
+        is_primary: true,
+      },
+    ],
+  },
+  {
+    id: "insulation_100mm",
+    name: "Insulation 100mm",
+    name_fi: "Eristys 100mm",
+    name_en: "Insulation 100mm",
+    category_name: "Insulation",
+    category_name_fi: "Eristys",
+    image_url: null,
+    pricing: [
+      {
+        supplier_id: "stark",
+        supplier_name: "STARK",
+        unit_price: 8,
+        unit: "m2",
+        link: "https://www.stark-suomi.fi/eriste",
+        is_primary: true,
+      },
+    ],
+  },
+];
+
+const bom: BomItem[] = [
+  {
+    material_id: "osb_18mm",
+    material_name: "OSB 18mm",
+    quantity: 6,
+    unit: "sheet",
+    unit_price: 32,
+    total: 192,
+    supplier: "K-Rauta",
+    link: "https://www.k-rauta.fi/tuote/osb",
+  },
+  {
+    material_id: "insulation_100mm",
+    material_name: "Insulation 100mm",
+    quantity: 20,
+    unit: "m2",
+    unit_price: 8,
+    total: 160,
+    supplier: "STARK",
+    link: "https://www.stark-suomi.fi/eriste",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("open", vi.fn());
+});
+
+describe("MarketplaceCheckoutPanel", () => {
+  it("groups BOM lines into retailer baskets and creates marketplace orders", async () => {
+    vi.mocked(api.createMarketplaceCheckout).mockResolvedValueOnce({
+      orders: [
+        {
+          id: "order-1",
+          project_id: "proj-1",
+          user_id: "user-1",
+          supplier_id: "k-rauta",
+          supplier_name: "K-Rauta",
+          partner_id: null,
+          partner_name: null,
+          status: "draft",
+          currency: "EUR",
+          subtotal: 192,
+          estimated_commission_rate: 0.15,
+          estimated_commission_amount: 28.8,
+          checkout_url: "https://www.k-rauta.fi/tuote/osb",
+          external_order_ref: null,
+          created_at: "2026-04-24T10:00:00.000Z",
+          updated_at: "2026-04-24T10:00:00.000Z",
+          lines: [],
+        },
+      ],
+    });
+
+    render(<MarketplaceCheckoutPanel projectId="proj-1" bom={bom} materials={materials} />);
+
+    await waitFor(() => {
+      expect(api.getMarketplaceOrders).toHaveBeenCalledWith("proj-1");
+    });
+
+    expect(screen.getByRole("heading", { name: "Retailer baskets from the BOM" })).toBeInTheDocument();
+    expect(screen.getByText("K-Rauta")).toBeInTheDocument();
+    expect(screen.getByText("STARK")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create checkout baskets" }));
+
+    await waitFor(() => {
+      expect(api.createMarketplaceCheckout).toHaveBeenCalledWith(
+        "proj-1",
+        expect.objectContaining({
+          supplier_carts: expect.arrayContaining([
+            expect.objectContaining({ supplier_name: "K-Rauta" }),
+            expect.objectContaining({ supplier_name: "STARK" }),
+          ]),
+        }),
+      );
+    });
+
+    expect(screen.getAllByText("K-Rauta").length).toBeGreaterThan(0);
+  });
+
+  it("opens a retailer basket and updates order status", async () => {
+    const existingOrder: MarketplaceOrder = {
+      id: "order-2",
+      project_id: "proj-1",
+      user_id: "user-1",
+      supplier_id: "k-rauta",
+      supplier_name: "K-Rauta",
+      partner_id: null,
+      partner_name: null,
+      status: "draft",
+      currency: "EUR",
+      subtotal: 192,
+      estimated_commission_rate: 0.15,
+      estimated_commission_amount: 28.8,
+      checkout_url: "https://www.k-rauta.fi/tuote/osb",
+      external_order_ref: null,
+      created_at: "2026-04-24T10:00:00.000Z",
+      updated_at: "2026-04-24T10:00:00.000Z",
+      lines: [],
+    };
+    vi.mocked(api.getMarketplaceOrders).mockResolvedValueOnce([existingOrder]);
+    vi.mocked(api.openMarketplaceOrder).mockResolvedValueOnce({
+      checkout_url: "https://www.k-rauta.fi/tuote/osb",
+      click_count: 1,
+      order: { ...existingOrder, status: "opened", updated_at: "2026-04-24T10:02:00.000Z" },
+    });
+    vi.mocked(api.updateMarketplaceOrder).mockResolvedValueOnce({
+      ...existingOrder,
+      status: "ordered",
+      updated_at: "2026-04-24T10:03:00.000Z",
+    });
+
+    render(<MarketplaceCheckoutPanel projectId="proj-1" bom={bom} materials={materials} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Saved checkout baskets")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Open retailer" }));
+
+    await waitFor(() => {
+      expect(api.openMarketplaceOrder).toHaveBeenCalledWith("order-2");
+      expect(window.open).toHaveBeenCalledWith("https://www.k-rauta.fi/tuote/osb", "_blank", "noopener,noreferrer");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark ordered" }));
+
+    await waitFor(() => {
+      expect(api.updateMarketplaceOrder).toHaveBeenCalledWith("order-2", { status: "ordered" });
+    });
+    expect(screen.getByText(/Ordered/)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -18,6 +18,7 @@ import EuEnergyGrantPrecheckPanel from "@/components/EuEnergyGrantPrecheckPanel"
 import RenovationRoadmapPanel from "@/components/RenovationRoadmapPanel";
 import PhasedRenovationPlannerPanel from "@/components/PhasedRenovationPlannerPanel";
 import KrautaProPartnerPanel from "@/components/KrautaProPartnerPanel";
+import MarketplaceCheckoutPanel from "@/components/MarketplaceCheckoutPanel";
 import RenovationCostIndexPanel from "@/components/RenovationCostIndexPanel";
 import IfcPreviewPanel from "@/components/IfcPreviewPanel";
 import MaterialTrendDashboard from "@/components/MaterialTrendDashboard";
@@ -2743,6 +2744,13 @@ export default function BomPanel({
             bom={bom}
             materials={materials}
             buildingInfo={buildingInfo}
+          />
+        )}
+        {bom.length > 0 && projectId && (
+          <MarketplaceCheckoutPanel
+            projectId={projectId}
+            bom={bom}
+            materials={materials}
           />
         )}
         {bom.length > 0 && (

--- a/web/src/components/MarketplaceCheckoutPanel.tsx
+++ b/web/src/components/MarketplaceCheckoutPanel.tsx
@@ -1,0 +1,663 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import { api } from "@/lib/api";
+import { buildAffiliateRetailerUrl } from "@/lib/material-affiliate";
+import type {
+  BomItem,
+  MarketplaceOrder,
+  MarketplaceSupplierCheckoutInput,
+  Material,
+  StockLevel,
+} from "@/types";
+
+interface MarketplaceCheckoutPanelProps {
+  projectId: string;
+  bom: BomItem[];
+  materials: Material[];
+}
+
+interface CartLine {
+  material_id: string;
+  material_name: string;
+  quantity: number;
+  unit: string;
+  unit_price: number;
+  total: number;
+  link: string | null;
+  stock_level: StockLevel;
+}
+
+interface CartGroup {
+  key: string;
+  supplier_id: string | null;
+  supplier_name: string;
+  subtotal: number;
+  estimated_commission_amount: number;
+  checkout_url: string | null;
+  lines: CartLine[];
+  shoppable_lines: number;
+}
+
+type PanelLocale = "fi" | "en" | "sv";
+type PanelCopy = {
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  coverage: string;
+  retailers: string;
+  commission: string;
+  missing: string;
+  selectAll: string;
+  clearAll: string;
+  ready: string;
+  partial: string;
+  noLink: string;
+  create: string;
+  creating: string;
+  empty: string;
+  savedOrders: string;
+  noOrders: string;
+  open: string;
+  ordered: string;
+  confirmed: string;
+  cancelled: string;
+  draft: string;
+  opened: string;
+  orderedStatus: string;
+  confirmedStatus: string;
+  cancelledStatus: string;
+  lines: string;
+  supplierFallback: string;
+  openFailed: string;
+  createFailed: string;
+  loadFailed: string;
+  statusFailed: string;
+};
+
+const COPY: Record<PanelLocale, PanelCopy> = {
+  fi: {
+    eyebrow: "Osta materiaalit",
+    title: "Jälleenmyyjäkorit BOMista",
+    subtitle: "Ryhmitä materiaalit kaupoittain, avaa seuratut ostokorit ja pidä tilauksen tila Helscoopissa.",
+    coverage: "Ostokattavuus",
+    retailers: "Jälleenmyyjät",
+    commission: "Arvioitu komissio",
+    missing: "Manuaalisesti hankittavaa",
+    selectAll: "Valitse kaikki",
+    clearAll: "Tyhjennä valinta",
+    ready: "Valmis kori",
+    partial: "Osittainen kori",
+    noLink: "Ei suoraa ostolinkkiä",
+    create: "Luo ostokorit",
+    creating: "Luodaan...",
+    empty: "BOMissa ei ole vielä ostokelpoisia jälleenmyyjärivejä.",
+    savedOrders: "Tallennetut ostokorit",
+    noOrders: "Ei vielä tallennettuja ostokoreja.",
+    open: "Avaa jälleenmyyjä",
+    ordered: "Merkitse tilatuksi",
+    confirmed: "Merkitse vahvistetuksi",
+    cancelled: "Peru kori",
+    draft: "Luonnos",
+    opened: "Avattu",
+    orderedStatus: "Tilattu",
+    confirmedStatus: "Vahvistettu",
+    cancelledStatus: "Peruttu",
+    lines: "riviä",
+    supplierFallback: "Muu toimittaja",
+    openFailed: "Ostokorin avaaminen epäonnistui",
+    createFailed: "Ostokorin luonti epäonnistui",
+    loadFailed: "Tallennettujen ostokorien lataus epäonnistui",
+    statusFailed: "Tilan päivitys epäonnistui",
+  },
+  en: {
+    eyebrow: "Buy materials",
+    title: "Retailer baskets from the BOM",
+    subtitle: "Group BOM lines by store, open tracked checkout baskets, and keep order state inside Helscoop.",
+    coverage: "Checkout coverage",
+    retailers: "Retailers",
+    commission: "Est. commission",
+    missing: "Manual sourcing",
+    selectAll: "Select all",
+    clearAll: "Clear",
+    ready: "Ready basket",
+    partial: "Partial basket",
+    noLink: "No direct retailer link",
+    create: "Create checkout baskets",
+    creating: "Creating...",
+    empty: "No shoppable retailer lines in the BOM yet.",
+    savedOrders: "Saved checkout baskets",
+    noOrders: "No marketplace baskets yet.",
+    open: "Open retailer",
+    ordered: "Mark ordered",
+    confirmed: "Mark confirmed",
+    cancelled: "Cancel basket",
+    draft: "Draft",
+    opened: "Opened",
+    orderedStatus: "Ordered",
+    confirmedStatus: "Confirmed",
+    cancelledStatus: "Cancelled",
+    lines: "lines",
+    supplierFallback: "Other supplier",
+    openFailed: "Failed to open retailer basket",
+    createFailed: "Failed to create retailer baskets",
+    loadFailed: "Failed to load saved baskets",
+    statusFailed: "Failed to update order status",
+  },
+  sv: {
+    eyebrow: "Kop material",
+    title: "Aterforsaljarkorgar fran BOM",
+    subtitle: "Gruppera materialrader per butik, oppna sparade inkopskorgar och folj orderstatus i Helscoop.",
+    coverage: "Koptäckning",
+    retailers: "Aterforsaljare",
+    commission: "Est. provision",
+    missing: "Manuell sourcing",
+    selectAll: "Valj alla",
+    clearAll: "Rensa",
+    ready: "Redo korg",
+    partial: "Delvis korg",
+    noLink: "Ingen direktlank",
+    create: "Skapa inkopskorgar",
+    creating: "Skapar...",
+    empty: "Inga kopbara aterforsaljarrader i BOM annu.",
+    savedOrders: "Sparade inkopskorgar",
+    noOrders: "Inga marknadsplatskorgar annu.",
+    open: "Oppna aterforsaljare",
+    ordered: "Markera bestalld",
+    confirmed: "Markera bekrftad",
+    cancelled: "Avbryt korg",
+    draft: "Utkast",
+    opened: "Oppnad",
+    orderedStatus: "Bestalld",
+    confirmedStatus: "Bekraftad",
+    cancelledStatus: "Avbruten",
+    lines: "rader",
+    supplierFallback: "Annan leverantor",
+    openFailed: "Kunde inte oppna inkopskorgen",
+    createFailed: "Kunde inte skapa inkopskorgar",
+    loadFailed: "Kunde inte ladda sparade korgar",
+    statusFailed: "Kunde inte uppdatera status",
+  },
+};
+
+function panelLocale(locale: string): PanelLocale {
+  if (locale === "fi" || locale === "sv") return locale;
+  return "en";
+}
+
+function formatMoney(value: number, locale: string): string {
+  const tag = locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB";
+  return `${value.toLocaleString(tag, { minimumFractionDigits: 0, maximumFractionDigits: 0 })} EUR`;
+}
+
+function formatDate(value: string | null | undefined, locale: string): string {
+  if (!value) return "";
+  const tag = locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB";
+  return new Date(value).toLocaleDateString(tag);
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function normalizeStockLevel(level?: string | null): StockLevel {
+  if (level === "in_stock" || level === "low_stock" || level === "out_of_stock") return level;
+  return "unknown";
+}
+
+function getOrderStatusLabel(order: MarketplaceOrder, copy: PanelCopy): string {
+  if (order.status === "opened") return copy.opened;
+  if (order.status === "ordered") return copy.orderedStatus;
+  if (order.status === "confirmed") return copy.confirmedStatus;
+  if (order.status === "cancelled") return copy.cancelledStatus;
+  return copy.draft;
+}
+
+function findMatchingPricing(item: BomItem, material: Material | undefined) {
+  const pricing = material?.pricing ?? [];
+  const supplierName = (item.supplier || item.supplier_name || "").toLowerCase();
+  const bySupplier = pricing.find((candidate) => (candidate.supplier_name || "").toLowerCase() === supplierName);
+  const byLink = pricing.find((candidate) => candidate.link && item.link && candidate.link === item.link);
+  return byLink ?? bySupplier ?? pricing.find((candidate) => candidate.is_primary) ?? pricing[0] ?? null;
+}
+
+function getMaterialName(item: BomItem, material: Material | undefined): string {
+  return material?.name_en || material?.name_fi || material?.name || item.material_name || item.material_id;
+}
+
+function buildMarketplaceGroups(bom: BomItem[], materials: Material[], copy: PanelCopy): CartGroup[] {
+  const materialMap = new Map(materials.map((material) => [material.id, material]));
+  const groups = new Map<string, CartGroup>();
+
+  for (const item of bom) {
+    const material = materialMap.get(item.material_id);
+    const matchedPricing = findMatchingPricing(item, material);
+    const supplierId = matchedPricing?.supplier_id ?? item.supplier_id ?? null;
+    const supplierName = matchedPricing?.supplier_name ?? item.supplier ?? item.supplier_name ?? copy.supplierFallback;
+    const lineUrl = buildAffiliateRetailerUrl(item.link ?? matchedPricing?.link, {
+      materialId: item.material_id,
+      supplier: supplierName,
+      source: "marketplace_checkout",
+    });
+    const key = supplierId || supplierName.toLowerCase();
+    const unitPrice = Number(item.unit_price ?? matchedPricing?.unit_price ?? 0);
+    const total = roundMoney(Number(item.total ?? unitPrice * item.quantity));
+    const line: CartLine = {
+      material_id: item.material_id,
+      material_name: getMaterialName(item, material),
+      quantity: Number(item.quantity) || 0,
+      unit: item.unit || matchedPricing?.unit || "kpl",
+      unit_price: unitPrice,
+      total,
+      link: lineUrl,
+      stock_level: normalizeStockLevel(item.stock_level ?? matchedPricing?.stock_level),
+    };
+
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        supplier_id: supplierId,
+        supplier_name: supplierName,
+        subtotal: 0,
+        estimated_commission_amount: 0,
+        checkout_url: lineUrl,
+        lines: [],
+        shoppable_lines: 0,
+      });
+    }
+
+    const group = groups.get(key)!;
+    group.lines.push(line);
+    group.subtotal = roundMoney(group.subtotal + total);
+    if (line.link) {
+      group.shoppable_lines += 1;
+      if (!group.checkout_url) group.checkout_url = line.link;
+    }
+    group.estimated_commission_amount = roundMoney(group.subtotal * 0.15);
+  }
+
+  return Array.from(groups.values()).sort((a, b) => b.subtotal - a.subtotal);
+}
+
+export default function MarketplaceCheckoutPanel({
+  projectId,
+  bom,
+  materials,
+}: MarketplaceCheckoutPanelProps) {
+  const { locale } = useTranslation();
+  const copy = COPY[panelLocale(locale)];
+  const [orders, setOrders] = useState<MarketplaceOrder[]>([]);
+  const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
+  const [loadingOrders, setLoadingOrders] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [busyOrderId, setBusyOrderId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const groups = useMemo(() => buildMarketplaceGroups(bom, materials, copy), [bom, materials, copy]);
+
+  useEffect(() => {
+    const defaultSelection = new Set(
+      groups
+        .filter((group) => group.checkout_url && group.shoppable_lines > 0)
+        .map((group) => group.key),
+    );
+    setSelectedGroups(defaultSelection);
+  }, [groups]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingOrders(true);
+    api.getMarketplaceOrders(projectId)
+      .then((nextOrders) => {
+        if (!cancelled) {
+          setOrders(nextOrders);
+          setError(null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError(copy.loadFailed);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingOrders(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, copy.loadFailed]);
+
+  const totals = useMemo(() => {
+    const manualLines = groups.reduce((sum, group) => sum + (group.lines.length - group.shoppable_lines), 0);
+    return {
+      coverage: `${groups.reduce((sum, group) => sum + group.shoppable_lines, 0)}/${bom.length}`,
+      retailers: groups.length,
+      commission: roundMoney(groups.reduce((sum, group) => sum + group.estimated_commission_amount, 0)),
+      manualLines,
+    };
+  }, [bom.length, groups]);
+
+  const selectedSupplierCarts = useMemo<MarketplaceSupplierCheckoutInput[]>(
+    () => groups
+      .filter((group) => selectedGroups.has(group.key) && group.shoppable_lines > 0)
+      .map((group) => ({
+        supplier_id: group.supplier_id,
+        supplier_name: group.supplier_name,
+        subtotal: group.subtotal,
+        checkout_url: group.checkout_url,
+        currency: "EUR",
+        items: group.lines.map((line) => ({
+          material_id: line.material_id,
+          material_name: line.material_name,
+          quantity: line.quantity,
+          unit: line.unit,
+          unit_price: line.unit_price,
+          total: line.total,
+          link: line.link,
+          stock_level: line.stock_level,
+        })),
+      })),
+    [groups, selectedGroups],
+  );
+
+  const createCheckout = async () => {
+    if (selectedSupplierCarts.length === 0) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const response = await api.createMarketplaceCheckout(projectId, {
+        supplier_carts: selectedSupplierCarts,
+      });
+      setOrders((prev) => [...response.orders, ...prev]);
+    } catch {
+      setError(copy.createFailed);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const openOrder = async (orderId: string) => {
+    setBusyOrderId(orderId);
+    setError(null);
+    try {
+      const response = await api.openMarketplaceOrder(orderId);
+      if (response.order) {
+        setOrders((prev) => prev.map((order) => (order.id === orderId ? response.order! : order)));
+      }
+      if (response.checkout_url) {
+        window.open(response.checkout_url, "_blank", "noopener,noreferrer");
+      }
+    } catch {
+      setError(copy.openFailed);
+    } finally {
+      setBusyOrderId(null);
+    }
+  };
+
+  const updateOrderStatus = async (orderId: string, status: MarketplaceOrder["status"]) => {
+    setBusyOrderId(orderId);
+    setError(null);
+    try {
+      const updated = await api.updateMarketplaceOrder(orderId, { status });
+      setOrders((prev) => prev.map((order) => (order.id === orderId ? updated : order)));
+    } catch {
+      setError(copy.statusFailed);
+    } finally {
+      setBusyOrderId(null);
+    }
+  };
+
+  if (bom.length === 0) return null;
+
+  return (
+    <section
+      data-testid="marketplace-checkout-panel"
+      style={{
+        marginTop: 12,
+        padding: 14,
+        borderRadius: "var(--radius-md)",
+        border: "1px solid rgba(74,124,89,0.22)",
+        background: "linear-gradient(155deg, rgba(74,124,89,0.14), rgba(229,160,75,0.08) 62%, rgba(22,27,31,0.45))",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <div className="label-mono" style={{ color: "var(--forest)", fontSize: 10, marginBottom: 4 }}>
+            {copy.eyebrow}
+          </div>
+          <h4 style={{ margin: 0, fontSize: 15, color: "var(--text-primary)" }}>
+            {copy.title}
+          </h4>
+          <p style={{ margin: "5px 0 0", fontSize: 11, lineHeight: 1.45, color: "var(--text-muted)" }}>
+            {copy.subtitle}
+          </p>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: 8, marginTop: 12 }}>
+        <Metric label={copy.coverage} value={totals.coverage} />
+        <Metric label={copy.retailers} value={String(totals.retailers)} />
+        <Metric label={copy.commission} value={formatMoney(totals.commission, locale)} strong />
+        <Metric label={copy.missing} value={String(totals.manualLines)} />
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
+        <button
+          type="button"
+          className="material-btn"
+          onClick={() => setSelectedGroups(new Set(groups.filter((group) => group.shoppable_lines > 0).map((group) => group.key)))}
+        >
+          {copy.selectAll}
+        </button>
+        <button type="button" className="material-btn" onClick={() => setSelectedGroups(new Set())}>
+          {copy.clearAll}
+        </button>
+      </div>
+
+      <div style={{ display: "grid", gap: 8, marginTop: 12 }}>
+        {groups.length === 0 ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 12 }}>{copy.empty}</div>
+        ) : (
+          groups.map((group) => {
+            const selected = selectedGroups.has(group.key);
+            const ready = group.shoppable_lines === group.lines.length && group.lines.length > 0;
+            return (
+              <label
+                key={group.key}
+                style={{
+                  display: "block",
+                  padding: 10,
+                  borderRadius: "var(--radius-sm)",
+                  border: selected ? "1px solid rgba(229,160,75,0.35)" : "1px solid var(--border)",
+                  background: selected ? "rgba(229,160,75,0.08)" : "var(--bg-tertiary)",
+                  cursor: group.shoppable_lines > 0 ? "pointer" : "default",
+                }}
+              >
+                <div style={{ display: "flex", alignItems: "flex-start", gap: 10 }}>
+                  <input
+                    type="checkbox"
+                    checked={selected}
+                    disabled={group.shoppable_lines === 0}
+                    onChange={() => {
+                      setSelectedGroups((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(group.key)) next.delete(group.key);
+                        else next.add(group.key);
+                        return next;
+                      });
+                    }}
+                    style={{ marginTop: 2 }}
+                  />
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+                      <strong style={{ fontSize: 13 }}>{group.supplier_name}</strong>
+                      <span style={{ fontFamily: "var(--font-mono)", color: "var(--text-primary)", fontSize: 12 }}>
+                        {formatMoney(group.subtotal, locale)}
+                      </span>
+                    </div>
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginTop: 4, fontSize: 10, color: "var(--text-muted)" }}>
+                      <span>{ready ? copy.ready : copy.partial}</span>
+                      <span>{formatMoney(group.estimated_commission_amount, locale)}</span>
+                    </div>
+                    <div style={{ display: "grid", gap: 4, marginTop: 8 }}>
+                      {group.lines.slice(0, 4).map((line) => (
+                        <div key={`${group.key}-${line.material_id}`} style={{ display: "flex", justifyContent: "space-between", gap: 8, fontSize: 11 }}>
+                          <span style={{ color: "var(--text-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                            {line.material_name}
+                          </span>
+                          <span style={{ color: "var(--text-muted)", whiteSpace: "nowrap" }}>
+                            {line.quantity} {line.unit} · {formatMoney(line.total, locale)}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                    {group.lines.length > 4 && (
+                      <div style={{ marginTop: 4, fontSize: 10, color: "var(--text-muted)" }}>
+                        +{group.lines.length - 4} {copy.lines}
+                      </div>
+                    )}
+                    {group.shoppable_lines === 0 && (
+                      <div style={{ marginTop: 6, fontSize: 10, color: "var(--amber)" }}>
+                        {copy.noLink}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </label>
+            );
+          })
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => void createCheckout()}
+        disabled={creating || selectedSupplierCarts.length === 0}
+        style={{
+          marginTop: 12,
+          width: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 8,
+          padding: "9px 12px",
+          fontSize: 12,
+          fontWeight: 700,
+          color: selectedSupplierCarts.length === 0 ? "var(--text-muted)" : "var(--bg-primary)",
+          background: selectedSupplierCarts.length === 0 ? "var(--bg-tertiary)" : "var(--forest)",
+          border: "1px solid var(--border)",
+          borderRadius: "var(--radius-sm)",
+          cursor: selectedSupplierCarts.length === 0 ? "not-allowed" : "pointer",
+        }}
+      >
+        {creating ? copy.creating : copy.create}
+      </button>
+
+      {error && (
+        <p style={{ margin: "10px 0 0", color: "var(--danger)", fontSize: 11 }}>{error}</p>
+      )}
+
+      <div style={{ marginTop: 14 }}>
+        <div className="label-mono" style={{ color: "var(--text-muted)", fontSize: 10, marginBottom: 6 }}>
+          {copy.savedOrders}
+        </div>
+        {loadingOrders ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 11 }}>…</div>
+        ) : orders.length === 0 ? (
+          <div style={{ color: "var(--text-muted)", fontSize: 11 }}>{copy.noOrders}</div>
+        ) : (
+          <div style={{ display: "grid", gap: 8 }}>
+            {orders.map((order) => (
+              <article
+                key={order.id}
+                style={{
+                  padding: 10,
+                  borderRadius: "var(--radius-sm)",
+                  border: "1px solid var(--border)",
+                  background: "rgba(0,0,0,0.08)",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+                  <div>
+                    <strong style={{ fontSize: 12 }}>{order.supplier_name}</strong>
+                    <div style={{ fontSize: 10, color: "var(--text-muted)", marginTop: 2 }}>
+                      {getOrderStatusLabel(order, copy)} · {formatDate(order.updated_at, locale)}
+                    </div>
+                  </div>
+                  <div style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+                    {formatMoney(order.subtotal, locale)}
+                  </div>
+                </div>
+                <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginTop: 8 }}>
+                  <button
+                    type="button"
+                    className="material-btn"
+                    disabled={busyOrderId === order.id || !order.checkout_url}
+                    onClick={() => void openOrder(order.id)}
+                  >
+                    {copy.open}
+                  </button>
+                  {order.status !== "ordered" && order.status !== "confirmed" && order.status !== "cancelled" && (
+                    <button
+                      type="button"
+                      className="material-btn"
+                      disabled={busyOrderId === order.id}
+                      onClick={() => void updateOrderStatus(order.id, "ordered")}
+                    >
+                      {copy.ordered}
+                    </button>
+                  )}
+                  {order.status !== "confirmed" && order.status !== "cancelled" && (
+                    <button
+                      type="button"
+                      className="material-btn"
+                      disabled={busyOrderId === order.id}
+                      onClick={() => void updateOrderStatus(order.id, "confirmed")}
+                    >
+                      {copy.confirmed}
+                    </button>
+                  )}
+                  {order.status !== "cancelled" && (
+                    <button
+                      type="button"
+                      className="material-btn"
+                      disabled={busyOrderId === order.id}
+                      onClick={() => void updateOrderStatus(order.id, "cancelled")}
+                    >
+                      {copy.cancelled}
+                    </button>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  strong = false,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        padding: "8px 9px",
+        borderRadius: "var(--radius-sm)",
+        border: "1px solid var(--border)",
+        background: "rgba(255,255,255,0.04)",
+      }}
+    >
+      <div style={{ fontSize: 10, color: "var(--text-muted)", marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 12, fontWeight: strong ? 700 : 600, color: strong ? "var(--forest)" : "var(--text-primary)" }}>
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,10 @@ import type {
   EnergySubsidyRequest,
   BomSubstitutionResponse,
   KeskoProduct,
+  MarketplaceCheckoutResponse,
+  MarketplaceOpenOrderResponse,
+  MarketplaceOrder,
+  MarketplaceSupplierCheckoutInput,
   MaterialSubstitutionResponse,
   AppNotification,
   ProjectVersionCompareResponse,
@@ -386,6 +390,28 @@ export const api = {
   }) =>
     apiFetch("/affiliates/click", {
       method: "POST",
+      body: JSON.stringify(data),
+    }),
+  getMarketplaceOrders: (projectId: string): Promise<MarketplaceOrder[]> =>
+    apiFetch(`/marketplace/project/${encodeURIComponent(projectId)}/orders`),
+  createMarketplaceCheckout: (
+    projectId: string,
+    data: { supplier_carts: MarketplaceSupplierCheckoutInput[] },
+  ): Promise<MarketplaceCheckoutResponse> =>
+    apiFetch(`/marketplace/project/${encodeURIComponent(projectId)}/checkout`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+  openMarketplaceOrder: (orderId: string): Promise<MarketplaceOpenOrderResponse> =>
+    apiFetch(`/marketplace/orders/${encodeURIComponent(orderId)}/open`, {
+      method: "POST",
+    }),
+  updateMarketplaceOrder: (
+    orderId: string,
+    data: { status: MarketplaceOrder["status"]; external_order_ref?: string | null },
+  ): Promise<MarketplaceOrder> =>
+    apiFetch(`/marketplace/orders/${encodeURIComponent(orderId)}`, {
+      method: "PATCH",
       body: JSON.stringify(data),
     }),
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -314,6 +314,7 @@ export interface Material {
   category_name_fi: string | null;
   image_url: string | null;
   pricing: {
+    supplier_id?: string;
     unit_price: number;
     unit: string;
     supplier_name: string;
@@ -363,6 +364,7 @@ export interface BomItem {
   quantity: number;
   unit: string;
   unit_price?: number;
+  supplier_id?: string | null;
   supplier_name?: string;
   total?: number;
   supplier?: string;
@@ -374,6 +376,72 @@ export interface BomItem {
   note?: string;
   manual_override?: boolean;
   geometry_driven?: boolean;
+}
+
+export interface MarketplaceOrderLine {
+  id: string;
+  material_id: string;
+  material_name: string;
+  quantity: number;
+  unit: string;
+  unit_price: number;
+  total: number;
+  link: string | null;
+  stock_level: StockLevel;
+}
+
+export interface MarketplaceOrder {
+  id: string;
+  project_id: string;
+  user_id: string;
+  supplier_id: string | null;
+  supplier_name: string;
+  partner_id: string | null;
+  partner_name: string | null;
+  status: "draft" | "opened" | "ordered" | "confirmed" | "cancelled";
+  currency: string;
+  subtotal: number;
+  estimated_commission_rate: number;
+  estimated_commission_amount: number;
+  checkout_url: string | null;
+  external_order_ref: string | null;
+  created_at: string;
+  updated_at: string;
+  opened_at?: string | null;
+  ordered_at?: string | null;
+  confirmed_at?: string | null;
+  cancelled_at?: string | null;
+  lines: MarketplaceOrderLine[];
+}
+
+export interface MarketplaceSupplierCheckoutLineInput {
+  material_id: string;
+  material_name: string;
+  quantity: number;
+  unit: string;
+  unit_price: number;
+  total: number;
+  link?: string | null;
+  stock_level?: StockLevel | null;
+}
+
+export interface MarketplaceSupplierCheckoutInput {
+  supplier_id?: string | null;
+  supplier_name: string;
+  subtotal: number;
+  currency?: string;
+  checkout_url?: string | null;
+  items: MarketplaceSupplierCheckoutLineInput[];
+}
+
+export interface MarketplaceCheckoutResponse {
+  orders: MarketplaceOrder[];
+}
+
+export interface MarketplaceOpenOrderResponse {
+  checkout_url: string | null;
+  click_count: number;
+  order: MarketplaceOrder | null;
 }
 
 export interface QuoteRequestPayload {


### PR DESCRIPTION
Fixes #511.

Summary:
- Adds persisted marketplace order and order-line tables plus authenticated API routes to create retailer checkout baskets, open tracked retailer carts, and update order lifecycle state.
- Adds a BOM marketplace checkout panel that groups lines by retailer, creates homeowner-facing checkout baskets, opens tracked supplier carts, and keeps order progress inside Helscoop.
- Reuses affiliate click attribution, supplier pricing metadata, and a default 15% estimated commission model with exact partner-rate overrides when an active affiliate partner exists.

Validation:
- npm test -- --run src/__tests__/marketplace.test.ts
- npm test -- --run src/__tests__/marketplace-checkout-panel.test.tsx
- npx tsc --noEmit (api)
- npx tsc --noEmit (web)
- npm test -- --run (api)
- npm test -- --run (web)
- npm run build (web; existing experimental.viewTransition warning only)