### PR TITLE
fix: harden assembly checklist storage

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -32,6 +32,11 @@ import GuidedRenovationWizard from "@/components/GuidedRenovationWizard";
 import TaloyhtioPanel from "@/components/TaloyhtioPanel";
 import { parseSceneParams, applyParamToScript } from "@/lib/scene-interpreter";
 import {
+  getAssemblyProgressStorageKey,
+  readAssemblyProgressFromStorage,
+  writeAssemblyProgressToStorage,
+} from "@/lib/assembly-progress-storage";
+import {
   analyzeSceneGeometry,
   suggestGeometryBomUpdates,
   type GeometryBomSuggestion,
@@ -1328,21 +1333,15 @@ export default function ProjectPage() {
     setAssemblyProgressLoaded(false);
     if (typeof window === "undefined") return;
     const validIds = new Set(assemblyGuide.steps.map((step) => step.id));
-    const storageKey = `helscoop_assembly_progress_${projectId}`;
-    try {
-      const saved = JSON.parse(window.localStorage.getItem(storageKey) || "[]") as string[];
-      setAssemblyCompletedStepIds(new Set(saved.filter((id) => validIds.has(id))));
-    } catch {
-      setAssemblyCompletedStepIds(new Set());
-    } finally {
-      setAssemblyProgressLoaded(true);
-    }
+    const storageKey = getAssemblyProgressStorageKey(projectId);
+    setAssemblyCompletedStepIds(readAssemblyProgressFromStorage(window.localStorage, storageKey, validIds));
+    setAssemblyProgressLoaded(true);
   }, [assemblyStepSignature, assemblyGuide.steps, projectId]);
 
   useEffect(() => {
     if (!assemblyProgressLoaded || typeof window === "undefined") return;
-    const storageKey = `helscoop_assembly_progress_${projectId}`;
-    window.localStorage.setItem(storageKey, JSON.stringify(Array.from(assemblyCompletedStepIds)));
+    const storageKey = getAssemblyProgressStorageKey(projectId);
+    writeAssemblyProgressToStorage(window.localStorage, storageKey, assemblyCompletedStepIds);
   }, [assemblyCompletedStepIds, assemblyProgressLoaded, projectId]);
 
   useEffect(() => {

--- a/web/src/lib/__tests__/assembly-progress-storage.test.ts
+++ b/web/src/lib/__tests__/assembly-progress-storage.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  getAssemblyProgressStorageKey,
+  readAssemblyProgressFromStorage,
+  writeAssemblyProgressToStorage,
+} from "@/lib/assembly-progress-storage";
+
+describe("assembly progress storage", () => {
+  const storageKey = getAssemblyProgressStorageKey("project-1");
+  const validStepIds = new Set(["foundation", "walls", "roof"]);
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("removes corrupt JSON and returns empty progress", () => {
+    localStorage.setItem(storageKey, "{not valid json");
+
+    const progress = readAssemblyProgressFromStorage(localStorage, storageKey, validStepIds);
+
+    expect(Array.from(progress)).toEqual([]);
+    expect(localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it("removes non-array payloads and returns empty progress", () => {
+    localStorage.setItem(storageKey, JSON.stringify({ foundation: true }));
+
+    const progress = readAssemblyProgressFromStorage(localStorage, storageKey, validStepIds);
+
+    expect(Array.from(progress)).toEqual([]);
+    expect(localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it("filters stale, duplicate, and non-string step ids", () => {
+    localStorage.setItem(storageKey, JSON.stringify(["walls", "missing", "walls", 12, "roof"]));
+
+    const progress = readAssemblyProgressFromStorage(localStorage, storageKey, validStepIds);
+
+    expect(Array.from(progress)).toEqual(["walls", "roof"]);
+    expect(localStorage.getItem(storageKey)).toBe(JSON.stringify(["walls", "roof"]));
+  });
+
+  it("writes completed ids as a JSON array", () => {
+    writeAssemblyProgressToStorage(localStorage, storageKey, new Set(["foundation", "roof"]));
+
+    expect(localStorage.getItem(storageKey)).toBe(JSON.stringify(["foundation", "roof"]));
+  });
+
+  it("treats storage failures as empty best-effort persistence", () => {
+    const failingStorage = {
+      getItem: () => {
+        throw new Error("storage unavailable");
+      },
+      removeItem: () => {
+        throw new Error("storage unavailable");
+      },
+      setItem: () => {
+        throw new Error("storage unavailable");
+      },
+    };
+
+    expect(readAssemblyProgressFromStorage(failingStorage, storageKey, validStepIds)).toEqual(new Set());
+    expect(() => writeAssemblyProgressToStorage(failingStorage, storageKey, new Set(["walls"]))).not.toThrow();
+  });
+});

--- a/web/src/lib/assembly-progress-storage.ts
+++ b/web/src/lib/assembly-progress-storage.ts
@@ -1,0 +1,66 @@
+export const ASSEMBLY_PROGRESS_STORAGE_PREFIX = "helscoop_assembly_progress_";
+
+type AssemblyProgressStorage = Pick<Storage, "getItem" | "removeItem" | "setItem">;
+
+export function getAssemblyProgressStorageKey(projectId: string): string {
+  return `${ASSEMBLY_PROGRESS_STORAGE_PREFIX}${projectId}`;
+}
+
+export function readAssemblyProgressFromStorage(
+  storage: AssemblyProgressStorage,
+  storageKey: string,
+  validStepIds: Set<string>,
+): Set<string> {
+  let raw: string | null;
+
+  try {
+    raw = storage.getItem(storageKey);
+  } catch {
+    return new Set();
+  }
+
+  if (raw === null) return new Set();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    removeAssemblyProgress(storage, storageKey);
+    return new Set();
+  }
+
+  if (!Array.isArray(parsed)) {
+    removeAssemblyProgress(storage, storageKey);
+    return new Set();
+  }
+
+  const normalized = Array.from(
+    new Set(parsed.filter((stepId): stepId is string => typeof stepId === "string" && validStepIds.has(stepId))),
+  );
+  const normalizedJson = JSON.stringify(normalized);
+  if (normalizedJson !== raw) {
+    writeAssemblyProgressToStorage(storage, storageKey, new Set(normalized));
+  }
+
+  return new Set(normalized);
+}
+
+export function writeAssemblyProgressToStorage(
+  storage: AssemblyProgressStorage,
+  storageKey: string,
+  completedStepIds: Set<string>,
+): void {
+  try {
+    storage.setItem(storageKey, JSON.stringify(Array.from(completedStepIds)));
+  } catch {
+    // A full, disabled, or unavailable localStorage should not break the editor.
+  }
+}
+
+function removeAssemblyProgress(storage: AssemblyProgressStorage, storageKey: string): void {
+  try {
+    storage.removeItem(storageKey);
+  } catch {
+    // Ignore cleanup failures for the same reason writes are best-effort.
+  }
+}


### PR DESCRIPTION
Fixes #1009.

Summary:
- Moves assembly checklist persistence into a safe storage helper.
- Removes corrupt or non-array persisted progress instead of letting bad localStorage poison the editor.
- Filters stale, duplicate, and non-string step IDs before restoring progress.
- Treats localStorage read/write failures as best-effort so the project editor remains usable.

Validation:
- npm ci
- npm test -- --run src/lib/__tests__/assembly-progress-storage.test.ts
- npx tsc --noEmit
- npm audit --json
- git diff --check