### PR TITLE
Stabilize building import E2E and locale fallback

### DIFF
--- a/e2e/tests/building-lookup.spec.ts
+++ b/e2e/tests/building-lookup.spec.ts
@@ -73,14 +73,30 @@ test.describe("Building Lookup & Import", () => {
     await dismissOnboarding(page);
 
     const addressInput = page.locator('[data-tour="address-input"] input').first();
-    await addressInput.fill("Ribbingintie 109-11, 00890 Helsinki");
-    await page
-      .getByRole("button", { name: /hae|search/i })
+    const searchButton = page
+      .locator('[data-tour="address-input"]')
       .first()
-      .click({ force: true });
+      .getByRole("button", { name: /hae|search/i });
+    await addressInput.scrollIntoViewIfNeeded();
+    await addressInput.fill("Ribbingintie 109-11, 00890 Helsinki");
+    await expect(addressInput).toHaveValue("Ribbingintie 109-11, 00890 Helsinki");
+    await expect(searchButton).toBeEnabled({ timeout: 5_000 });
+    await Promise.all([
+      page.waitForResponse(
+        (response) =>
+          response.request().method() === "GET" &&
+          response.url().includes("/building?") &&
+          response.ok(),
+        { timeout: 15_000 }
+      ),
+      searchButton.click(),
+    ]);
 
     await expect(
-      page.getByText(/omakotitalo|detached house/i)
+      page
+        .locator(".address-result-glow, [class*='address-result']")
+        .filter({ hasText: /omakotitalo|detached house/i })
+        .first()
     ).toBeVisible({ timeout: 15_000 });
 
     const importBtn = page.getByRole("button", {

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -212,6 +212,7 @@ describe("getTranslation — English (en)", () => {
 describe("fallback — missing keys return the key itself", () => {
   const tFi = getTranslation("fi");
   const tEn = getTranslation("en");
+  const tSv = getTranslation("sv");
 
   it("returns the key for a completely nonexistent top-level namespace", () => {
     expect(tFi("nonexistent.key")).toBe("nonexistent.key");
@@ -235,6 +236,11 @@ describe("fallback — missing keys return the key itself", () => {
 
   it("returns the key for an empty string key", () => {
     expect(tFi("")).toBe("");
+  });
+
+  it("falls back to English when Swedish copy is incomplete", () => {
+    expect(tSv("bomAggregate.title")).toBe("Combine project materials");
+    expect(tSv("photoEstimate.title")).toBe("Estimate renovation from photos");
   });
 });
 

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -5837,24 +5837,30 @@ const translations = {
 type Translations = typeof translations;
 type TranslationTree = Translations[Locale];
 
-/** Resolve a dot-notated key like 'auth.login' from the translations object */
-function resolve(obj: Record<string, unknown>, path: string): string {
+/** Resolve a dot-notated key like 'auth.login' from a translation tree. */
+function resolve(obj: Record<string, unknown>, path: string): string | undefined {
   const parts = path.split('.');
   let current: unknown = obj;
   for (const part of parts) {
     if (current && typeof current === 'object' && part in (current as Record<string, unknown>)) {
       current = (current as Record<string, unknown>)[part];
     } else {
-      return path;
+      return undefined;
     }
   }
-  return typeof current === 'string' ? current : path;
+  return typeof current === 'string' ? current : undefined;
 }
 
 export function getTranslation(locale: Locale) {
   const tree = translations[locale] as unknown as Record<string, unknown>;
+  const englishTree = translations.en as unknown as Record<string, unknown>;
+  const finnishTree = translations.fi as unknown as Record<string, unknown>;
   return function t(key: string, params?: Record<string, string | number>): string {
-    let value = resolve(tree, key);
+    let value =
+      resolve(tree, key) ??
+      (locale !== 'en' ? resolve(englishTree, key) : undefined) ??
+      (locale !== 'fi' ? resolve(finnishTree, key) : undefined) ??
+      key;
     if (params) {
       for (const [k, v] of Object.entries(params)) {
         value = value.replace(`{{${k}}}`, String(v));


### PR DESCRIPTION
## Summary
- Harden the logged-in building lookup/import E2E flow by waiting for the actual `/building` response before asserting rendered results.
- Add translation fallback from selected locale to English/Finnish before returning the raw key, preventing incomplete Swedish copy from leaking internal keys into UI.
- Cover Swedish fallback behavior with unit tests.

## Validation
- `npm test` in `api`
- `npm test` in `web`
- `npm run build` in `api`
- `npm run build` in `web`
- `npm run typecheck && npm test` in `scraper`
- `npm test -- src/lib/__tests__/i18n.test.ts src/__tests__/i18n.test.ts src/__tests__/i18n-completeness.test.ts` in `web`
- `npm run test:local -- tests/building-lookup.spec.ts` in `e2e`
- `npm run test:local` in `e2e`: 170 passed