### PR TITLE
fix: enforce production JWT secret

### DIFF
--- a/api/src/__tests__/secrets.test.ts
+++ b/api/src/__tests__/secrets.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertProductionSecrets,
+  DEV_JWT_SECRET,
+  getJwtSecret,
+  getViewerIpHashSalt,
+} from "../secrets";
+
+const originalEnv = {
+  NODE_ENV: process.env.NODE_ENV,
+  JWT_SECRET: process.env.JWT_SECRET,
+  VIEW_IP_HASH_SALT: process.env.VIEW_IP_HASH_SALT,
+};
+
+function restoreEnv() {
+  process.env.NODE_ENV = originalEnv.NODE_ENV;
+  if (originalEnv.JWT_SECRET === undefined) delete process.env.JWT_SECRET;
+  else process.env.JWT_SECRET = originalEnv.JWT_SECRET;
+  if (originalEnv.VIEW_IP_HASH_SALT === undefined) delete process.env.VIEW_IP_HASH_SALT;
+  else process.env.VIEW_IP_HASH_SALT = originalEnv.VIEW_IP_HASH_SALT;
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe("API secret configuration", () => {
+  it("uses the development JWT fallback outside production", () => {
+    process.env.NODE_ENV = "test";
+    delete process.env.JWT_SECRET;
+
+    expect(getJwtSecret()).toBe(DEV_JWT_SECRET);
+  });
+
+  it("trims and uses an explicit JWT_SECRET outside production", () => {
+    process.env.NODE_ENV = "test";
+    process.env.JWT_SECRET = "  explicit-test-secret  ";
+
+    expect(getJwtSecret()).toBe("explicit-test-secret");
+  });
+
+  it("fails production startup when JWT_SECRET is missing", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.JWT_SECRET;
+
+    expect(() => assertProductionSecrets()).toThrow("JWT_SECRET must be set");
+  });
+
+  it("fails production startup when JWT_SECRET is empty", () => {
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "   ";
+
+    expect(() => assertProductionSecrets()).toThrow("JWT_SECRET must be set");
+  });
+
+  it("fails production startup when JWT_SECRET is the public dev fallback", () => {
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = DEV_JWT_SECRET;
+
+    expect(() => assertProductionSecrets()).toThrow("non-default");
+  });
+
+  it("allows production with a non-default JWT_SECRET", () => {
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "prod-secret-from-render-or-fly";
+    delete process.env.VIEW_IP_HASH_SALT;
+
+    expect(() => assertProductionSecrets()).not.toThrow();
+    expect(getJwtSecret()).toBe("prod-secret-from-render-or-fly");
+    expect(getViewerIpHashSalt()).toBe("prod-secret-from-render-or-fly");
+  });
+
+  it("uses VIEW_IP_HASH_SALT when explicitly configured", () => {
+    process.env.NODE_ENV = "production";
+    process.env.JWT_SECRET = "prod-secret-from-render-or-fly";
+    process.env.VIEW_IP_HASH_SALT = "  viewer-salt  ";
+
+    expect(getViewerIpHashSalt()).toBe("viewer-salt");
+  });
+});

--- a/api/src/auth.ts
+++ b/api/src/auth.ts
@@ -5,8 +5,7 @@ import bcrypt from "bcryptjs";
 import { query } from "./db";
 import { sendPasswordResetEmail, sendVerificationEmail } from "./email";
 import { Role, normalizeRole, ROLES, isValidRole } from "./permissions";
-
-const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+import { getJwtSecret } from "./secrets";
 
 export interface AuthUser {
   id: string;
@@ -33,7 +32,7 @@ const ACCESS_TOKEN_SECONDS = 15 * 60;
 const REFRESH_GRACE_SECONDS = 60;
 
 export function signToken(user: AuthUser): string {
-  return jwt.sign(user, JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRES });
+  return jwt.sign(user, getJwtSecret(), { expiresIn: ACCESS_TOKEN_EXPIRES });
 }
 
 /** Returns the absolute expiry timestamp (epoch seconds) for a freshly-signed token. */
