### PR TITLE
ci: tolerate docker cache export failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           tags: ${{ steps.meta-api.outputs.tags }}
           labels: ${{ steps.meta-api.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           build-args: |
             APP_VERSION=${{ github.sha }}
 
@@ -157,7 +157,7 @@ jobs:
           tags: ${{ steps.meta-web.outputs.tags }}
           labels: ${{ steps.meta-web.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'https://helscoop-api.fly.dev' }}
 
@@ -217,7 +217,7 @@ jobs:
 
   auto-merge:
     name: Auto Merge
-    needs: [test-api, test-web]
+    needs: [test-api, test-web, build-images]
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:


### PR DESCRIPTION
Summary:
- Treat Docker Buildx GHA cache export failures as non-fatal for API and web image builds.
- Make auto-merge wait for the Docker image job so future PRs do not merge before all CI jobs finish.

Context:
- PR #991 merged with API/Web checks green but Docker failed while exporting a cache layer to GitHub Actions Cache with a 502 Unicorn HTML response. The Dockerfile build had already completed; the failure was in cache export.

Validation:
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'