### PR TITLE
feat: add renovation mood board

### DIFF
--- a/api/src/__tests__/projects.test.ts
+++ b/api/src/__tests__/projects.test.ts
@@ -836,6 +836,48 @@ describe("PUT /projects/:id", () => {
   });
 });
 
+describe("PUT /projects/:id/mood-board", () => {
+  it("persists a normalized mood board", async () => {
+    const mood_board = {
+      items: [
+        { id: "note-1", type: "note", x: 24, y: 32, width: 200, height: 120, text: "Warm timber" },
+        { id: "mat-1", type: "material", x: 80, y: 90, material_id: "material-1" },
+      ],
+    };
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ mood_board, updated_at: "2026-04-25T00:00:00.000Z" }],
+      command: "UPDATE",
+      rowCount: 1,
+      oid: 0,
+      fields: [],
+    });
+
+    const res = await makeRequest("PUT", "/projects/proj-1/mood-board", {
+      headers: { Authorization: `Bearer ${authToken("user-1")}` },
+      body: { mood_board },
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as { ok: boolean }).ok).toBe(true);
+    expect(mockQuery.mock.calls[0][0]).toContain("mood_board = $1::jsonb");
+    const saved = JSON.parse(mockQuery.mock.calls[0][1][0] as string);
+    expect(saved.items).toHaveLength(2);
+    expect(saved.items[0]).toMatchObject({ type: "note", text: "Warm timber" });
+    expect(mockQuery.mock.calls[0][1][1]).toBe("proj-1");
+    expect(mockQuery.mock.calls[0][1][2]).toBe("user-1");
+  });
+
+  it("rejects invalid mood board payloads", async () => {
+    const res = await makeRequest("PUT", "/projects/proj-1/mood-board", {
+      headers: { Authorization: `Bearer ${authToken("user-1")}` },
+      body: { mood_board: { items: [{ id: "bad", type: "video", x: 0, y: 0 }] } },
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
 // --------------------------------------------------------------------------
 // DELETE /projects/:id
 // --------------------------------------------------------------------------

--- a/api/src/routes/projects.ts
+++ b/api/src/routes/projects.ts
@@ -185,6 +185,76 @@ function normalizePhotoOverlay(value: unknown): Record<string, unknown> | null {
   };
 }
 
+function normalizeMoodBoard(value: unknown): Record<string, unknown> {
+  if (value == null) return { items: [] };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("mood_board must be an object");
+  }
+
+  const raw = value as Record<string, unknown>;
+  const items = Array.isArray(raw.items) ? raw.items : [];
+  if (items.length > 100) {
+    throw new Error("mood_board.items must contain at most 100 cards");
+  }
+
+  const normalizedItems = items.map((item, index) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error("mood_board.items rows must be objects");
+    }
+    const card = item as Record<string, unknown>;
+    const type = card.type;
+    if (type !== "material" && type !== "photo" && type !== "color" && type !== "note") {
+      throw new Error("mood_board item type is invalid");
+    }
+    const base = {
+      id: typeof card.id === "string" && card.id ? card.id.slice(0, 80) : `mood-${index + 1}`,
+      type,
+      x: clampNumber(card.x, 0, 5000, 24),
+      y: clampNumber(card.y, 0, 5000, 24),
+      width: clampNumber(card.width, 48, 800, type === "note" ? 180 : 140),
+      height: clampNumber(card.height, 48, 800, type === "note" ? 120 : 140),
+      title: typeof card.title === "string" ? card.title.slice(0, 160) : undefined,
+    };
+
+    if (type === "material") {
+      const materialId = typeof card.material_id === "string" ? card.material_id.slice(0, 120) : "";
+      if (!materialId) throw new Error("mood_board material cards require material_id");
+      return { ...base, material_id: materialId };
+    }
+    if (type === "photo") {
+      const src = typeof card.src === "string" ? card.src : "";
+      if (!/^data:image\/(png|jpeg|jpg|webp);base64,/i.test(src)) {
+        throw new Error("mood_board photo cards require image data URLs");
+      }
+      if (src.length > 1_500_000) {
+        throw new Error("mood_board photo card is too large");
+      }
+      return {
+        ...base,
+        src,
+        file_name: typeof card.file_name === "string" ? card.file_name.slice(0, 160) : undefined,
+      };
+    }
+    if (type === "color") {
+      const color = typeof card.color === "string" && /^#[0-9a-f]{6}$/i.test(card.color) ? card.color : "#d6a15d";
+      return { ...base, color };
+    }
+    return {
+      ...base,
+      text: typeof card.text === "string" ? card.text.slice(0, 2000) : "",
+    };
+  });
+
+  const normalized = {
+    items: normalizedItems,
+    updated_at: typeof raw.updated_at === "string" ? raw.updated_at : new Date().toISOString(),
+  };
+  if (JSON.stringify(normalized).length > 2_000_000) {
+    throw new Error("mood_board is too large");
+  }
+  return normalized;
+}
+
 function formatCurrency(value: number, locale: "fi" | "en"): string {
   return `${value.toLocaleString(locale === "fi" ? "fi-FI" : "en-GB", {
     minimumFractionDigits: 2,
@@ -1262,6 +1332,27 @@ router.put("/:id", async (req, res) => {
   res.json(updatedProject);
 });
 
+router.put("/:id/mood-board", async (req, res) => {
+  let safeMoodBoard: Record<string, unknown>;
+  try {
+    safeMoodBoard = normalizeMoodBoard(req.body?.mood_board);
+  } catch (err) {
+    return res.status(400).json({ error: err instanceof Error ? err.message : "Invalid mood_board" });
+  }
+
+  const result = await query(
+    `UPDATE projects
+     SET mood_board = $1::jsonb, updated_at = now()
+     WHERE id = $2 AND user_id = $3 AND deleted_at IS NULL
+     RETURNING mood_board, updated_at`,
+    [JSON.stringify(safeMoodBoard), req.params.id, req.user!.id],
+  );
+  if (result.rows.length === 0) {
+    return res.status(404).json({ error: "Project not found" });
+  }
+  res.json({ ok: true, mood_board: result.rows[0].mood_board, updated_at: result.rows[0].updated_at });
+});
+
 router.delete("/:id", async (req, res) => {
   await query(
     "UPDATE projects SET deleted_at = NOW() WHERE id=$1 AND user_id=$2 AND deleted_at IS NULL",
@@ -1605,9 +1696,9 @@ router.post("/:id/duplicate", requirePermission("project:create"), async (req, r
     `INSERT INTO projects (
        user_id, name, description, scene_js, original_scene_js, building_info,
        project_type, unit_count, business_id, property_manager_name,
-       property_manager_email, property_manager_phone, shareholder_shares
+       property_manager_email, property_manager_phone, shareholder_shares, mood_board
      )
-     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) RETURNING *`,
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14) RETURNING *`,
     [
       req.user!.id,
       `${p.name} ${suffix}`,
@@ -1622,6 +1713,7 @@ router.post("/:id/duplicate", requirePermission("project:create"), async (req, r
       p.property_manager_email ?? null,
       p.property_manager_phone ?? null,
       jsonbParam(p.shareholder_shares ?? []),
+      jsonbParam(p.mood_board ?? { items: [] }),
     ]
   );
   const newId = dup.rows[0].id;

--- a/db/migrations/036_project_mood_board.sql
+++ b/db/migrations/036_project_mood_board.sql
@@ -1,0 +1,5 @@
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS mood_board JSONB NOT NULL DEFAULT '{"items":[]}'::jsonb;
+
+COMMENT ON COLUMN projects.mood_board IS
+  'Free-form homeowner mood board: material, photo, color, and note cards used during visual renovation planning.';

--- a/web/src/__tests__/mood-board-panel.test.tsx
+++ b/web/src/__tests__/mood-board-panel.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import MoodBoardPanel from "@/components/MoodBoardPanel";
+import type { Material, MoodBoardState } from "@/types";
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({ locale: "en", t: (key: string) => key }),
+}));
+
+const materials = [
+  {
+    id: "mat-1",
+    name: "Warm timber",
+    name_fi: null,
+    name_en: "Warm timber",
+    category_name: "Wood",
+    category_name_fi: null,
+    image_url: null,
+    pricing: [{ unit_price: 12, unit: "m2", supplier_name: "Supplier", is_primary: true }],
+    visual_albedo: [0.6, 0.42, 0.24],
+  },
+] as Material[];
+
+describe("MoodBoardPanel", () => {
+  it("adds material, color, and note cards", () => {
+    let board: MoodBoardState = { items: [] };
+    const handleChange = vi.fn((next: MoodBoardState) => {
+      board = next;
+      rerenderPanel();
+    });
+    const addToBom = vi.fn();
+
+    const { rerender } = render(
+      <MoodBoardPanel
+        board={board}
+        materials={materials}
+        bomMaterialIds={new Set()}
+        onChange={handleChange}
+        onAddMaterialToBom={addToBom}
+      />,
+    );
+
+    function rerenderPanel() {
+      rerender(
+        <MoodBoardPanel
+          board={board}
+          materials={materials}
+          bomMaterialIds={new Set()}
+          onChange={handleChange}
+          onAddMaterialToBom={addToBom}
+        />,
+      );
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Material" }));
+    expect(screen.getAllByText("Warm timber").length).toBeGreaterThan(1);
+    expect(screen.getAllByText("12 EUR").length).toBeGreaterThan(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Color" }));
+    expect(board.items.some((item) => item.type === "color")).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "+ Note" }));
+    expect(screen.getByPlaceholderText("Write style, concern, or decision...")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add to BOM" }));
+    expect(addToBom).toHaveBeenCalledWith("mat-1");
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4242,6 +4242,273 @@ select:focus {
   box-shadow: var(--shadow-depth-2), inset 0 1px 0 rgba(229, 160, 75, 0.08);
 }
 
+.mood-board-panel {
+  height: 300px;
+  flex-shrink: 0;
+  margin: 0 8px 8px;
+  border: 1px solid var(--glass-float-border);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(135deg, rgba(229, 160, 75, 0.07), transparent 34%),
+    var(--glass-mid);
+  backdrop-filter: var(--glass-mid-blur);
+  -webkit-backdrop-filter: var(--glass-mid-blur);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: var(--shadow-depth-2);
+}
+
+.mood-board-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.mood-board-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 7px;
+}
+
+.mood-board-header h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 15px;
+}
+
+.mood-board-header p {
+  margin: 3px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.mood-board-total {
+  min-width: 150px;
+  border: 1px solid var(--amber-border);
+  border-radius: var(--radius-md);
+  background: var(--amber-glow);
+  padding: 8px 10px;
+  align-self: flex-start;
+}
+
+.mood-board-total span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.mood-board-total strong {
+  display: block;
+  margin-top: 3px;
+  color: var(--amber);
+  font-family: var(--font-mono);
+  font-size: 15px;
+}
+
+.mood-board-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+}
+
+.mood-board-toolbar select,
+.mood-board-toolbar input[type="color"] {
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.mood-board-toolbar select {
+  min-width: 190px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+.mood-board-toolbar input[type="color"] {
+  width: 38px;
+  padding: 2px;
+}
+
+.mood-board-toolbar .btn {
+  white-space: nowrap;
+  min-height: 32px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.mood-board-canvas {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  background-color: var(--bg-tertiary);
+  background-image: radial-gradient(circle, var(--border) 1px, transparent 1px);
+  background-size: 20px 20px;
+}
+
+.mood-board-hint {
+  position: sticky;
+  top: 8px;
+  left: 8px;
+  z-index: 1;
+  width: fit-content;
+  margin: 8px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--bg-primary) 84%, transparent);
+  font-size: 11px;
+  pointer-events: none;
+}
+
+.mood-board-empty {
+  position: absolute;
+  inset: 46px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.mood-board-empty strong {
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.mood-board-empty span {
+  margin-top: 6px;
+  max-width: 320px;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.mood-board-card {
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  box-shadow: var(--shadow-subtle);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.mood-board-card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.mood-board-card:active {
+  cursor: grabbing;
+}
+
+.mood-board-card[data-selected="true"] {
+  outline: 2px solid var(--amber);
+  outline-offset: 2px;
+  border-color: var(--amber-border);
+}
+
+.mood-board-card strong {
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.mood-board-card span {
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.mood-board-card em {
+  width: fit-content;
+  padding: 3px 6px;
+  border-radius: 999px;
+  background: var(--amber-glow);
+  color: var(--amber);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-style: normal;
+}
+
+.mood-board-swatch,
+.mood-board-color {
+  height: 70px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.mood-board-swatch img,
+.mood-board-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.mood-board-photo {
+  min-height: 92px;
+  border-radius: var(--radius-md);
+}
+
+.mood-board-color {
+  min-height: 54px;
+}
+
+.mood-board-bom-btn {
+  min-height: 28px;
+  border: 1px solid var(--amber-border);
+  border-radius: var(--radius-sm);
+  background: var(--amber-glow);
+  color: var(--amber);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.mood-board-bom-btn:disabled {
+  border-color: var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: default;
+}
+
+.mood-board-card textarea {
+  width: 100%;
+  min-height: 104px;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 /* Embedded chat */
 .chat-embedded {
   flex-shrink: 0;
@@ -7920,6 +8187,7 @@ select:focus {
 
   .editor-page[data-mobile-panel]:not([data-mobile-panel="chat"]) .chat-embedded,
   .editor-page[data-mobile-panel]:not([data-mobile-panel="code"]) .editor-code-panel,
+  .editor-page[data-mobile-panel]:not([data-mobile-panel="mood"]) .mood-board-panel,
   .editor-page[data-mobile-panel]:not([data-mobile-panel="bom"]) .editor-bom-panel,
   .editor-page[data-mobile-panel]:not([data-mobile-panel="params"]) .scene-params-panel,
   .editor-page[data-mobile-panel]:not([data-mobile-panel="docs"]) .scene-docs-panel {
@@ -7927,7 +8195,8 @@ select:focus {
   }
 
   .editor-page[data-mobile-panel="chat"] .chat-embedded,
-  .editor-page[data-mobile-panel="code"] .editor-code-panel {
+  .editor-page[data-mobile-panel="code"] .editor-code-panel,
+  .editor-page[data-mobile-panel="mood"] .mood-board-panel {
     display: flex;
     flex-direction: column;
     height: var(--mobile-active-panel-height) !important;
@@ -7935,6 +8204,51 @@ select:focus {
     padding: 8px;
     border-top: 1px solid var(--border);
     background: color-mix(in srgb, var(--surface-raised) 72%, transparent);
+  }
+
+  .editor-page[data-mobile-panel="mood"] .mood-board-panel {
+    margin: 0;
+    border-radius: 0;
+  }
+
+  .editor-page[data-mobile-panel="mood"] .mood-board-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .editor-page[data-mobile-panel="mood"] .mood-board-toolbar {
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+    order: 3;
+    border-top: 1px solid var(--border);
+    border-bottom: 0;
+    background: var(--bg-secondary);
+  }
+
+  .editor-page[data-mobile-panel="mood"] .mood-board-canvas {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-content: start;
+    gap: 8px;
+    padding: 10px;
+    background-size: 16px 16px;
+  }
+
+  .editor-page[data-mobile-panel="mood"] .mood-board-card {
+    position: relative;
+    left: auto !important;
+    top: auto !important;
+    width: auto !important;
+    min-height: 112px;
+    touch-action: pan-y;
+  }
+
+  .editor-page[data-mobile-panel="mood"] .mood-board-hint,
+  .editor-page[data-mobile-panel="mood"] .mood-board-empty {
+    grid-column: 1 / -1;
+    position: static;
+    margin: 0;
   }
 
   .editor-page[data-mobile-panel="chat"] .chat-messages-area {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "@/components/LocaleProvider";
 import SceneEditor from "@/components/SceneEditor";
 import BomPanel, { matchSceneMaterial } from "@/components/BomPanel";
 import EnergyDashboard from "@/components/EnergyDashboard";
+import MoodBoardPanel from "@/components/MoodBoardPanel";
 import MaterialPicker from "@/components/MaterialPicker";
 import type { BomPriceOverride } from "@/components/BomSavingsPanel";
 import ChatPanel from "@/components/ChatPanel";
@@ -78,7 +79,7 @@ import type { KeyboardShortcut } from "@/hooks/useKeyboardShortcuts";
 import SaveStatusIndicator from "@/components/SaveStatusIndicator";
 import EditorStatusBar from "@/components/EditorStatusBar";
 import type { SaveStatus } from "@/components/SaveStatusIndicator";
-import type { Material, BomItem, Project, ProjectVersionSnapshot, ProjectPriceChangeSummary, ProjectImage } from "@/types";
+import type { Material, BomItem, Project, ProjectVersionSnapshot, ProjectPriceChangeSummary, ProjectImage, MoodBoardState } from "@/types";
 import type { PhotoOverlayState } from "@/types";
 import type { GuidedRenovationPlan, RenovationWizardState, WizardStepId } from "@/lib/renovation-wizard";
 import type { ViewportAssemblyGuideState, ViewportCameraState, ViewportMaterialSelection, ViewportPresentationApi } from "@/components/Viewport3D";
@@ -180,7 +181,7 @@ scene.add(wall4, { material: "lumber", color: [0.85, 0.75, 0.55] });
 const HISTORY_LIMIT = 50;
 const MOBILE_EDITOR_QUERY = "(max-width: 768px)";
 
-type MobileEditorPanel = "viewport" | "chat" | "bom" | "code" | "params" | "docs";
+type MobileEditorPanel = "viewport" | "chat" | "mood" | "bom" | "code" | "params" | "docs";
 type MobilePanelSize = "normal" | "expanded" | "minimized";
 
 interface GeometryBomUpdateState {
@@ -262,6 +263,10 @@ function buildProjectVersionSnapshot(fields: {
   };
 }
 
+function normalizeMoodBoardState(value: Project["mood_board"]): MoodBoardState {
+  return value && Array.isArray(value.items) ? value : { items: [] };
+}
+
 function hydrateSnapshotBom(snapshot: ProjectVersionSnapshot, materials: Material[]): BomItem[] {
   return snapshot.bom.map((item) => {
     const material = materials.find((candidate) => candidate.id === item.material_id);
@@ -318,6 +323,7 @@ export default function ProjectPage() {
   const [project, setProject] = useState<Project | null>(null);
   const [materials, setMaterials] = useState<Material[]>([]);
   const [bom, setBom] = useState<BomItem[]>([]);
+  const [moodBoard, setMoodBoard] = useState<MoodBoardState>({ items: [] });
   const [manualBomOverrideIds, setManualBomOverrideIds] = useState<Set<string>>(() => new Set());
   const [geometryBomUpdate, setGeometryBomUpdate] = useState<GeometryBomUpdateState | null>(null);
   const [surfacePickerMaterialId, setSurfacePickerMaterialId] = useState<string | null>(null);
@@ -347,6 +353,7 @@ export default function ProjectPage() {
   const [showCode, setShowCode] = useState(false);
   const [editorMode, setEditorMode] = useState<"simple" | "advanced">("simple");
   const [showGuidedWizard, setShowGuidedWizard] = useState(false);
+  const [showMoodBoard, setShowMoodBoard] = useState(false);
   const [showBom, setShowBom] = useState(true);
   const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
   const [showDocs, setShowDocs] = useState(false);
@@ -636,7 +643,9 @@ export default function ProjectPage() {
           setShareExpiresAt(proj.share_token_expires_at ?? null);
         }
         const initialPhotoOverlay = normalizePhotoOverlayState(proj.photo_overlay);
+        const initialMoodBoard = normalizeMoodBoardState(proj.mood_board);
         setPhotoOverlay(initialPhotoOverlay);
+        setMoodBoard(initialMoodBoard);
         setParamPresets(proj.param_presets || []);
         const initialScene = proj.scene_js || DEFAULT_SCENE;
         setOriginalSceneJs(proj.original_scene_js || initialScene);
@@ -667,6 +676,7 @@ export default function ProjectPage() {
             unit: b.unit,
           })),
           photo_overlay: initialPhotoOverlay,
+          mood_board: initialMoodBoard,
         });
         setTimeout(() => {
           initialLoadDoneRef.current = true;
@@ -727,8 +737,9 @@ export default function ProjectPage() {
       scene_js: sceneJs,
       bom: bomForSave,
       photo_overlay: photoOverlay,
+      mood_board: moodBoard,
     }),
-    [projectName, projectDesc, sceneJs, bomForSave, photoOverlay]
+    [projectName, projectDesc, sceneJs, bomForSave, photoOverlay, moodBoard]
   );
   const currentVersionSnapshot = useMemo(
     () => buildProjectVersionSnapshot({
@@ -747,6 +758,9 @@ export default function ProjectPage() {
       },
       onSaveBom: async (items: SaveableFields["bom"]) => {
         await api.saveBOM(projectId, items, collaborationClientIdRef.current);
+      },
+      onSaveMoodBoard: async (nextMoodBoard: SaveableFields["mood_board"]) => {
+        await api.saveMoodBoard(projectId, nextMoodBoard, collaborationClientIdRef.current);
       },
       onSaveThumbnail: async () => {
         const thumbDataUrl = captureThumbRef.current?.();
@@ -1514,9 +1528,14 @@ export default function ProjectPage() {
       setMobilePanelSize(panel === "viewport" ? "minimized" : "normal");
       if (panel === "chat") markChat();
       if (panel === "bom") setShowBom(true);
+      if (panel === "mood") {
+        setShowMoodBoard(true);
+        setShowCode(false);
+      }
       if (panel === "code") {
         if (!showCode) markCodeEditor();
         setShowCode(true);
+        setShowMoodBoard(false);
       }
       if (panel === "params") setShowParams(true);
       if (panel === "docs") setShowDocs(true);
@@ -1527,6 +1546,7 @@ export default function ProjectPage() {
   const mobilePanelOrder = useMemo<MobileEditorPanel[]>(() => [
     "viewport",
     "chat",
+    "mood",
     "bom",
     ...(isAdvancedMode ? (["code"] as MobileEditorPanel[]) : []),
     ...(isAdvancedMode && sceneParams.length > 0 ? (["params"] as MobileEditorPanel[]) : []),
@@ -1574,9 +1594,19 @@ export default function ProjectPage() {
     setShowCode((visible) => {
       const next = !visible;
       if (isMobileEditor) setActiveMobilePanel(next ? "code" : "viewport");
+      if (next) setShowMoodBoard(false);
       return next;
     });
   }, [isMobileEditor, markCodeEditor, showCode]);
+
+  const toggleMoodBoardPanel = useCallback(() => {
+    setShowMoodBoard((visible) => {
+      const next = !visible;
+      if (next) setShowCode(false);
+      if (isMobileEditor) setActiveMobilePanel(next ? "mood" : "viewport");
+      return next;
+    });
+  }, [isMobileEditor]);
 
   const toggleDocsPanel = useCallback(() => {
     setEditorMode("advanced");
@@ -1854,12 +1884,13 @@ export default function ProjectPage() {
         scene_js: snapshot.scene_js || DEFAULT_SCENE,
         bom: snapshot.bom,
         photo_overlay: photoOverlay,
+        mood_board: moodBoard,
       });
       pushHistory(snapshot.scene_js || DEFAULT_SCENE);
       setViewportKey((key) => key + 1);
       toast(t("versions.restoreSuccess"), "success");
     },
-    [materials, photoOverlay, pushHistory, queueSceneAnnouncement, setSavedSnapshot, t, toast],
+    [materials, moodBoard, photoOverlay, pushHistory, queueSceneAnnouncement, setSavedSnapshot, t, toast],
   );
 
   useEffect(() => {
@@ -1869,15 +1900,17 @@ export default function ProjectPage() {
       return;
     }
     if ((activeMobilePanel === "code" && !showCode) ||
+      (activeMobilePanel === "mood" && !showMoodBoard) ||
       (activeMobilePanel === "params" && !showParams) ||
       (activeMobilePanel === "docs" && !showDocs)) {
       setActiveMobilePanel("viewport");
     }
-  }, [activeMobilePanel, isMobileEditor, showCode, showDocs, showParams]);
+  }, [activeMobilePanel, isMobileEditor, showCode, showDocs, showMoodBoard, showParams]);
 
   /* ── Keyboard shortcuts ──────────────────────────────────────── */
   const closeAllPanels = useCallback(() => {
     setShowCode(false);
+    setShowMoodBoard(false);
     setShowShortcutsHelp(false);
     setShowExportMenu(false);
     setShowHeaderMenu(false);
@@ -2518,6 +2551,17 @@ export default function ProjectPage() {
     },
     [materials, track, playSound]
   );
+
+  const addMoodMaterialToBom = useCallback((materialId: string) => {
+    if (bom.some((item) => item.material_id === materialId)) {
+      setShowBom(true);
+      toast(locale === "fi" ? "Materiaali on jo materiaalilistalla" : "Material is already in the BOM", "info");
+      return;
+    }
+    addBomItem(materialId, 1);
+    setShowBom(true);
+    toast(locale === "fi" ? "Tunnelmataulun materiaali lisätty BOMiin" : "Mood board material added to BOM", "success");
+  }, [addBomItem, bom, locale, toast]);
 
   const addImportedBomItem = useCallback(
     (item: BomItem, material: Material) => {
@@ -3769,7 +3813,7 @@ export default function ProjectPage() {
               flex: 1,
               minHeight: 0,
               padding: 8,
-              paddingBottom: showCode ? 0 : 8,
+              paddingBottom: showCode || showMoodBoard ? 0 : 8,
             }}
           >
             <ErrorBoundary
@@ -4465,6 +4509,19 @@ export default function ProjectPage() {
               {t('editor.resetCamera')}
             </button>
             <span className="viewport-toolbar-sep" />
+            <button
+              className="viewport-toolbar-btn"
+              data-active={showMoodBoard}
+              onClick={toggleMoodBoardPanel}
+              title={locale === "fi" ? "Tunnelmataulu" : "Mood board"}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+                <path d="M15 5l4 4" />
+              </svg>
+              {locale === "fi" ? "Tunnelma" : "Mood"}
+            </button>
             {isAdvancedMode && (
               <button
                 className="viewport-toolbar-btn"
@@ -4825,16 +4882,28 @@ export default function ProjectPage() {
                 label:
                   id === "viewport" ? t("editor.scene") :
                   id === "chat" ? t("editor.assistant") :
+                  id === "mood" ? (locale === "fi" ? "Tunnelma" : "Mood") :
                   id === "bom" ? t("editor.materialList") :
                   id === "code" ? (locale === "fi" ? "Koodi" : "Code") :
                   id === "params" ? t("editor.params") :
                   t("editor.docs") || "Docs",
                 badge:
                   id === "chat" ? chatMessageCount || undefined :
+                  id === "mood" ? moodBoard.items.length || undefined :
                   id === "bom" ? bom.length || undefined :
                   id === "params" ? sceneParams.length :
                   undefined,
               }))}
+            />
+          )}
+
+          {showMoodBoard && (
+            <MoodBoardPanel
+              board={moodBoard}
+              materials={materials}
+              bomMaterialIds={new Set(bom.map((item) => item.material_id))}
+              onChange={setMoodBoard}
+              onAddMaterialToBom={addMoodMaterialToBom}
             />
           )}
 

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -2475,6 +2475,11 @@ export default function BomPanel({
       onMouseLeave={glow.onMouseLeave}
       onPaste={handleBomPaste}
       onDragOver={(event) => {
+        if (event.dataTransfer.types.includes("application/x-helscoop-material-id")) {
+          event.preventDefault();
+          event.dataTransfer.dropEffect = "copy";
+          return;
+        }
         if (event.dataTransfer.types.includes("Files")) {
           event.preventDefault();
           setImportDragging(true);
@@ -2482,6 +2487,15 @@ export default function BomPanel({
       }}
       onDragLeave={() => setImportDragging(false)}
       onDrop={(event) => {
+        const moodBoardMaterialId = event.dataTransfer.getData("application/x-helscoop-material-id");
+        if (moodBoardMaterialId) {
+          event.preventDefault();
+          setImportDragging(false);
+          if (!bom.some((item) => item.material_id === moodBoardMaterialId)) {
+            onAdd(moodBoardMaterialId, 1);
+          }
+          return;
+        }
         const file = event.dataTransfer.files[0];
         if (!file) return;
         event.preventDefault();

--- a/web/src/components/MoodBoardPanel.tsx
+++ b/web/src/components/MoodBoardPanel.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { useMemo, useRef, useState, type ChangeEvent, type PointerEvent } from "react";
+import { useTranslation } from "@/components/LocaleProvider";
+import type { Material, MoodBoardItem, MoodBoardState } from "@/types";
+
+interface MoodBoardPanelProps {
+  board?: MoodBoardState | null;
+  materials: Material[];
+  bomMaterialIds: Set<string>;
+  onChange: (board: MoodBoardState) => void;
+  onAddMaterialToBom: (materialId: string) => void;
+}
+
+interface DragState {
+  ids: string[];
+  startX: number;
+  startY: number;
+  origins: Record<string, { x: number; y: number }>;
+}
+
+function createId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+function getPrimaryPrice(material: Material): NonNullable<Material["pricing"]>[number] | null {
+  return material.pricing?.find((price) => price.is_primary) ?? material.pricing?.[0] ?? null;
+}
+
+function getUnitPrice(material?: Material | null): number {
+  if (!material) return 0;
+  return Number(getPrimaryPrice(material)?.unit_price ?? 0);
+}
+
+function getMaterialName(material: Material, locale: string): string {
+  if (locale === "fi") return material.name_fi || material.name;
+  if (locale === "en") return material.name_en || material.name;
+  return material.name;
+}
+
+function materialSwatch(material: Material): string {
+  const albedo = material.visual_albedo;
+  if (Array.isArray(albedo) && albedo.length >= 3) {
+    const [r, g, b] = albedo.map((value) => Math.max(0, Math.min(255, Math.round(Number(value) * 255))));
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  const palette = ["#8b6f47", "#c49058", "#4a5568", "#4a8b7f", "#718096", "#cbd5e0", "#d6a15d"];
+  const seed = Array.from(material.category_name || material.name).reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  return palette[seed % palette.length];
+}
+
+function formatCurrency(amount: number, locale: string): string {
+  return `${Math.round(amount).toLocaleString(locale === "fi" ? "fi-FI" : locale === "sv" ? "sv-SE" : "en-GB")} EUR`;
+}
+
+function nextPosition(items: MoodBoardItem[]) {
+  const index = items.length;
+  return {
+    x: 24 + (index % 4) * 34,
+    y: 24 + Math.floor(index / 4) * 34,
+  };
+}
+
+function copyFor(locale: string) {
+  if (locale === "fi") {
+    return {
+      code: "Koodi",
+      mood: "Tunnelma",
+      title: "Tunnelmataulu",
+      subtitle: "Kerää materiaalit, värit, kuvat ja muistiinpanot samaan ostoa edeltävään näkymään.",
+      addMaterial: "+ Materiaali",
+      addPhoto: "+ Kuva",
+      addColor: "+ Väri",
+      addNote: "+ Muistiinpano",
+      removeSelected: "Poista valitut",
+      materialPlaceholder: "Valitse materiaali",
+      colorValue: "Värin hex-arvo",
+      roughTotal: "Materiaalien karkea summa",
+      selected: "valittu",
+      emptyTitle: "Lisää materiaaleja ja inspiraatiokuvia",
+      emptyBody: "Aloita materiaalikortilla, värillä, kuvalla tai vapaalla muistiinpanolla.",
+      addToBom: "Lisää BOMiin",
+      inBom: "BOMissa",
+      notePlaceholder: "Kirjoita tyyli, huoli tai päätös...",
+      dragHint: "Vedä kortteja vapaasti. Shift-klikkaus valitsee useita.",
+    };
+  }
+  if (locale === "sv") {
+    return {
+      code: "Kod",
+      mood: "Stämning",
+      title: "Moodboard",
+      subtitle: "Samla material, färger, bilder och anteckningar innan teknisk projektering.",
+      addMaterial: "+ Material",
+      addPhoto: "+ Foto",
+      addColor: "+ Färg",
+      addNote: "+ Anteckning",
+      removeSelected: "Ta bort valda",
+      materialPlaceholder: "Välj material",
+      colorValue: "Färgens hexvärde",
+      roughTotal: "Grov materialsumma",
+      selected: "vald",
+      emptyTitle: "Lägg till material och inspirationsbilder",
+      emptyBody: "Börja med ett materialkort, en färg, en bild eller en fri anteckning.",
+      addToBom: "Lägg till i BOM",
+      inBom: "I BOM",
+      notePlaceholder: "Skriv stil, risk eller beslut...",
+      dragHint: "Dra korten fritt. Shift-klick väljer flera.",
+    };
+  }
+  return {
+    code: "Code",
+    mood: "Mood",
+    title: "Mood board",
+    subtitle: "Collect materials, colors, photos, and notes before the technical design hardens.",
+    addMaterial: "+ Material",
+    addPhoto: "+ Photo",
+    addColor: "+ Color",
+    addNote: "+ Note",
+    removeSelected: "Remove selected",
+    materialPlaceholder: "Choose material",
+    colorValue: "Color hex value",
+    roughTotal: "Rough material total",
+    selected: "selected",
+    emptyTitle: "Add materials and inspiration photos",
+    emptyBody: "Start with a material card, color chip, photo, or free-form note.",
+    addToBom: "Add to BOM",
+    inBom: "In BOM",
+    notePlaceholder: "Write style, concern, or decision...",
+    dragHint: "Drag cards freely. Shift-click selects several.",
+  };
+}
+
+export default function MoodBoardPanel({
+  board,
+  materials,
+  bomMaterialIds,
+  onChange,
+  onAddMaterialToBom,
+}: MoodBoardPanelProps) {
+  const { locale } = useTranslation();
+  const copy = copyFor(locale);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const [materialId, setMaterialId] = useState(materials[0]?.id ?? "");
+  const [color, setColor] = useState("#d6a15d");
+  const items = board?.items ?? [];
+  const materialById = useMemo(() => new Map(materials.map((material) => [material.id, material])), [materials]);
+  const materialTotal = items.reduce((sum, item) => {
+    if (item.type !== "material") return sum;
+    return sum + getUnitPrice(materialById.get(item.material_id));
+  }, 0);
+
+  function updateItems(updater: (current: MoodBoardItem[]) => MoodBoardItem[]) {
+    onChange({
+      items: updater(items),
+      updated_at: new Date().toISOString(),
+    });
+  }
+
+  function addMaterial() {
+    const selectedMaterialId = materialId || materials[0]?.id;
+    if (!selectedMaterialId) return;
+    const position = nextPosition(items);
+    updateItems((current) => [
+      ...current,
+      {
+        id: createId("material"),
+        type: "material",
+        material_id: selectedMaterialId,
+        x: position.x,
+        y: position.y,
+        width: 142,
+        height: 166,
+      },
+    ]);
+  }
+
+  function addColor() {
+    const position = nextPosition(items);
+    updateItems((current) => [
+      ...current,
+      {
+        id: createId("color"),
+        type: "color",
+        color,
+        title: color.toUpperCase(),
+        x: position.x,
+        y: position.y,
+        width: 96,
+        height: 96,
+      },
+    ]);
+  }
+
+  function addNote() {
+    const position = nextPosition(items);
+    updateItems((current) => [
+      ...current,
+      {
+        id: createId("note"),
+        type: "note",
+        text: "",
+        x: position.x,
+        y: position.y,
+        width: 210,
+        height: 132,
+      },
+    ]);
+  }
+
+  function addPhoto(file: File) {
+    if (!file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const src = typeof reader.result === "string" ? reader.result : "";
+      if (!src) return;
+      const position = nextPosition(items);
+      updateItems((current) => [
+        ...current,
+        {
+          id: createId("photo"),
+          type: "photo",
+          src,
+          file_name: file.name,
+          title: file.name,
+          x: position.x,
+          y: position.y,
+          width: 180,
+          height: 132,
+        },
+      ]);
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function removeSelected() {
+    if (selectedIds.size === 0) return;
+    updateItems((current) => current.filter((item) => !selectedIds.has(item.id)));
+    setSelectedIds(new Set());
+  }
+
+  function selectItem(itemId: string, additive: boolean) {
+    setSelectedIds((current) => {
+      const next = additive ? new Set(current) : new Set<string>();
+      if (additive && next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  }
+
+  function beginDrag(event: PointerEvent<HTMLElement>, item: MoodBoardItem) {
+    const target = event.target as HTMLElement;
+    if (target.closest("button,input,textarea,select,a")) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const alreadySelected = selectedIds.has(item.id);
+    const ids = alreadySelected ? Array.from(selectedIds) : [item.id];
+    if (!alreadySelected) setSelectedIds(new Set([item.id]));
+    setDrag({
+      ids,
+      startX: event.clientX,
+      startY: event.clientY,
+      origins: Object.fromEntries(items.filter((candidate) => ids.includes(candidate.id)).map((candidate) => [candidate.id, { x: candidate.x, y: candidate.y }])),
+    });
+  }
+
+  function moveDrag(event: PointerEvent<HTMLElement>) {
+    if (!drag) return;
+    const dx = event.clientX - drag.startX;
+    const dy = event.clientY - drag.startY;
+    updateItems((current) => current.map((item) => {
+      const origin = drag.origins[item.id];
+      if (!origin) return item;
+      return {
+        ...item,
+        x: Math.max(0, origin.x + dx),
+        y: Math.max(0, origin.y + dy),
+      };
+    }));
+  }
+
+  function endDrag(event: PointerEvent<HTMLElement>) {
+    if (drag) event.currentTarget.releasePointerCapture(event.pointerId);
+    setDrag(null);
+  }
+
+  function updateNote(id: string, text: string) {
+    updateItems((current) => current.map((item) => (item.id === id && item.type === "note" ? { ...item, text } : item)));
+  }
+
+  function handlePhotoInput(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (file) addPhoto(file);
+    event.target.value = "";
+  }
+
+  return (
+    <section className="mood-board-panel anim-slide-l" aria-label={copy.title} data-testid="mood-board-panel">
+      <div className="mood-board-header">
+        <div>
+          <div className="mood-board-tabs" role="tablist" aria-label={copy.title}>
+            <span className="badge badge-muted" role="tab" aria-selected="false">{copy.code}</span>
+            <span className="badge badge-amber" role="tab" aria-selected="true">{copy.mood}</span>
+          </div>
+          <h3>{copy.title}</h3>
+          <p>{copy.subtitle}</p>
+        </div>
+        <div className="mood-board-total" aria-label={copy.roughTotal}>
+          <span>{copy.roughTotal}</span>
+          <strong>{formatCurrency(materialTotal, locale)}</strong>
+        </div>
+      </div>
+
+      <div className="mood-board-toolbar" aria-label={copy.title}>
+        <select value={materialId} onChange={(event) => setMaterialId(event.target.value)} aria-label={copy.materialPlaceholder}>
+          {materials.slice(0, 80).map((material) => (
+            <option key={material.id} value={material.id}>{getMaterialName(material, locale)}</option>
+          ))}
+        </select>
+        <button type="button" className="btn btn-ghost" onClick={addMaterial}>{copy.addMaterial}</button>
+        <button type="button" className="btn btn-ghost" onClick={() => fileInputRef.current?.click()}>{copy.addPhoto}</button>
+        <input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handlePhotoInput} />
+        <input type="color" value={color} onChange={(event) => setColor(event.target.value)} aria-label={copy.colorValue} />
+        <button type="button" className="btn btn-ghost" onClick={addColor}>{copy.addColor}</button>
+        <button type="button" className="btn btn-ghost" onClick={addNote}>{copy.addNote}</button>
+        <button type="button" className="btn btn-ghost" onClick={removeSelected} disabled={selectedIds.size === 0}>
+          {copy.removeSelected}
+        </button>
+      </div>
+
+      <div className="mood-board-canvas" onClick={() => setSelectedIds(new Set())}>
+        <div className="mood-board-hint">{copy.dragHint}</div>
+        {items.length === 0 && (
+          <div className="mood-board-empty">
+            <strong>{copy.emptyTitle}</strong>
+            <span>{copy.emptyBody}</span>
+          </div>
+        )}
+
+        {items.map((item) => {
+          const selected = selectedIds.has(item.id);
+          const style = {
+            left: item.x,
+            top: item.y,
+            width: item.width,
+            minHeight: item.height,
+          };
+          return (
+            <article
+              key={item.id}
+              className="mood-board-card"
+              data-type={item.type}
+              data-selected={selected}
+              style={style}
+              tabIndex={0}
+              aria-label={`${item.type} ${selected ? copy.selected : ""}`}
+              draggable={item.type === "material"}
+              onDragStart={(event) => {
+                if (item.type !== "material") return;
+                event.dataTransfer.setData("application/x-helscoop-material-id", item.material_id);
+                event.dataTransfer.effectAllowed = "copy";
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+                selectItem(item.id, event.shiftKey);
+              }}
+              onPointerDown={(event) => beginDrag(event, item)}
+              onPointerMove={moveDrag}
+              onPointerUp={endDrag}
+              onPointerCancel={endDrag}
+            >
+              {item.type === "material" && (() => {
+                const material = materialById.get(item.material_id);
+                const price = getUnitPrice(material);
+                return (
+                  <>
+                    <div
+                      className="mood-board-swatch"
+                      style={{ background: material ? materialSwatch(material) : "var(--bg-tertiary)" }}
+                    >
+                      {material?.image_url && <img src={material.image_url} alt="" />}
+                    </div>
+                    <strong>{material ? getMaterialName(material, locale) : item.material_id}</strong>
+                    <span>{material?.category_name}</span>
+                    <em>{formatCurrency(price, locale)}</em>
+                    <button
+                      type="button"
+                      className="mood-board-bom-btn"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onAddMaterialToBom(item.material_id);
+                      }}
+                      disabled={bomMaterialIds.has(item.material_id)}
+                    >
+                      {bomMaterialIds.has(item.material_id) ? copy.inBom : copy.addToBom}
+                    </button>
+                  </>
+                );
+              })()}
+
+              {item.type === "photo" && (
+                <>
+                  <img className="mood-board-photo" src={item.src} alt={item.title || item.file_name || "Mood board photo"} />
+                  <span>{item.file_name || item.title}</span>
+                </>
+              )}
+
+              {item.type === "color" && (
+                <>
+                  <div className="mood-board-color" style={{ background: item.color }} />
+                  <strong>{item.color.toUpperCase()}</strong>
+                </>
+              )}
+
+              {item.type === "note" && (
+                <textarea
+                  value={item.text}
+                  onChange={(event) => updateNote(item.id, event.target.value)}
+                  placeholder={copy.notePlaceholder}
+                  aria-label={copy.notePlaceholder}
+                />
+              )}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/useAutoSave.ts
+++ b/web/src/hooks/useAutoSave.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import type { PhotoOverlayState } from "@/types";
+import type { MoodBoardState, PhotoOverlayState } from "@/types";
 
 /**
  * Fields that can be auto-saved. Each key maps to a saveable project field.
@@ -10,6 +10,7 @@ export interface SaveableFields {
   scene_js: string;
   bom: { material_id: string; quantity: number; unit: string }[];
   photo_overlay?: PhotoOverlayState | null;
+  mood_board?: MoodBoardState | null;
 }
 
 export interface AutoSaveCallbacks {
@@ -17,6 +18,8 @@ export interface AutoSaveCallbacks {
   onSaveProject: (dirty: Partial<Pick<SaveableFields, "name" | "description" | "scene_js" | "photo_overlay">>) => Promise<void>;
   /** Called when BOM has changed. */
   onSaveBom: (bom: SaveableFields["bom"]) => Promise<void>;
+  /** Called when mood board layout/content has changed. */
+  onSaveMoodBoard?: (moodBoard: SaveableFields["mood_board"]) => Promise<void>;
   /** Called when scene_js changed and save succeeded, to capture a new thumbnail. */
   onSaveThumbnail: () => Promise<void>;
   /** Called on save status transitions. */
@@ -64,6 +67,10 @@ function bomEquals(
 
 function photoOverlayEquals(a: PhotoOverlayState | null | undefined, b: PhotoOverlayState | null | undefined): boolean {
   return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+function moodBoardEquals(a: MoodBoardState | null | undefined, b: MoodBoardState | null | undefined): boolean {
+  return JSON.stringify(a ?? { items: [] }) === JSON.stringify(b ?? { items: [] });
 }
 
 /**
@@ -136,12 +143,14 @@ export function useAutoSave(
       }
 
       const bomChanged = !bomEquals(current.bom, saved.bom);
+      const moodBoardChanged = !moodBoardEquals(current.mood_board, saved.mood_board);
 
       return {
         projectDirty: hasProjectChanges ? projectDirty : null,
         bomChanged,
+        moodBoardChanged,
         sceneChanged,
-        hasAnyChanges: hasProjectChanges || bomChanged,
+        hasAnyChanges: hasProjectChanges || bomChanged || moodBoardChanged,
       };
     },
     []
@@ -155,7 +164,7 @@ export function useAutoSave(
 
     const current = { ...currentRef.current };
     const saved = savedRef.current;
-    const { projectDirty, bomChanged, sceneChanged, hasAnyChanges } =
+    const { projectDirty, bomChanged, moodBoardChanged, sceneChanged, hasAnyChanges } =
       computeDirtyFields(current, saved);
 
     if (!hasAnyChanges) {
@@ -175,6 +184,9 @@ export function useAutoSave(
       }
       if (bomChanged) {
         promises.push(cbRef.current.onSaveBom(current.bom));
+      }
+      if (moodBoardChanged && cbRef.current.onSaveMoodBoard) {
+        promises.push(cbRef.current.onSaveMoodBoard(current.mood_board ?? { items: [] }));
       }
 
       await Promise.all(promises);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   MarketplaceSupplierCheckoutInput,
   MaterialSubstitutionResponse,
   NeighborhoodInsightsResponse,
+  MoodBoardState,
   AppNotification,
   ProjectVersionCompareResponse,
   ProjectVersionsResponse,
@@ -459,6 +460,17 @@ export const api = {
     apiFetch(`/projects/${id}/thumbnail`, {
       method: "PUT",
       body: JSON.stringify({ thumbnail }),
+    }),
+  saveMoodBoard: (
+    id: string,
+    moodBoard: MoodBoardState | null | undefined,
+    collaborationClientId?: string | null,
+  ): Promise<{ ok: boolean; mood_board: MoodBoardState }> =>
+    apiFetch(`/projects/${id}/mood-board`, {
+      method: "PUT",
+      body: JSON.stringify(collaborationClientId
+        ? { mood_board: moodBoard ?? { items: [] }, collaboration_client_id: collaborationClientId }
+        : { mood_board: moodBoard ?? { items: [] } }),
     }),
 
   getMaterials: () => apiFetch("/materials"),

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -58,6 +58,7 @@ export interface Project {
   cost_band?: GalleryCostRange;
   material_highlights?: string[];
   building_info?: BuildingInfo | null;
+  mood_board?: MoodBoardState | null;
   permit_metadata?: RyhtiPermitMetadata | null;
   photo_overlay?: PhotoOverlayState | null;
   share_token?: string | null;
@@ -135,6 +136,50 @@ export interface PhotoOverlayState {
   offset_y: number;
   scale: number;
   rotation: number;
+  updated_at?: string;
+}
+
+export type MoodBoardItemType = "material" | "photo" | "color" | "note";
+
+export interface MoodBoardBaseItem {
+  id: string;
+  type: MoodBoardItemType;
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  title?: string;
+}
+
+export interface MoodBoardMaterialItem extends MoodBoardBaseItem {
+  type: "material";
+  material_id: string;
+}
+
+export interface MoodBoardPhotoItem extends MoodBoardBaseItem {
+  type: "photo";
+  src: string;
+  file_name?: string;
+}
+
+export interface MoodBoardColorItem extends MoodBoardBaseItem {
+  type: "color";
+  color: string;
+}
+
+export interface MoodBoardNoteItem extends MoodBoardBaseItem {
+  type: "note";
+  text: string;
+}
+
+export type MoodBoardItem =
+  | MoodBoardMaterialItem
+  | MoodBoardPhotoItem
+  | MoodBoardColorItem
+  | MoodBoardNoteItem;
+
+export interface MoodBoardState {
+  items: MoodBoardItem[];
   updated_at?: string;
 }
 


### PR DESCRIPTION
Fixes #150.

Summary:
- Adds persistent project mood boards backed by a new JSONB column and authenticated save endpoint.
- Adds an editor Mood/Tunnelma panel with free-form material, photo, color, and note cards, selection/removal, drag positioning, mobile masonry layout, and rough material total.
- Bridges mood-board material cards into the BOM via per-card add actions and drag-to-BOM material drops.

Validation:
- npm test -- --run src/__tests__/projects.test.ts (api)
- npm test -- --run src/__tests__/mood-board-panel.test.tsx src/__tests__/useAutoSave.test.ts (web)
- npx tsc --noEmit (api)
- npx tsc --noEmit (web)
- npm test -- --run (api)
- npm test -- --run (web)
- npm run build (api)
- npm run build (web; existing experimental.viewTransition warning only)