@@ -49,13 +48,13 @@ export function tokenExpiresAt(): number {
 export function verifyForRefresh(token: string): AuthUser | null {
   // First try normal verification
   try {
-    const payload = jwt.verify(token, JWT_SECRET) as AuthUser;
+    const payload = jwt.verify(token, getJwtSecret()) as AuthUser;
     return { id: payload.id, email: payload.email, role: payload.role };
   } catch (err) {
     // If expired, check grace window
     if (err instanceof jwt.TokenExpiredError) {
       try {
-        const payload = jwt.verify(token, JWT_SECRET, {
+        const payload = jwt.verify(token, getJwtSecret(), {
           ignoreExpiration: true,
         }) as AuthUser & { exp: number };
         const expiredAgo = Math.floor(Date.now() / 1000) - payload.exp;
@@ -76,7 +75,7 @@ export function requireAuth(req: Request, res: Response, next: NextFunction) {
     return res.status(401).json({ error: "Missing authorization header" });
   }
   try {
-    const payload = jwt.verify(header.slice(7), JWT_SECRET) as AuthUser;
+    const payload = jwt.verify(header.slice(7), getJwtSecret()) as AuthUser;
     req.user = payload;
     next();
   } catch {

--- a/api/src/collaboration.ts
+++ b/api/src/collaboration.ts
@@ -4,8 +4,8 @@ import jwt from "jsonwebtoken";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { query } from "./db";
 import logger from "./logger";
+import { getJwtSecret } from "./secrets";
 
-const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
 const COLORS = ["#e5a04b", "#7ab3e0", "#8bc48b", "#d4a0e0", "#f0b86a", "#e07a7a"];
 const MAX_SCENE_BYTES = 512 * 1024;
 
@@ -148,7 +148,7 @@ async function authorizeProjectAccess(projectId: string, token: string | null, s
   let payload: AuthPayload | null = null;
   if (token) {
     try {
-      payload = jwt.verify(token, JWT_SECRET) as AuthPayload;
+      payload = jwt.verify(token, getJwtSecret()) as AuthPayload;
     } catch {
       if (!shareToken) return { authorized: false, payload: null };
     }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -47,6 +47,7 @@ import { logAuditEvent } from "./audit";
 import { sendEmail } from "./email";
 import { hashViewerIp, logProjectView } from "./notifications";
 import { installCollaborationServer } from "./collaboration";
+import { assertProductionSecrets, getJwtSecret } from "./secrets";
 
 // ---------------------------------------------------------------------------
 // Sentry — initialize before anything else so it can instrument the app
@@ -60,7 +61,7 @@ if (process.env.SENTRY_DSN) {
   });
 }
 
-const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+assertProductionSecrets();
 
 const app = express();
 const PORT = parseInt(process.env.PORT || "3001");
@@ -117,7 +118,7 @@ function extractUserId(req: express.Request): string | null {
   const header = req.headers.authorization;
   if (!header?.startsWith("Bearer ")) return null;
   try {
-    const decoded = jwt.verify(header.slice(7), JWT_SECRET) as AuthUser;
+    const decoded = jwt.verify(header.slice(7), getJwtSecret()) as AuthUser;
     return decoded.id || null;
   } catch {
     return null;

--- a/api/src/notifications.ts
+++ b/api/src/notifications.ts
@@ -1,6 +1,7 @@
 import crypto from "crypto";
 import { query } from "./db";
 import { sendEmail } from "./email";
+import { getViewerIpHashSalt } from "./secrets";
 
 export interface WeeklyDigestProject {
   id: string;
@@ -32,7 +33,7 @@ const VIEW_DEDUPE_WINDOW = "1 hour";
 const PRICE_CHANGE_THRESHOLD = 0.05;
 
 export function hashViewerIp(ip: string | undefined | null): string {
-  const salt = process.env.VIEW_IP_HASH_SALT || process.env.JWT_SECRET || "helscoop-dev-secret";
+  const salt = getViewerIpHashSalt();
   return crypto
     .createHash("sha256")
     .update(`${salt}:${ip || "unknown"}`)

--- a/api/src/secrets.ts
+++ b/api/src/secrets.ts
@@ -1,0 +1,35 @@
+export const DEV_JWT_SECRET = "helscoop-dev-secret";
+
+function envName(): string {
+  return process.env.NODE_ENV || "development";
+}
+
+function normalizedEnv(name: string): string {
+  return (process.env[name] || "").trim();
+}
+
+function isProduction(): boolean {
+  return envName() === "production";
+}
+
+export function getJwtSecret(): string {
+  const secret = normalizedEnv("JWT_SECRET");
+  if (isProduction()) {
+    if (!secret || secret === DEV_JWT_SECRET) {
+      throw new Error("JWT_SECRET must be set to a non-default value in production");
+    }
+    return secret;
+  }
+  return secret || DEV_JWT_SECRET;
+}
+
+export function getViewerIpHashSalt(): string {
+  const salt = normalizedEnv("VIEW_IP_HASH_SALT");
+  if (salt) return salt;
+  return getJwtSecret();
+}
+
+export function assertProductionSecrets(): void {
+  getJwtSecret();
+  getViewerIpHashSalt();
+}


### PR DESCRIPTION
Fixes #1012. Adds shared API secret helper, production JWT_SECRET fail-fast validation, call-site cleanup, and tests. Validation: focused API tests, typecheck, full API tests, API build, git diff --check.