### PR TITLE
Fix upgrade CTA route

### DIFF
--- a/web/src/__tests__/upgrade-gate.test.tsx
+++ b/web/src/__tests__/upgrade-gate.test.tsx
@@ -74,10 +74,10 @@ describe("UpgradeGate", () => {
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
-  it("navigates to /pricing on CTA click", () => {
+  it("navigates to /pro on CTA click", () => {
     render(<UpgradeGate feature="premiumExport" requiredPlan="pro" currentPlan="free" />);
     fireEvent.click(screen.getByText("upgrade.ctaPro"));
-    expect(window.location.href).toBe("/pricing");
+    expect(window.location.href).toBe("/pro");
   });
 
   it("renders feature comparison table header", () => {

--- a/web/src/components/UpgradeGate.tsx
+++ b/web/src/components/UpgradeGate.tsx
@@ -308,8 +308,7 @@ export default function UpgradeGate({
             cursor: "pointer",
           }}
           onClick={() => {
-            // TODO: navigate to /pricing once payment integration is added
-            window.location.href = "/pricing";
+            window.location.href = "/pro";
           }}
         >
           {ctaLabel}


### PR DESCRIPTION
## Summary
- Route the UpgradeGate CTA to the existing `/pro` page instead of the nonexistent `/pricing` route.
- Update the UpgradeGate test so it protects the live Pro route.

## Validation
- `cd web && npm test -- src/__tests__/upgrade-gate.test.tsx`
- `cd web && npm test`
- `cd web && npm run build`
- `cd api && npm test`
- `cd api && npm run build`
- `cd scraper && npm test`
- `cd scraper && npm run typecheck`
- `cd e2e && E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@localhost:55433/helscoop E2E_API_PORT=3151 E2E_WEB_PORT=3152 TEST_API_URL=http://localhost:3151 TEST_WEB_URL=http://localhost:3152 npm run test:local` (170 passed)

Note: the default Docker-backed E2E startup timed out locally before Playwright because Docker did not return from `docker compose up -d db`; the rerun used an isolated local Postgres instance and separate web/API ports.