### PR TITLE
test: chat endpoint e2e, ChatPanel, and quote-engine edge coverage

### DIFF
--- a/api/src/__tests__/chat-e2e.test.ts
+++ b/api/src/__tests__/chat-e2e.test.ts
@@ -1,0 +1,717 @@
+/**
+ * End-to-end tests for the chat endpoint covering:
+ * - Message formatting and system prompt content
+ * - Materials catalog injection
+ * - Credit/entitlement enforcement
+ * - Auth requirement
+ * - Error handling and fallback behaviour
+ * - Substitution suggestions in local fallback
+ * - Reference image metadata in local fallback
+ * - Context block building with all optional fields
+ *
+ * The Anthropic API is mocked via global.fetch spy — no real API key used.
+ */
+
+process.env.NODE_ENV = "test";
+process.env.ANTHROPIC_API_KEY = "sk-ant-test-e2e-key";
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import jwt from "jsonwebtoken";
+import http from "http";
+import type { AddressInfo } from "net";
+
+const JWT_SECRET = process.env.JWT_SECRET || "helscoop-dev-secret";
+
+// ---------------------------------------------------------------------------
+// Mock DB and email
+// ---------------------------------------------------------------------------
+vi.mock("../db", () => ({
+  query: vi.fn().mockResolvedValue({ rows: [] }),
+  pool: { query: vi.fn() },
+}));
+
+vi.mock("../email", () => ({
+  sendEmail: vi.fn(),
+  sendVerificationEmail: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  sendPriceAlertEmail: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock global.fetch to intercept Anthropic API calls
+// ---------------------------------------------------------------------------
+const fetchSpy = vi.fn();
+const originalFetch = global.fetch;
+global.fetch = fetchSpy as unknown as typeof global.fetch;
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+function mockAnthropicResponse(text: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ content: [{ type: "text", text }] }),
+  };
+}
+
+function lastRequestBody(): {
+  model: string;
+  max_tokens: number;
+  system: string;
+  messages: Array<{ role: string; content: string }>;
+} {
+  const [, opts] = fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1];
+  return JSON.parse(opts.body as string);
+}
+
+import app from "../index";
+import { _resetStores } from "../entitlements";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function authToken(userId = "user-e2e") {
+  return jwt.sign(
+    { id: userId, email: "test@test.com", role: "user" },
+    JWT_SECRET,
+    { expiresIn: "7d" },
+  );
+}
+
+const TOKEN = authToken();
+
+function postChat(
+  body: Record<string, unknown>,
+  token = TOKEN,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address() as AddressInfo;
+      const bodyStr = JSON.stringify(body);
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+
+      const req = http.request(
+        { hostname: "127.0.0.1", port, path: "/chat", method: "POST", headers },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({ status: res.statusCode || 0, body: JSON.parse(data) });
+            } catch {
+              resolve({ status: res.statusCode || 0, body: { raw: data } });
+            }
+          });
+        },
+      );
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+      req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+const SCENE = `const floor = box(6, 0.2, 4);
+scene.add(floor, { material: "concrete_c25", color: [0.8, 0.8, 0.8] });`;
+
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  fetchSpy.mockReset();
+  _resetStores();
+});
+
+// =====================================================================
+// 1. Authentication enforcement
+// =====================================================================
+describe("chat e2e: authentication", () => {
+  it("rejects request with no Authorization header", async () => {
+    const res = await postChat(
+      { messages: [{ role: "user", content: "Hello" }], currentScene: "" },
+      "",
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects request with invalid JWT token", async () => {
+    const res = await postChat(
+      { messages: [{ role: "user", content: "Hello" }], currentScene: "" },
+      "invalid-token-xyz",
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects request with expired JWT token", async () => {
+    const expired = jwt.sign(
+      { id: "user-e2e", email: "test@test.com", role: "user" },
+      JWT_SECRET,
+      { expiresIn: "-1s" },
+    );
+    const res = await postChat(
+      { messages: [{ role: "user", content: "Hello" }], currentScene: "" },
+      expired,
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+// =====================================================================
+// 2. Input validation
+// =====================================================================
+describe("chat e2e: input validation", () => {
+  it("rejects empty messages array with 400", async () => {
+    const res = await postChat({ messages: [], currentScene: "" });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error");
+  });
+
+  it("rejects missing messages field with 400", async () => {
+    const res = await postChat({ currentScene: "box(1,1,1);" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects null messages with 400", async () => {
+    const res = await postChat({ messages: null, currentScene: "" });
+    expect(res.status).toBe(400);
+  });
+});
+
+// =====================================================================
+// 3. Message formatting — correct messages sent to Anthropic
+// =====================================================================
+describe("chat e2e: message formatting", () => {
+  it("sends user messages in correct order to the API", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("Response"));
+
+    await postChat({
+      messages: [
+        { role: "user", content: "First message" },
+        { role: "assistant", content: "First reply" },
+        { role: "user", content: "Second message" },
+      ],
+      currentScene: SCENE,
+    });
+
+    const body = lastRequestBody();
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[0].content).toBe("First message");
+    expect(body.messages[1].role).toBe("assistant");
+    expect(body.messages[2].content).toBe("Second message");
+  });
+
+  it("uses the correct model name", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.model).toContain("claude");
+  });
+
+  it("sets max_tokens to 2048", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.max_tokens).toBe(2048);
+  });
+
+  it("preserves multi-turn conversation history", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    const conversation = [
+      { role: "user", content: "Lisää katto" },
+      { role: "assistant", content: "Katto lisätty" },
+      { role: "user", content: "Vaihda väri" },
+      { role: "assistant", content: "Väri vaihdettu" },
+      { role: "user", content: "Lisää ovi" },
+    ];
+
+    await postChat({
+      messages: conversation,
+      currentScene: SCENE,
+    });
+
+    const body = lastRequestBody();
+    expect(body.messages).toHaveLength(5);
+  });
+});
+
+// =====================================================================
+// 4. System prompt content
+// =====================================================================
+describe("chat e2e: system prompt content", () => {
+  it("includes scene primitives documentation in system prompt", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("box(width, height, depth)");
+    expect(body.system).toContain("cylinder(radius, height)");
+    expect(body.system).toContain("sphere(radius)");
+  });
+
+  it("includes Finnish building types in system prompt", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("omakotitalo");
+    expect(body.system).toContain("kerrostalo");
+    expect(body.system).toContain("rivitalo");
+    expect(body.system).toContain("paritalo");
+  });
+
+  it("includes energy class scale in system prompt", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("energy");
+    expect(body.system).toContain("kWh");
+  });
+
+  it("includes the current scene in the system prompt context", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Current scene script:");
+    expect(body.system).toContain("concrete_c25");
+  });
+
+  it("includes language detection instructions", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toMatch(/detect.*language|language.*detect/i);
+  });
+});
+
+// =====================================================================
+// 5. Materials catalog injection
+// =====================================================================
+describe("chat e2e: materials catalog injection", () => {
+  it("includes materials catalog section in system prompt", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Materials catalog");
+  });
+
+  it("includes substitution group instructions", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Substitution groups");
+  });
+});
+
+// =====================================================================
+// 6. Context block with optional fields
+// =====================================================================
+describe("chat e2e: context block building", () => {
+  it("includes BOM summary when provided", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      bomSummary: [
+        { material: "pine_48x98_c24", qty: 50, unit: "jm", total: 130.0 },
+        { material: "rockwool_50mm", qty: 20, unit: "m2", total: 160.0 },
+      ],
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Current BOM");
+    expect(body.system).toContain("pine_48x98_c24");
+    expect(body.system).toContain("130.00 EUR");
+    expect(body.system).toContain("total 290.00 EUR");
+  });
+
+  it("includes building info when provided", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      buildingInfo: {
+        address: "Testikatu 1, Helsinki",
+        type: "rivitalo",
+        year_built: 1995,
+        area_m2: 80,
+        floors: 1,
+        material: "tiili",
+        heating: "kaukolämpö",
+        climate_zone: "zone_I",
+        heating_degree_days: 3900,
+      },
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Building info:");
+    expect(body.system).toContain("Testikatu 1, Helsinki");
+    expect(body.system).toContain("rivitalo");
+    expect(body.system).toContain("1995");
+    expect(body.system).toContain("80 m²");
+    expect(body.system).toContain("kaukolämpö");
+    expect(body.system).toContain("zone_I");
+    expect(body.system).toContain("3900");
+  });
+
+  it("includes project info when provided", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      projectInfo: {
+        name: "Saunaremontti",
+        description: "Täysi saunan uusiminen ja laajennus",
+      },
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain('Project: "Saunaremontti"');
+    expect(body.system).toContain("Täysi saunan uusiminen ja laajennus");
+  });
+
+  it("includes renovation ROI summary when provided", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    const roiSummary =
+      "Cost 15000 EUR, subsidy 2000 EUR, net 13000 EUR, value impact 8000 EUR, 15-year ROI +18%.";
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      renovationRoiSummary: roiSummary,
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Renovation ROI dashboard:");
+    expect(body.system).toContain("15000 EUR");
+  });
+
+  it("includes substitution suggestions when provided", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      substitutionSuggestions: [
+        {
+          material: "Pine 48x148 C24",
+          materialId: "pine_48x148_c24",
+          substitute: "Spruce 48x148 C24",
+          substituteId: "spruce_48x148_c24",
+          savings: 45,
+          savingsPercent: 12,
+          reason: "price",
+          stockLevel: "high",
+        },
+      ],
+    });
+
+    const body = lastRequestBody();
+    expect(body.system).toContain("Material substitution opportunities");
+    expect(body.system).toContain("Pine 48x148 C24");
+    expect(body.system).toContain("spruce_48x148_c24");
+    expect(body.system).toContain("saves 45 EUR");
+  });
+
+  it("caps BOM summary at 20 items", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    const largeBom = Array.from({ length: 30 }, (_, i) => ({
+      material: `mat_${i}`,
+      qty: 1,
+      unit: "kpl",
+      total: 10,
+    }));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      bomSummary: largeBom,
+    });
+
+    const body = lastRequestBody();
+    // The system prompt should contain "30 items" (the total count) but only list 20
+    expect(body.system).toContain("30 items");
+    // Count how many mat_ entries appear (should be 20, not 30)
+    const matMatches = body.system.match(/mat_\d+/g) || [];
+    expect(matMatches.length).toBe(20);
+  });
+
+  it("omits empty building info gracefully", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("OK"));
+
+    await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+      buildingInfo: {},
+    });
+
+    const body = lastRequestBody();
+    // Should not contain the "Building info:" header when empty
+    expect(body.system).not.toContain("Building info:");
+  });
+});
+
+// =====================================================================
+// 7. Error handling and fallback
+// =====================================================================
+describe("chat e2e: error handling", () => {
+  it("returns 200 with fallback when Anthropic returns 500", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Add a roof to my building" }],
+      currentScene: SCENE,
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as { role: string }).role).toBe("assistant");
+    expect((res.body as { content: string }).content).toContain("roof");
+  });
+
+  it("returns 200 with fallback when Anthropic returns 429 (rate limit)", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      statusText: "Rate Limited",
+    });
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Add a window" }],
+      currentScene: SCENE,
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as { role: string }).role).toBe("assistant");
+  });
+
+  it("returns 200 with fallback when fetch throws", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("DNS resolution failed"));
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Add a door" }],
+      currentScene:
+        'const wall2 = box(4, 3, 0.2);\nscene.add(wall2, {material: "wood"});',
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as { content: string }).content).toContain("door");
+  });
+
+  it("returns 200 with fallback on malformed API JSON response", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new SyntaxError("Unexpected end of JSON")),
+    });
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Make it bigger" }],
+      currentScene: SCENE,
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as { role: string }).role).toBe("assistant");
+  });
+});
+
+// =====================================================================
+// 8. Local fallback response quality
+// =====================================================================
+describe("chat e2e: local fallback responses", () => {
+  // Delete API key so local fallback is used
+  const savedKey = process.env.ANTHROPIC_API_KEY;
+
+  it("provides substitution response when user asks for alternatives", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Onko vaihtoehtoja?" }],
+      currentScene: SCENE,
+      substitutionSuggestions: [
+        {
+          material: "Pine 48x148",
+          materialId: "pine_48x148_c24",
+          substitute: "Spruce 48x148",
+          substituteId: "spruce_48x148_c24",
+          savings: 30,
+          savingsPercent: 10,
+          reason: "price",
+        },
+      ],
+    });
+
+    process.env.ANTHROPIC_API_KEY = savedKey;
+
+    expect(res.status).toBe(200);
+    const content = (res.body as { content: string }).content;
+    expect(content).toContain("substitution");
+    expect(content).toContain("Pine 48x148");
+    expect(content).toContain("spruce_48x148_c24");
+    expect(content).toContain("30 EUR");
+  });
+
+  it("provides reference image metadata response in fallback mode", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    // We need to check the local fallback for reference image queries.
+    // The route loads images from the DB, but our mock returns empty rows.
+    // So referenceImages will be empty. We test via the fallback response.
+    const res = await postChat({
+      messages: [{ role: "user", content: "What do you see in the photo of my roof?" }],
+      currentScene: SCENE,
+    });
+
+    process.env.ANTHROPIC_API_KEY = savedKey;
+
+    expect(res.status).toBe(200);
+    // Without images loaded, it should give the generic fallback
+    expect((res.body as { role: string }).role).toBe("assistant");
+  });
+
+  it("returns color guidance for color questions", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Change the colour of the walls" }],
+      currentScene: SCENE,
+    });
+
+    process.env.ANTHROPIC_API_KEY = savedKey;
+
+    expect(res.status).toBe(200);
+    expect((res.body as { content: string }).content).toContain("color");
+  });
+
+  it("returns generic help for unrecognized messages", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Tell me about Finnish history" }],
+      currentScene: SCENE,
+    });
+
+    process.env.ANTHROPIC_API_KEY = savedKey;
+
+    expect(res.status).toBe(200);
+    const content = (res.body as { content: string }).content;
+    // Generic fallback mentions available capabilities
+    expect(content).toContain("roof");
+    expect(content).toContain("door");
+    expect(content).toContain("window");
+    expect(content).toContain("ANTHROPIC_API_KEY");
+  });
+});
+
+// =====================================================================
+// 9. Credits integration
+// =====================================================================
+describe("chat e2e: credits", () => {
+  it("returns credits information in the response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      mockAnthropicResponse("Here is your response."),
+    );
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: SCENE,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("credits");
+    const credits = (res.body as { credits: { cost: number; balance: number } }).credits;
+    expect(credits).toHaveProperty("cost");
+    expect(credits).toHaveProperty("balance");
+    expect(typeof credits.cost).toBe("number");
+    expect(typeof credits.balance).toBe("number");
+  });
+});
+
+// =====================================================================
+// 10. Response structure validation
+// =====================================================================
+describe("chat e2e: response structure", () => {
+  it("always returns role=assistant and non-empty content", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("Moi!"));
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "Hei" }],
+      currentScene: SCENE,
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as { role: string; content: string };
+    expect(body.role).toBe("assistant");
+    expect(body.content.length).toBeGreaterThan(0);
+  });
+
+  it("content is a string not an array", async () => {
+    fetchSpy.mockResolvedValueOnce(mockAnthropicResponse("Test response"));
+
+    const res = await postChat({
+      messages: [{ role: "user", content: "test" }],
+      currentScene: "",
+    });
+
+    expect(res.status).toBe(200);
+    expect(typeof (res.body as { content: string }).content).toBe("string");
+  });
+});

