### PR TITLE
fix: align Playwright e2e database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ git submodule update --init --recursive
 
 This repository is mostly autonomously written by an LLM.
 
+### Browser E2E
+
+The Playwright browser suite expects the repo-local Docker Postgres service:
+
+```
+cd api && npm ci
+cd ../web && npm ci
+cd ../e2e && npm ci
+npm run test:local
+```
+
+`npm run test:local` starts `docker compose up -d db`, waits for the `helscoop` database, runs API migrations, then launches the API and web Playwright web servers. The default database URL is `postgres://helscoop:helscoop_dev@localhost:5433/helscoop`, matching `docker-compose.yml`.
+
+Override the database when needed:
+
+```
+E2E_DATABASE_URL=postgres://user:pass@localhost:5433/db npm run test:local -- tests/auth.spec.ts
+```
+
 ### Keyboard Shortcuts
 
 | Key | Action |

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test": "playwright test",
+    "test:local": "node scripts/run-local.mjs",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -2,8 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 const API_PORT = 3051;
 const WEB_PORT = 3052;
+const DEFAULT_E2E_DATABASE_URL = "postgres://helscoop:helscoop_dev@localhost:5433/helscoop";
 
 process.env.TEST_API_URL ??= `http://localhost:${API_PORT}`;
+process.env.E2E_DATABASE_URL ??= DEFAULT_E2E_DATABASE_URL;
 
 export default defineConfig({
   testDir: "./tests",
@@ -39,7 +41,7 @@ export default defineConfig({
         ...process.env,
         PORT: String(API_PORT),
         CORS_ORIGIN: `http://localhost:${WEB_PORT}`,
-        DATABASE_URL: "postgres://dingcad:dingcad_dev@localhost:5433/dingcad",
+        DATABASE_URL: process.env.E2E_DATABASE_URL,
         JWT_SECRET: "helscoop-e2e-test-secret",
         NODE_ENV: "test",
         E2E: "1",

--- a/e2e/scripts/run-local.mjs
+++ b/e2e/scripts/run-local.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const e2eDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(e2eDir, "..");
+const databaseUrl = process.env.E2E_DATABASE_URL || "postgres://helscoop:helscoop_dev@localhost:5433/helscoop";
+const apiUrl = process.env.TEST_API_URL || "http://localhost:3051";
+
+const passthroughArgs = process.argv.slice(2);
+
+function requirePath(relativePath, installHint) {
+  const fullPath = path.join(repoRoot, relativePath);
+  if (!existsSync(fullPath)) {
+    console.error(`Missing ${relativePath}. ${installHint}`);
+    process.exit(1);
+  }
+}
+
+function run(command, args, options = {}) {
+  const {
+    cwd = repoRoot,
+    env = process.env,
+    quiet = false,
+    timeoutMs = 120_000,
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: quiet ? "ignore" : "inherit",
+    });
+
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          child.kill("SIGTERM");
+          reject(new Error(`${command} ${args.join(" ")} timed out after ${timeoutMs}ms`));
+        }, timeoutMs)
+      : null;
+
+    child.on("error", (error) => {
+      if (timer) clearTimeout(timer);
+      reject(error);
+    });
+
+    child.on("exit", (code) => {
+      if (timer) clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(" ")} exited with ${code}`));
+      }
+    });
+  });
+}
+
+async function waitForDb() {
+  for (let attempt = 1; attempt <= 30; attempt += 1) {
+    try {
+      await run("docker", ["compose", "exec", "-T", "db", "pg_isready", "-U", "helscoop", "-d", "helscoop"], {
+        quiet: true,
+        timeoutMs: 5_000,
+      });
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+    }
+  }
+
+  throw new Error("Postgres did not become ready via docker compose service 'db'.");
+}
+
+async function main() {
+  requirePath("api/node_modules/.bin/tsx", "Run `cd api && npm ci`.");
+  requirePath("web/node_modules/.bin/next", "Run `cd web && npm ci`.");
+  requirePath("e2e/node_modules/.bin/playwright", "Run `cd e2e && npm ci`.");
+
+  console.log("Starting docker compose Postgres service...");
+  await run("docker", ["compose", "up", "-d", "db"]);
+
+  console.log("Waiting for Postgres readiness...");
+  await waitForDb();
+
+  console.log("Applying API migrations...");
+  await run("npm", ["--prefix", "api", "run", "db:migrate"], {
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+    },
+  });
+
+  console.log("Running Playwright E2E...");
+  await run("npx", ["playwright", "test", ...passthroughArgs], {
+    cwd: e2eDir,
+    env: {
+      ...process.env,
+      E2E_DATABASE_URL: databaseUrl,
+      TEST_API_URL: apiUrl,
+    },
+    timeoutMs: 0,
+  });
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -114,13 +114,13 @@ test.describe("Authentication", () => {
     const res = await page.request.post(`${API_URL}/auth/register`, {
       data: { email, password: testPassword, name: "Persist Test" },
     });
-    const { token } = await res.json();
+    await res.json();
 
     await page.goto("/");
-    await page.evaluate((t) => {
-      localStorage.setItem("helscoop_token", t);
+    await page.evaluate(() => {
+      localStorage.setItem("helscoop_session_active", "true");
       localStorage.setItem("helscoop_onboarding_completed", "true");
-    }, token);
+    });
     await page.reload();
 
     await expect(

--- a/e2e/tests/full-flow.spec.ts
+++ b/e2e/tests/full-flow.spec.ts
@@ -36,7 +36,9 @@ test.describe("Full User Flows", () => {
     await page.getByRole("button", { name: /luo tili|create account/i }).click({ force: true });
 
     await expect(page.getByText(/omat projektit|my projects/i)).toBeVisible({ timeout: 15_000 });
-    userToken = await page.evaluate(() => localStorage.getItem("helscoop_token") || "");
+    const sessionActive = await page.evaluate(() => localStorage.getItem("helscoop_session_active") || "");
+    expect(sessionActive).toBe("true");
+    userToken = await apiLogin(page);
     expect(userToken).toBeTruthy();
   });
 
@@ -48,7 +50,7 @@ test.describe("Full User Flows", () => {
     if (await logoutBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
       await logoutBtn.click();
     } else {
-      await page.evaluate(() => localStorage.removeItem("helscoop_token"));
+      await page.evaluate(() => localStorage.removeItem("helscoop_session_active"));
       await page.reload();
     }
     await page.waitForLoadState("networkidle");
@@ -76,7 +78,7 @@ test.describe("Full User Flows", () => {
 
   test("protected routes redirect without auth", async ({ page }) => {
     await page.goto("/");
-    await page.evaluate(() => localStorage.removeItem("helscoop_token"));
+    await page.evaluate(() => localStorage.removeItem("helscoop_session_active"));
     await page.goto("/project/some-fake-id");
     await page.waitForTimeout(3000);
     expect(page.url()).not.toContain("/project/");

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -43,7 +43,7 @@ export async function loginUser(
 export async function setAuthToken(page: Page, token: string): Promise<void> {
   await page.goto("/");
   await page.evaluate((t) => {
-    localStorage.setItem("helscoop_token", t);
+    if (t) localStorage.setItem("helscoop_session_active", "true");
     localStorage.setItem("helscoop_onboarding_completed", "true");
   }, token);
   await page.reload();
@@ -62,7 +62,7 @@ export async function setAuthToken(page: Page, token: string): Promise<void> {
       .catch(() => false);
     if (hasLoginForm) {
       await page.evaluate((t) => {
-        localStorage.setItem("helscoop_token", t);
+        if (t) localStorage.setItem("helscoop_session_active", "true");
       }, token);
       await page.reload();
       await page.waitForLoadState("networkidle");

--- a/e2e/tests/landing-auth.spec.ts
+++ b/e2e/tests/landing-auth.spec.ts
@@ -289,16 +289,17 @@ test.describe("Registration flow", () => {
     await page.goto("/");
     await dismissOnboarding(page);
 
-    // Log in via API to get the token
+    // Log in via API; the API response sets the httpOnly session cookie in
+    // Playwright's browser context, while the web app uses a non-secret
+    // localStorage hint to decide whether to attempt authenticated loading.
     const res = await page.request.post(`${API_URL}/auth/login`, {
       data: { email: testEmail, password: testPassword },
     });
-    const { token } = await res.json();
+    await res.json();
 
-    // Set token in localStorage
-    await page.evaluate((t) => {
-      localStorage.setItem("helscoop_token", t);
-    }, token);
+    await page.evaluate(() => {
+      localStorage.setItem("helscoop_session_active", "true");
+    });
     await page.reload();
     await page.waitForLoadState("networkidle");
 
@@ -410,8 +411,8 @@ test.describe("Login flow", () => {
     if (await logoutBtn.first().isVisible({ timeout: 3_000 }).catch(() => false)) {
       await logoutBtn.first().click();
     } else {
-      // Fallback: clear token manually
-      await page.evaluate(() => localStorage.removeItem("helscoop_token"));
+      // Fallback: clear the non-secret session hint manually.
+      await page.evaluate(() => localStorage.removeItem("helscoop_session_active"));
       await page.reload();
     }
 


### PR DESCRIPTION
Fixes #1019.

Summary:
- Aligns Playwright API server defaults with docker-compose Postgres (`helscoop`/`helscoop_dev` on localhost:5433).
- Adds `E2E_DATABASE_URL` override support for custom local databases.
- Adds `npm run test:local` in `e2e/` to start compose Postgres, wait for readiness, run API migrations, and then run Playwright.
- Updates E2E auth helpers/tests for the current httpOnly-cookie session model instead of legacy `helscoop_token` localStorage.
- Documents the local E2E command in README.

Validation:
- cd e2e && npm ci
- cd e2e && npx playwright test --list (89 tests listed)
- node --check e2e/scripts/run-local.mjs
- rg -n "helscoop_token" e2e/tests returns no matches
- git diff --check

Note:
- I did not run the full browser suite locally because this machine's Docker client/daemon is currently hanging; the new runner fails fast with explicit prerequisite checks before attempting Docker.