### PR TITLE
fix: stop logging auth email tokens

### DIFF
--- a/api/src/__tests__/email-unit.test.ts
+++ b/api/src/__tests__/email-unit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   sendEmail,
   sendPasswordResetEmail,
@@ -7,10 +7,45 @@ import {
 } from "../email";
 
 let consoleSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+const originalEnv = {
+  APP_URL: process.env.APP_URL,
+  EMAIL_FROM: process.env.EMAIL_FROM,
+  NODE_ENV: process.env.NODE_ENV,
+  RESEND_API_KEY: process.env.RESEND_API_KEY,
+};
 
 beforeEach(() => {
+  process.env.NODE_ENV = "test";
+  process.env.APP_URL = "https://app.helscoop.test";
+  delete process.env.EMAIL_FROM;
+  delete process.env.RESEND_API_KEY;
   consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 });
+
+afterEach(() => {
+  restoreEnv("APP_URL", originalEnv.APP_URL);
+  restoreEnv("EMAIL_FROM", originalEnv.EMAIL_FROM);
+  restoreEnv("NODE_ENV", originalEnv.NODE_ENV);
+  restoreEnv("RESEND_API_KEY", originalEnv.RESEND_API_KEY);
+  vi.restoreAllMocks();
+});
+
+function restoreEnv(name: keyof typeof originalEnv, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function loggedOutput() {
+  return [
+    ...consoleSpy.mock.calls.flat().map(String),
+    ...consoleErrorSpy.mock.calls.flat().map(String),
+  ].join("\n");
+}
 
 describe("sendEmail", () => {
   it("returns true", async () => {
@@ -61,14 +96,24 @@ describe("sendPasswordResetEmail", () => {
     expect(result).toBe(true);
   });
 
-  it("logs email and token", async () => {
+  it("logs redacted metadata without the raw token", async () => {
     await sendPasswordResetEmail("user@example.com", "tok-abc");
+    const output = loggedOutput();
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("user@example.com"),
+      expect.stringContaining("Password reset"),
     );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("tok-abc"),
-    );
+    expect(output).toContain("us**@example.com");
+    expect(output).toContain("token [redacted]");
+    expect(output).not.toContain("tok-abc");
+  });
+
+  it("fails safe in production when no provider is configured", async () => {
+    process.env.NODE_ENV = "production";
+    const result = await sendPasswordResetEmail("user@example.com", "prod-reset-token");
+    const output = loggedOutput();
+    expect(result).toBe(false);
+    expect(output).toContain("RESEND_API_KEY is not configured");
+    expect(output).not.toContain("prod-reset-token");
   });
 });
 
@@ -78,14 +123,24 @@ describe("sendVerificationEmail", () => {
     expect(result).toBe(true);
   });
 
-  it("logs email and token", async () => {
+  it("logs redacted metadata without the raw token", async () => {
     await sendVerificationEmail("new@example.com", "vrf-123");
+    const output = loggedOutput();
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("new@example.com"),
+      expect.stringContaining("Verification"),
     );
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("vrf-123"),
-    );
+    expect(output).toContain("ne*@example.com");
+    expect(output).toContain("token [redacted]");
+    expect(output).not.toContain("vrf-123");
+  });
+
+  it("fails safe in production when no provider is configured", async () => {
+    process.env.NODE_ENV = "production";
+    const result = await sendVerificationEmail("new@example.com", "prod-verify-token");
+    const output = loggedOutput();
+    expect(result).toBe(false);
+    expect(output).toContain("RESEND_API_KEY is not configured");
+    expect(output).not.toContain("prod-verify-token");
   });
 });
 

--- a/api/src/email.ts
+++ b/api/src/email.ts
@@ -1,26 +1,127 @@
+import { Resend } from "resend";
+
 export interface EmailAttachment {
   filename: string;
   content: Buffer | string;
   contentType: string;
 }
 
+const DEFAULT_EMAIL_FROM = "noreply@helscoop.fi";
+
+let resendClient: Resend | null = null;
+let resendClientKey: string | null = null;
+
+function isProduction() {
+  return process.env.NODE_ENV === "production";
+}
+
+function cleanEnv(name: string) {
+  const value = process.env[name]?.trim();
+  return value || null;
+}
+
+function getAppUrl() {
+  return (cleanEnv("APP_URL") || "https://helscoop.fi").replace(/\/+$/, "");
+}
+
+function getEmailFrom() {
+  return cleanEnv("EMAIL_FROM") || DEFAULT_EMAIL_FROM;
+}
+
+function getResendClient() {
+  const apiKey = cleanEnv("RESEND_API_KEY");
+  if (!apiKey) return null;
+  if (!resendClient || resendClientKey !== apiKey) {
+    resendClient = new Resend(apiKey);
+    resendClientKey = apiKey;
+  }
+  return resendClient;
+}
+
+function maskEmail(email: string) {
+  const [local = "", domain = ""] = email.split("@");
+  if (!domain) return "[redacted-email]";
+  const visible = local.slice(0, 2);
+  return `${visible}${"*".repeat(Math.max(1, local.length - visible.length))}@${domain}`;
+}
+
+function sensitiveFallback(messageType: string, email: string) {
+  const destination = maskEmail(email);
+  if (isProduction()) {
+    console.error(`[EMAIL] ${messageType} email not sent: RESEND_API_KEY is not configured for ${destination}`);
+    return false;
+  }
+  console.log(`[EMAIL] ${messageType} email would be sent to ${destination} with token [redacted]`);
+  return true;
+}
+
 export async function sendEmail(to: string, subject: string, body: string, attachments: EmailAttachment[] = []): Promise<boolean> {
+  const client = getResendClient();
+  if (client) {
+    const result = await client.emails.send({
+      from: getEmailFrom(),
+      to,
+      subject,
+      text: body,
+      attachments: attachments.map((attachment) => ({
+        filename: attachment.filename,
+        content: attachment.content,
+        contentType: attachment.contentType,
+      })),
+    });
+    if (result.error) {
+      console.error(`[EMAIL] Failed to send email to ${maskEmail(to)}: ${result.error.message}`);
+      return false;
+    }
+    return true;
+  }
+
   const attachmentSummary = attachments.length > 0 ? ` with ${attachments.length} attachment(s)` : "";
+  if (isProduction()) {
+    console.error(`[EMAIL] Email not sent: RESEND_API_KEY is not configured for ${maskEmail(to)}: ${subject}${attachmentSummary}`);
+    return false;
+  }
   console.log(`[EMAIL] Email would be sent to ${to}: ${subject}${attachmentSummary}`);
   return true;
 }
 
 export async function sendPasswordResetEmail(email: string, token: string): Promise<boolean> {
-  console.log(`[EMAIL] Password reset email would be sent to ${email} with token ${token}`);
-  return true;
+  const resetUrl = `${getAppUrl()}/reset-password?token=${encodeURIComponent(token)}`;
+  const body = [
+    "Use the link below to reset your Helscoop password.",
+    "",
+    resetUrl,
+    "",
+    "If you did not request this, ignore this email.",
+  ].join("\n");
+
+  const client = getResendClient();
+  if (!client) return sensitiveFallback("Password reset", email);
+
+  return sendEmail(email, "Reset your Helscoop password", body);
 }
 
 export async function sendVerificationEmail(email: string, token: string): Promise<boolean> {
-  console.log(`[EMAIL] Verification email would be sent to ${email} with token ${token}`);
-  return true;
+  const verifyUrl = `${getAppUrl()}/verify-email?token=${encodeURIComponent(token)}`;
+  const body = [
+    "Use the link below to verify your Helscoop email address.",
+    "",
+    verifyUrl,
+    "",
+    "If you did not create this account, ignore this email.",
+  ].join("\n");
+
+  const client = getResendClient();
+  if (!client) return sensitiveFallback("Verification", email);
+
+  return sendEmail(email, "Verify your Helscoop email", body);
 }
 
 export async function sendPriceAlertEmail(email: string, alertData: Record<string, unknown>): Promise<boolean> {
-  console.log(`[EMAIL] Price alert email would be sent to ${email}`);
-  return true;
+  const material = typeof alertData.material === "string" ? alertData.material : "a watched material";
+  return sendEmail(
+    email,
+    "Helscoop price alert",
+    `Price alert: ${material} has a new price update in Helscoop.`,
+  );
 }


### PR DESCRIPTION
Fixes #1011.

Summary:
- Sends configured email through Resend when `RESEND_API_KEY` is present.
- Replaces password-reset and verification token console output with redacted metadata-only fallback logs.
- Makes production email fallback fail closed when no provider is configured, without exposing raw tokens.
- Routes price-alert helper through the shared email provider/fallback path.

Validation:
- npm test -- --run src/__tests__/email-unit.test.ts
- npx tsc --noEmit
- npm test -- --run
- npm run build
- git diff --check