--- a/web/src/__tests__/ChatPanel-extended.test.tsx
+++ b/web/src/__tests__/ChatPanel-extended.test.tsx
@@ -1,0 +1,477 @@
+/**
+ * Extended ChatPanel tests covering:
+ * - Loading state rendering during API call
+ * - Message display ordering
+ * - Error handling when API fails (402 credits, network errors)
+ * - Diff preview toggle
+ * - Reference image context indicator
+ * - Grouped message styling
+ * - Credit update event dispatch
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockToast = vi.fn();
+const mockTrack = vi.fn();
+const mockChat = vi.fn();
+const mockPlaySound = vi.fn();
+
+vi.mock("@/components/LocaleProvider", () => ({
+  useTranslation: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/hooks/useCursorGlow", () => ({
+  useCursorGlow: () => ({
+    ref: { current: null },
+    onMouseMove: vi.fn(),
+    onMouseLeave: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useAmbientSound", () => ({
+  useAmbientSound: () => ({ play: mockPlaySound }),
+}));
+
+vi.mock("@/components/ToastProvider", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/hooks/useAnalytics", () => ({
+  useAnalytics: () => ({ track: mockTrack }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: { chat: (...args: unknown[]) => mockChat(...args) },
+  ApiError: class ApiError extends Error {
+    status: number;
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+vi.mock("@/components/ConfirmDialog", () => ({
+  default: ({
+    open,
+    onConfirm,
+    onCancel,
+    children,
+  }: {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmText: string;
+    cancelText: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+    children?: React.ReactNode;
+  }) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <button onClick={onConfirm}>confirm</button>
+        <button onClick={onCancel}>cancel</button>
+        {children}
+      </div>
+    ) : null,
+}));
+
+import ChatPanel from "@/components/ChatPanel";
+import { ApiError } from "@/lib/api";
+
+beforeEach(() => {
+  mockToast.mockReset();
+  mockTrack.mockReset();
+  mockChat.mockReset();
+  mockPlaySound.mockReset();
+  localStorage.clear();
+});
+
+const defaultProps = {
+  sceneJs: "scene.add(box(1,1,1));",
+  onApplyCode: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Loading state
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: loading state", () => {
+  it("shows shimmer bar while waiting for API response", async () => {
+    let resolveChat: (value: unknown) => void;
+    const chatPromise = new Promise((resolve) => {
+      resolveChat = resolve;
+    });
+    mockChat.mockReturnValueOnce(chatPromise);
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "Add a roof" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Shimmer bar should appear during loading
+    await waitFor(() => {
+      expect(document.querySelector(".chat-shimmer-bar")).toBeTruthy();
+    });
+
+    // Resolve the promise
+    await act(async () => {
+      resolveChat!({ role: "assistant", content: "Done!" });
+    });
+
+    // Shimmer should disappear
+    await waitFor(() => {
+      expect(document.querySelector(".chat-shimmer-bar")).toBeFalsy();
+    });
+  });
+
+  it("disables input while loading", async () => {
+    let resolveChat: (value: unknown) => void;
+    const chatPromise = new Promise((resolve) => {
+      resolveChat = resolve;
+    });
+    mockChat.mockReturnValueOnce(chatPromise);
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(input.disabled).toBe(true);
+    });
+
+    await act(async () => {
+      resolveChat!({ role: "assistant", content: "ok" });
+    });
+
+    await waitFor(() => {
+      expect(input.disabled).toBe(false);
+    });
+  });
+
+  it("disables send button while loading", async () => {
+    let resolveChat: (value: unknown) => void;
+    const chatPromise = new Promise((resolve) => {
+      resolveChat = resolve;
+    });
+    mockChat.mockReturnValueOnce(chatPromise);
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const sendBtn = screen.getByLabelText("editor.chatSendLabel");
+    await waitFor(() => {
+      expect(sendBtn).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveChat!({ role: "assistant", content: "ok" });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Message ordering
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: message display ordering", () => {
+  it("displays messages in chronological order (user then assistant)", async () => {
+    mockChat.mockResolvedValueOnce({ role: "assistant", content: "Response 1" });
+    render(<ChatPanel {...defaultProps} />);
+
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "Message 1" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Response 1")).toBeInTheDocument();
+    });
+
+    // Check order: user message appears before assistant message
+    const msgs = document.querySelectorAll(".chat-msg");
+    expect(msgs.length).toBe(2);
+    expect(msgs[0].classList.contains("chat-msg-user")).toBe(true);
+    expect(msgs[1].classList.contains("chat-msg-ai")).toBe(true);
+  });
+
+  it("maintains correct order across multiple exchanges", async () => {
+    mockChat
+      .mockResolvedValueOnce({ role: "assistant", content: "Reply A" })
+      .mockResolvedValueOnce({ role: "assistant", content: "Reply B" });
+
+    render(<ChatPanel {...defaultProps} />);
+
+    // Send first message
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "Msg A" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Reply A")).toBeInTheDocument();
+    });
+
+    // Send second message
+    fireEvent.change(input, { target: { value: "Msg B" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Reply B")).toBeInTheDocument();
+    });
+
+    const msgs = document.querySelectorAll(".chat-msg");
+    expect(msgs.length).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: error handling", () => {
+  it("shows insufficient credits message on 402 error", async () => {
+    mockChat.mockRejectedValueOnce(new ApiError("Insufficient credits", 402));
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith("credits.insufficient", "error");
+    });
+  });
+
+  it("shows generic error message for non-402 errors", async () => {
+    mockChat.mockRejectedValueOnce(new Error("Server down"));
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith("Server down", "error");
+    });
+  });
+
+  it("displays error fallback message in chat on failure", async () => {
+    mockChat.mockRejectedValueOnce(new Error("fail"));
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("editor.chatError")).toBeInTheDocument();
+    });
+  });
+
+  it("re-enables input after error", async () => {
+    mockChat.mockRejectedValueOnce(new Error("fail"));
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(input.disabled).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Diff preview
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: diff preview", () => {
+  it("toggles diff preview on button click", async () => {
+    const code = "```javascript\nscene.add(box(2,2,2));\n```";
+    mockChat.mockResolvedValueOnce({ role: "assistant", content: code });
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "change box" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("editor.previewDiff")).toBeInTheDocument();
+    });
+
+    // Click to expand diff
+    fireEvent.click(screen.getByText("editor.previewDiff"));
+
+    await waitFor(() => {
+      const diffPreview = document.querySelector(".chat-diff-preview");
+      expect(diffPreview).toBeTruthy();
+    });
+
+    // Click again to collapse
+    fireEvent.click(screen.getByText("editor.previewDiff"));
+
+    await waitFor(() => {
+      const diffPreview = document.querySelector(".chat-diff-preview");
+      expect(diffPreview).toBeFalsy();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reference image context
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: reference images", () => {
+  it("shows reference photo count when images are provided", () => {
+    render(
+      <ChatPanel
+        {...defaultProps}
+        referenceImages={[
+          {
+            id: "img-1",
+            original_filename: "house.jpg",
+            width: 800,
+            height: 600,
+            uploaded_at: "2025-01-01",
+            thumbnail_800_key: "thumb-1",
+            project_id: "proj-1",
+          },
+          {
+            id: "img-2",
+            original_filename: "roof.jpg",
+            width: 1024,
+            height: 768,
+            uploaded_at: "2025-01-02",
+            thumbnail_800_key: "thumb-2",
+            project_id: "proj-1",
+          },
+        ]}
+      />,
+    );
+
+    const indicator = screen.getByLabelText("2 reference photos available to AI chat");
+    expect(indicator).toBeInTheDocument();
+    expect(indicator.textContent).toContain("2 house photos");
+  });
+
+  it("does not show reference photo indicator when no images", () => {
+    render(<ChatPanel {...defaultProps} />);
+    expect(
+      screen.queryByLabelText(/reference photos available/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sound effect
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: sound effects", () => {
+  it("plays chatReply sound on successful response", async () => {
+    mockChat.mockResolvedValueOnce({ role: "assistant", content: "ok" });
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "hello" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockPlaySound).toHaveBeenCalledWith("chatReply");
+    });
+  });
+
+  it("does not play sound on error", async () => {
+    mockChat.mockRejectedValueOnce(new Error("fail"));
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "hello" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("editor.chatError")).toBeInTheDocument();
+    });
+
+    expect(mockPlaySound).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credit events
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: credit events", () => {
+  it("dispatches helscoop:credits-updated event when credits in response", async () => {
+    const listener = vi.fn();
+    window.addEventListener("helscoop:credits-updated", listener);
+
+    mockChat.mockResolvedValueOnce({
+      role: "assistant",
+      content: "ok",
+      credits: { cost: 1, balance: 49 },
+    });
+
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel");
+    fireEvent.change(input, { target: { value: "test" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    const event = listener.mock.calls[0][0] as CustomEvent;
+    expect(event.detail).toEqual({ cost: 1, balance: 49 });
+
+    window.removeEventListener("helscoop:credits-updated", listener);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Grouped messages
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: message grouping", () => {
+  it("groups consecutive messages from the same role", async () => {
+    // Set up localStorage with consecutive assistant messages
+    const messages = [
+      { role: "user", content: "Q1" },
+      { role: "assistant", content: "A1" },
+      { role: "assistant", content: "A2" },
+    ];
+    localStorage.setItem("helscoop-chat-group-test", JSON.stringify(messages));
+
+    render(<ChatPanel {...defaultProps} projectId="group-test" />);
+
+    // The second assistant message should have the grouped class
+    const aiMsgs = document.querySelectorAll(".chat-msg-ai");
+    expect(aiMsgs.length).toBe(2);
+    expect(aiMsgs[1].classList.contains("chat-msg-grouped")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Placeholder text
+// ---------------------------------------------------------------------------
+describe("ChatPanel extended: placeholder text", () => {
+  it("uses describeChange placeholder when no messages", () => {
+    render(<ChatPanel {...defaultProps} />);
+    const input = screen.getByLabelText("editor.chatInputLabel") as HTMLTextAreaElement;
+    expect(input.placeholder).toBe("editor.describeChange");
+  });
+
+  it("uses continueConversation placeholder when messages exist", () => {
+    const messages = [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    localStorage.setItem("helscoop-chat-placeholder-test", JSON.stringify(messages));
+
+    render(<ChatPanel {...defaultProps} projectId="placeholder-test" />);
+    const input = screen.getByLabelText("editor.chatInputLabel") as HTMLTextAreaElement;
+    expect(input.placeholder).toBe("editor.continueConversation");
+  });
+});

--- a/web/src/__tests__/ChatPanel-extended.test.tsx
+++ b/web/src/__tests__/ChatPanel-extended.test.tsx
@@ -237,7 +237,9 @@ describe("ChatPanel extended: message display ordering", () => {
 // ---------------------------------------------------------------------------
 describe("ChatPanel extended: error handling", () => {
   it("shows insufficient credits message on 402 error", async () => {
-    mockChat.mockRejectedValueOnce(new ApiError("Insufficient credits", 402));
+    mockChat.mockRejectedValueOnce(
+      new ApiError("Insufficient credits", 402, "Payment Required"),
+    );
 
     render(<ChatPanel {...defaultProps} />);
     const input = screen.getByLabelText("editor.chatInputLabel");
@@ -335,21 +337,33 @@ describe("ChatPanel extended: reference images", () => {
         referenceImages={[
           {
             id: "img-1",
+            project_id: "proj-1",
             original_filename: "house.jpg",
+            content_type: "image/jpeg",
+            byte_size: 123_456,
             width: 800,
             height: 600,
             uploaded_at: "2025-01-01",
-            thumbnail_800_key: "thumb-1",
-            project_id: "proj-1",
+            urls: {
+              original: "/photos/img-1/original",
+              thumb_200: "/photos/img-1/thumb-200",
+              thumb_800: "/photos/img-1/thumb-800",
+            },
           },
           {
             id: "img-2",
+            project_id: "proj-1",
             original_filename: "roof.jpg",
+            content_type: "image/jpeg",
+            byte_size: 234_567,
             width: 1024,
             height: 768,
             uploaded_at: "2025-01-02",
-            thumbnail_800_key: "thumb-2",
-            project_id: "proj-1",
+            urls: {
+              original: "/photos/img-2/original",
+              thumb_200: "/photos/img-2/thumb-200",
+              thumb_800: "/photos/img-2/thumb-800",
+            },
           },
         ]}
       />,

--- a/web/src/__tests__/quote-engine-edge-cases.test.ts
+++ b/web/src/__tests__/quote-engine-edge-cases.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Edge case tests for the quote engine.
+ *
+ * Covers: empty BOM, zero quantity, very large quantities, missing prices,
+ * negative values, NaN inputs, extreme VAT/wastage/margin configs,
+ * and BOM items with no matching material in catalog.
+ */
+
+import { describe, it, expect } from "vitest";
+import { calculateQuote, defaultQuoteConfig } from "@/lib/quote-engine";
+import type { QuoteConfig } from "@/lib/quote-engine";
+import type { BomItem, Material } from "@/types";
+
+/* ── Fixtures ──────────────────────────────────────────────── */
+
+function makeMaterial(overrides: Partial<Material> = {}): Material {
+  return {
+    id: "test_mat",
+    name: "Test Material",
+    name_fi: "Testimateriaali",
+    name_en: "Test Material",
+    category_name: "lumber",
+    category_name_fi: "Sahatavara",
+    image_url: null,
+    pricing: [{ unit_price: 10, unit: "kpl", supplier_name: "Test", is_primary: true }],
+    ...overrides,
+  } as Material;
+}
+
+function makeBom(overrides: Partial<BomItem> = {}): BomItem {
+  return {
+    material_id: "test_mat",
+    quantity: 10,
+    unit: "kpl",
+    ...overrides,
+  };
+}
+
+const baseConfig: QuoteConfig = {
+  mode: "homeowner",
+  vatRate: 0.255,
+  labourRatePerHour: 45,
+  wastagePercent: 0.10,
+};
+
+const materials = [makeMaterial()];
+
+/* ── 1. Empty BOM edge cases ──────────────────────────────── */
+
+describe("quote-engine edge: empty BOM", () => {
+  it("returns zero totals for empty BOM with empty materials", () => {
+    const quote = calculateQuote([], [], baseConfig);
+    expect(quote.lines).toHaveLength(0);
+    expect(quote.grandTotal).toBe(0);
+    expect(quote.vatTotal).toBe(0);
+    expect(quote.materialSubtotal).toBe(0);
+    expect(quote.labourSubtotal).toBe(0);
+    expect(quote.wastageTotal).toBe(0);
+    expect(quote.subtotalExVat).toBe(0);
+  });
+
+  it("returns zero totals for empty BOM with populated materials catalog", () => {
+    const quote = calculateQuote([], [makeMaterial(), makeMaterial({ id: "m2" })], baseConfig);
+    expect(quote.lines).toHaveLength(0);
+    expect(quote.grandTotal).toBe(0);
+  });
+
+  it("contractor mode with empty BOM returns zero margin", () => {
+    const contractorConfig: QuoteConfig = {
+      ...baseConfig,
+      mode: "contractor",
+      contractorMarginPercent: 0.15,
+    };
+    const quote = calculateQuote([], [], contractorConfig);
+    expect(quote.contractorMargin).toBe(0);
+    expect(quote.grandTotal).toBe(0);
+  });
+});
+
+/* ── 2. Zero quantity ─────────────────────────────────────── */
+
+describe("quote-engine edge: zero quantity", () => {
+  it("produces zero costs for zero quantity item", () => {
+    const bom = [makeBom({ quantity: 0 })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+
+    expect(quote.lines).toHaveLength(1);
+    expect(quote.lines[0].designQty).toBe(0);
+    expect(quote.lines[0].wastageQty).toBe(0);
+    expect(quote.lines[0].materialCost).toBe(0);
+    expect(quote.lines[0].labourHours).toBe(0);
+    expect(quote.lines[0].labourCost).toBe(0);
+    expect(quote.lines[0].subtotal).toBe(0);
+    expect(quote.lines[0].vatAmount).toBe(0);
+    expect(quote.lines[0].total).toBe(0);
+  });
+
+  it("grand total is zero when all items have zero quantity", () => {
+    const bom = [
+      makeBom({ quantity: 0, material_id: "test_mat" }),
+      makeBom({ quantity: 0, material_id: "test_mat" }),
+    ];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    expect(quote.grandTotal).toBe(0);
+  });
+});
+
+/* ── 3. Large quantities ──────────────────────────────────── */
+
+describe("quote-engine edge: large quantities", () => {
+  it("handles very large quantity (100,000 units)", () => {
+    const bom = [makeBom({ quantity: 100_000 })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+
+    expect(quote.lines[0].designQty).toBe(100_000);
+    expect(quote.lines[0].wastageQty).toBe(10_000);
+    // materialCost = 110,000 * 10 = 1,100,000
+    expect(quote.lines[0].materialCost).toBe(1_100_000);
+    expect(quote.grandTotal).toBeGreaterThan(1_000_000);
+    // Ensure it is finite and not NaN
+    expect(Number.isFinite(quote.grandTotal)).toBe(true);
+  });
+
+  it("handles quantity of 1 million without overflow", () => {
+    const bom = [makeBom({ quantity: 1_000_000 })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    expect(Number.isFinite(quote.grandTotal)).toBe(true);
+    expect(quote.grandTotal).toBeGreaterThan(0);
+  });
+
+  it("handles fractional quantity (0.001)", () => {
+    const bom = [makeBom({ quantity: 0.001 })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    expect(quote.lines[0].designQty).toBe(0);
+    expect(Number.isFinite(quote.grandTotal)).toBe(true);
+  });
+});
+
+/* ── 4. Missing prices ────────────────────────────────────── */
+
+describe("quote-engine edge: missing prices", () => {
+  it("handles BOM item with no matching material (missing from catalog)", () => {
+    const bom = [makeBom({ material_id: "nonexistent_material" })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+
+    // Should still produce a line item
+    expect(quote.lines).toHaveLength(1);
+    // No material found -> unitPrice = 0 (from getUnitPrice fallback)
+    expect(quote.lines[0].materialCost).toBe(0);
+    // Labour still calculated with default rate
+    expect(quote.lines[0].labourHours).toBeGreaterThan(0);
+  });
+
+  it("uses BOM material_name as fallback name when material not in catalog", () => {
+    const bom = [makeBom({ material_id: "missing", material_name: "Custom Wood" })];
+    const quote = calculateQuote(bom, [], baseConfig);
+    expect(quote.lines[0].materialName).toBe("Custom Wood");
+  });
+
+  it("falls back to material_id when no material_name and no catalog entry", () => {
+    const bom = [makeBom({ material_id: "raw_id_only" })];
+    const quote = calculateQuote(bom, [], baseConfig);
+    expect(quote.lines[0].materialName).toBe("raw_id_only");
+  });
+
+  it("material with empty pricing array uses unitPrice=0", () => {
+    const matNoPricing = makeMaterial({ id: "no_price", pricing: [] });
+    const bom = [makeBom({ material_id: "no_price" })];
+    const quote = calculateQuote(bom, [matNoPricing], baseConfig);
+    expect(quote.lines[0].materialCost).toBe(0);
+  });
+
+  it("BOM unit_price overrides material catalog pricing", () => {
+    const bom = [makeBom({ unit_price: 25 })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    // 11 units * 25 = 275 (not 110 from catalog price of 10)
+    expect(quote.lines[0].materialCost).toBe(275);
+  });
+
+  it("BOM unit_price of zero produces zero material cost", () => {
+    const bom = [makeBom({ unit_price: 0 })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    expect(quote.lines[0].materialCost).toBe(0);
+  });
+});
+
+/* ── 5. VAT calculation edge cases ────────────────────────── */
+
+describe("quote-engine edge: VAT calculation", () => {
+  it("zero VAT rate produces zero VAT", () => {
+    const config: QuoteConfig = { ...baseConfig, vatRate: 0 };
+    const bom = [makeBom()];
+    const quote = calculateQuote(bom, materials, config);
+    expect(quote.vatTotal).toBe(0);
+    expect(quote.lines[0].vatAmount).toBe(0);
+    // grandTotal = subtotalExVat when VAT is 0
+    expect(quote.grandTotal).toBe(quote.subtotalExVat);
+  });
+
+  it("100% VAT rate doubles the total (approx)", () => {
+    const config: QuoteConfig = { ...baseConfig, vatRate: 1.0 };
+    const bom = [makeBom()];
+    const quote = calculateQuote(bom, materials, config);
+    expect(quote.vatTotal).toBe(quote.subtotalExVat);
+    expect(quote.grandTotal).toBe(
+      Math.round((quote.subtotalExVat * 2) * 100) / 100,
+    );
+  });
+
+  it("contractor mode VAT is on (subtotal + margin)", () => {
+    const config: QuoteConfig = {
+      ...baseConfig,
+      mode: "contractor",
+      contractorMarginPercent: 0.20,
+    };
+    const bom = [makeBom()];
+    const quote = calculateQuote(bom, materials, config);
+
+    const margin = quote.contractorMargin!;
+    const taxableBase = Math.round((quote.subtotalExVat + margin) * 100) / 100;
+    const expectedVat = Math.round(taxableBase * config.vatRate * 100) / 100;
+    expect(quote.vatTotal).toBe(expectedVat);
+  });
+});
+
+/* ── 6. Wastage edge cases ────────────────────────────────── */
+
+describe("quote-engine edge: wastage", () => {
+  it("zero wastage produces no wastage quantity or cost", () => {
+    const config: QuoteConfig = { ...baseConfig, wastagePercent: 0 };
+    const bom = [makeBom()];
+    const quote = calculateQuote(bom, materials, config);
+    expect(quote.lines[0].wastageQty).toBe(0);
+    expect(quote.wastageTotal).toBe(0);
+  });
+
+  it("50% wastage adds correct extra material", () => {
+    const config: QuoteConfig = { ...baseConfig, wastagePercent: 0.50 };
+    const bom = [makeBom({ quantity: 100 })];
+    const quote = calculateQuote(bom, materials, config);
+    expect(quote.lines[0].wastageQty).toBe(50);
+    // materialCost = 150 units * 10 = 1500
+    expect(quote.lines[0].materialCost).toBe(1500);
+    // But labourHours should still be based on designQty=100
+    // lumber = 0.5 h/unit => 50 hours
+    expect(quote.lines[0].labourHours).toBe(50);
+  });
+
+  it("wastageTotal correctly sums across multiple lines", () => {
+    const config: QuoteConfig = { ...baseConfig, wastagePercent: 0.10 };
+    const mat2 = makeMaterial({ id: "mat2", pricing: [{ unit_price: 20, unit: "m2", supplier_name: "X", is_primary: true }] });
+    const bom = [
+      makeBom({ quantity: 10, material_id: "test_mat" }),
+      makeBom({ quantity: 10, material_id: "mat2" }),
+    ];
+    const quote = calculateQuote(bom, [makeMaterial(), mat2], config);
+    // wastage for test_mat: 1 unit * 10 EUR = 10
+    // wastage for mat2: 1 unit * 20 EUR = 20
+    expect(quote.wastageTotal).toBeCloseTo(30, 1);
+  });
+});
+
+/* ── 7. Contractor margin edge cases ──────────────────────── */
+
+describe("quote-engine edge: contractor margin", () => {
+  it("zero margin in contractor mode equals homeowner total", () => {
+    const contractorConfig: QuoteConfig = {
+      ...baseConfig,
+      mode: "contractor",
+      contractorMarginPercent: 0,
+    };
+    const bom = [makeBom()];
+    const homeowner = calculateQuote(bom, materials, baseConfig);
+    const contractor = calculateQuote(bom, materials, contractorConfig);
+    expect(contractor.grandTotal).toBe(homeowner.grandTotal);
+    expect(contractor.contractorMargin).toBe(0);
+  });
+
+  it("undefined margin in contractor mode has no margin field", () => {
+    const contractorConfig: QuoteConfig = {
+      ...baseConfig,
+      mode: "contractor",
+      contractorMarginPercent: undefined,
+    };
+    const bom = [makeBom()];
+    const quote = calculateQuote(bom, materials, contractorConfig);
+    expect(quote.contractorMargin).toBeUndefined();
+  });
+
+  it("high margin (50%) significantly increases grand total", () => {
+    const highMarginConfig: QuoteConfig = {
+      ...baseConfig,
+      mode: "contractor",
+      contractorMarginPercent: 0.50,
+    };
+    const bom = [makeBom()];
+    const homeowner = calculateQuote(bom, materials, baseConfig);
+    const contractor = calculateQuote(bom, materials, highMarginConfig);
+    // Contractor should be much higher
+    expect(contractor.grandTotal).toBeGreaterThan(homeowner.grandTotal * 1.4);
+  });
+});
+
+/* ── 8. Labour by material category ───────────────────────── */
+
+describe("quote-engine edge: labour category edge cases", () => {
+  it("Finnish category name (eristys) matches insulation rate", () => {
+    const mat = makeMaterial({ id: "fi_insulation", category_name: "Eristys" });
+    const bom = [makeBom({ material_id: "fi_insulation", quantity: 10 })];
+    const config: QuoteConfig = { ...baseConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, [mat], config);
+    // eristys => 0.3 h/unit => 3h
+    expect(quote.lines[0].labourHours).toBe(3);
+  });
+
+  it("category with partial match (e.g. 'kalvo' in category name) matches membrane", () => {
+    const mat = makeMaterial({ id: "membrane", category_name: "Höyrynsulkukalvo" });
+    const bom = [makeBom({ material_id: "membrane", quantity: 10 })];
+    const config: QuoteConfig = { ...baseConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, [mat], config);
+    // kalvo => 0.25 h/unit => 2.5h
+    expect(quote.lines[0].labourHours).toBe(2.5);
+  });
+
+  it("null material uses default labour hours", () => {
+    const bom = [makeBom({ material_id: "missing" })];
+    const config: QuoteConfig = { ...baseConfig, wastagePercent: 0 };
+    const quote = calculateQuote(bom, [], config);
+    // default 0.2h/unit, 10 units => 2h
+    expect(quote.lines[0].labourHours).toBe(2);
+  });
+});
+
+/* ── 9. Multi-item BOM correctness ────────────────────────── */
+
+describe("quote-engine edge: multi-item BOM", () => {
+  it("handles 20 BOM items without issue", () => {
+    const mats = Array.from({ length: 20 }, (_, i) =>
+      makeMaterial({
+        id: `mat_${i}`,
+        pricing: [{ unit_price: i + 1, unit: "kpl", supplier_name: "S", is_primary: true }],
+      }),
+    );
+    const bom = mats.map((m) => makeBom({ material_id: m.id, quantity: 5 }));
+    const quote = calculateQuote(bom, mats, baseConfig);
+
+    expect(quote.lines).toHaveLength(20);
+    expect(Number.isFinite(quote.grandTotal)).toBe(true);
+    expect(quote.grandTotal).toBeGreaterThan(0);
+  });
+
+  it("subtotalExVat equals materialSubtotal + labourSubtotal exactly", () => {
+    const mat2 = makeMaterial({
+      id: "insul",
+      category_name: "insulation",
+      pricing: [{ unit_price: 8, unit: "m2", supplier_name: "X", is_primary: true }],
+    });
+    const bom = [
+      makeBom({ quantity: 7, material_id: "test_mat" }),
+      makeBom({ quantity: 13, material_id: "insul" }),
+    ];
+    const quote = calculateQuote(bom, [makeMaterial(), mat2], baseConfig);
+    expect(quote.subtotalExVat).toBe(
+      Math.round((quote.materialSubtotal + quote.labourSubtotal) * 100) / 100,
+    );
+  });
+});
+
+/* ── 10. Rounding precision ───────────────────────────────── */
+
+describe("quote-engine edge: rounding", () => {
+  it("all monetary values have at most 2 decimal places", () => {
+    const bom = [
+      makeBom({ quantity: 7 }),
+      makeBom({
+        material_id: "odd_price",
+        quantity: 13,
+      }),
+    ];
+    const oddMat = makeMaterial({
+      id: "odd_price",
+      pricing: [{ unit_price: 3.33, unit: "m", supplier_name: "X", is_primary: true }],
+    });
+    const quote = calculateQuote(bom, [makeMaterial(), oddMat], baseConfig);
+
+    const decPlaces = (n: number) => {
+      const s = n.toString();
+      const dot = s.indexOf(".");
+      return dot === -1 ? 0 : s.length - dot - 1;
+    };
+
+    for (const line of quote.lines) {
+      expect(decPlaces(line.materialCost)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.labourCost)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.subtotal)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.vatAmount)).toBeLessThanOrEqual(2);
+      expect(decPlaces(line.total)).toBeLessThanOrEqual(2);
+    }
+
+    expect(decPlaces(quote.grandTotal)).toBeLessThanOrEqual(2);
+    expect(decPlaces(quote.vatTotal)).toBeLessThanOrEqual(2);
+    expect(decPlaces(quote.materialSubtotal)).toBeLessThanOrEqual(2);
+    expect(decPlaces(quote.labourSubtotal)).toBeLessThanOrEqual(2);
+  });
+});
+
+/* ── 11. defaultQuoteConfig edge cases ────────────────────── */
+
+describe("quote-engine edge: defaultQuoteConfig", () => {
+  it("defaults to homeowner mode when no argument", () => {
+    const config = defaultQuoteConfig();
+    expect(config.mode).toBe("homeowner");
+  });
+
+  it("homeowner config has no contractorMarginPercent", () => {
+    const config = defaultQuoteConfig("homeowner");
+    expect(config.contractorMarginPercent).toBeUndefined();
+  });
+
+  it("contractor config has contractorMarginPercent of 0.15", () => {
+    const config = defaultQuoteConfig("contractor");
+    expect(config.contractorMarginPercent).toBe(0.15);
+  });
+
+  it("all numeric fields are positive", () => {
+    const config = defaultQuoteConfig();
+    expect(config.vatRate).toBeGreaterThan(0);
+    expect(config.labourRatePerHour).toBeGreaterThan(0);
+    expect(config.wastagePercent).toBeGreaterThan(0);
+  });
+});
+
+/* ── 12. generatedAt timestamp ────────────────────────────── */
+
+describe("quote-engine edge: timestamp", () => {
+  it("generatedAt is a valid ISO 8601 string", () => {
+    const quote = calculateQuote([], [], baseConfig);
+    expect(quote.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    // Should parse without error
+    const date = new Date(quote.generatedAt);
+    expect(date.getTime()).not.toBeNaN();
+  });
+
+  it("generatedAt is recent (within last 5 seconds)", () => {
+    const before = Date.now();
+    const quote = calculateQuote([], [], baseConfig);
+    const after = Date.now();
+    const ts = new Date(quote.generatedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});
+
+/* ── 13. Design unit passthrough ──────────────────────────── */
+
+describe("quote-engine edge: design unit", () => {
+  it("uses BOM unit when specified", () => {
+    const bom = [makeBom({ unit: "m2" })];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    expect(quote.lines[0].designUnit).toBe("m2");
+  });
+
+  it("falls back to material pricing unit when BOM has no unit", () => {
+    const bom = [{ material_id: "test_mat", quantity: 10 } as BomItem];
+    const quote = calculateQuote(bom, materials, baseConfig);
+    // Material pricing unit is "kpl"
+    expect(quote.lines[0].designUnit).toBe("kpl");
+  });
+
+  it("uses 'unit' as last resort when no unit info available", () => {
+    const bom = [{ material_id: "missing", quantity: 5 } as BomItem];
+    const quote = calculateQuote(bom, [], baseConfig);
+    expect(quote.lines[0].designUnit).toBe("unit");
+  });
+});


### PR DESCRIPTION
## Summary
- **API chat e2e tests** (35 tests): message formatting, system prompt content (Finnish building types, energy classes, materials catalog), context block building with all optional fields (BOM, building info, project info, ROI, substitutions), auth enforcement (missing/invalid/expired JWT), input validation, error handling + fallback (500, 429, network errors, malformed JSON), credits integration, response structure
- **ChatPanel extended tests** (18 tests): loading state (shimmer bar, disabled input/button), message display ordering, error handling (402 credits vs generic), diff preview toggle, reference image context indicator, sound effects, credit update event dispatch, message grouping, placeholder text
- **Quote-engine edge case tests** (38 tests): empty BOM with/without materials, zero quantity, large quantities (100K, 1M), fractional quantities, missing prices (no catalog entry, empty pricing array, unit_price=0), BOM unit_price override, VAT extremes (0%, 100%), wastage (0%, 50%), contractor margin (0%, undefined, 50%), Finnish category matching (eristys, kalvo), multi-item aggregation, rounding precision, design unit fallback chain, timestamp validity

## Test plan
- [x] `api/src/__tests__/chat-e2e.test.ts` — 35/35 passing
- [x] `web/src/__tests__/ChatPanel-extended.test.tsx` — 18/18 passing
- [x] `web/src/__tests__/quote-engine-edge-cases.test.ts` — 38/38 passing

Note: The chat endpoint uses the Anthropic API directly (not OpenAI-compatible), so OpenRouter cannot be substituted without code changes. All LLM calls are mocked via `global.fetch` spy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)