### PR TITLE
Harden client storage handling

### DIFF
--- a/web/src/__tests__/OnboardingTour.test.tsx
+++ b/web/src/__tests__/OnboardingTour.test.tsx
@@ -274,4 +274,16 @@ describe("isOnboardingCompleted / resetOnboarding", () => {
     resetOnboarding();
     expect(isOnboardingCompleted()).toBe(false);
   });
+
+  it("does not throw when localStorage is blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(isOnboardingCompleted()).toBe(false);
+    expect(() => resetOnboarding()).not.toThrow();
+  });
 });

--- a/web/src/__tests__/ambient-sound.test.ts
+++ b/web/src/__tests__/ambient-sound.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/sounds", () => ({
   playSound: vi.fn(),
@@ -11,6 +11,10 @@ import { renderHook, act } from "@testing-library/react";
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("getAmbientSoundEnabled", () => {
@@ -27,6 +31,14 @@ describe("getAmbientSoundEnabled", () => {
     localStorage.setItem("helscoop_ambient_sound", "false");
     expect(getAmbientSoundEnabled()).toBe(false);
   });
+
+  it("returns false when localStorage reads are blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(getAmbientSoundEnabled()).toBe(false);
+  });
 });
 
 describe("setAmbientSoundEnabled", () => {
@@ -39,6 +51,14 @@ describe("setAmbientSoundEnabled", () => {
     setAmbientSoundEnabled(false);
     expect(localStorage.getItem("helscoop_ambient_sound")).toBe("false");
   });
+
+  it("does not throw when localStorage writes are blocked", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(() => setAmbientSoundEnabled(true)).not.toThrow();
+  });
 });
 
 describe("useAmbientSound", () => {
@@ -50,6 +70,16 @@ describe("useAmbientSound", () => {
   it("does not play when sound is disabled", () => {
     const { result } = renderHook(() => useAmbientSound());
     act(() => { result.current.play("save"); });
+    expect(playSound).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when localStorage reads are blocked during playback", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+    const { result } = renderHook(() => useAmbientSound());
+
+    expect(() => act(() => { result.current.play("save"); })).not.toThrow();
     expect(playSound).not.toHaveBeenCalled();
   });
 

--- a/web/src/__tests__/i18n.test.ts
+++ b/web/src/__tests__/i18n.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getTranslation, detectLocale, persistLocale } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
 
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("getTranslation", () => {
@@ -67,6 +71,15 @@ describe("detectLocale", () => {
     Object.defineProperty(navigator, "language", { value: "en-US", writable: true, configurable: true });
     expect(detectLocale()).toBe("en");
   });
+
+  it("falls back to browser language when localStorage is blocked", () => {
+    Object.defineProperty(navigator, "language", { value: "sv-FI", writable: true, configurable: true });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(detectLocale()).toBe("sv");
+  });
 });
 
 describe("persistLocale", () => {
@@ -84,5 +97,13 @@ describe("persistLocale", () => {
     persistLocale("fi");
     persistLocale("en");
     expect(localStorage.getItem("helscoop_locale")).toBe("en");
+  });
+
+  it("does not throw when localStorage is blocked", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(() => persistLocale("en")).not.toThrow();
   });
 });

--- a/web/src/__tests__/theme-provider.test.tsx
+++ b/web/src/__tests__/theme-provider.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, act, renderHook } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import { ThemeProvider, useTheme, DARK_MOODS } from "@/components/ThemeProvider";
@@ -27,6 +27,10 @@ beforeEach(() => {
       removeEventListener: vi.fn(),
     })),
   });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 function TestConsumer() {
@@ -126,6 +130,16 @@ describe("ThemeProvider", () => {
     expect(screen.getByTestId("mood").textContent).toBe("black");
   });
 
+  it("renders with defaults when localStorage reads are blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+    expect(screen.getByTestId("mood").textContent).toBe("warm");
+  });
+
   it("sets data-theme attribute on document", () => {
     render(<ThemeProvider><TestConsumer /></ThemeProvider>);
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
@@ -150,6 +164,20 @@ describe("ThemeProvider", () => {
       screen.getByTestId("toggle").click();
     });
     expect(localStorage.getItem("helscoop-theme")).toBe("light");
+  });
+
+  it("theme changes still work when localStorage writes are blocked", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    render(<ThemeProvider><TestConsumer /></ThemeProvider>);
+    act(() => {
+      screen.getByTestId("set-light").click();
+      screen.getByTestId("set-mood-cool").click();
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(screen.getByTestId("mood").textContent).toBe("cool");
   });
 
   it("responds to system preference changes", () => {

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -43,6 +43,7 @@ import {
   type SceneGeometryMetrics,
 } from "@/lib/scene-geometry-bom";
 import { replaceSceneMaterialReferences } from "@/lib/scene-materials";
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 import { countSceneAddCalls } from "@/lib/scene-a11y";
 import {
   calculateSurfaceAnnualHeatLossKwh,
@@ -441,8 +442,11 @@ export default function ProjectPage() {
   const [showConfetti, setShowConfetti] = useState(false);
   const [bomWidth, setBomWidth] = useState(() => {
     if (typeof window !== "undefined") {
-      const saved = localStorage.getItem("helscoop_bom_width");
-      if (saved) return clampBomWidth(parseInt(saved, 10));
+      const saved = safeGetLocalStorageItem("helscoop_bom_width");
+      if (saved) {
+        const parsed = Number.parseInt(saved, 10);
+        if (Number.isFinite(parsed)) return clampBomWidth(parsed);
+      }
     }
     return 340;
   });
@@ -1102,7 +1106,7 @@ export default function ProjectPage() {
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
       setBomWidth((w) => {
-        localStorage.setItem("helscoop_bom_width", String(w));
+        safeSetLocalStorageItem("helscoop_bom_width", String(w));
         return w;
       });
     };
@@ -1130,7 +1134,7 @@ export default function ProjectPage() {
       document.removeEventListener("touchend", onEnd);
       document.removeEventListener("touchcancel", onEnd);
       setBomWidth((w) => {
-        localStorage.setItem("helscoop_bom_width", String(w));
+        safeSetLocalStorageItem("helscoop_bom_width", String(w));
         return w;
       });
     };

--- a/web/src/components/Minimap.tsx
+++ b/web/src/components/Minimap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useCallback, useState } from "react";
 import * as THREE from "three";
 import type { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 
 const MINIMAP_W = 200;
 const MINIMAP_H = 140;
@@ -31,7 +32,7 @@ export default function Minimap({ sceneRef, cameraRef, controlsRef, sceneBoundsR
   const offsetRef = useRef(new THREE.Vector3());
 
   useEffect(() => {
-    const saved = localStorage.getItem("helscoop-minimap-visible");
+    const saved = safeGetLocalStorageItem("helscoop-minimap-visible");
     if (saved !== null) setVisible(saved !== "false");
 
     const handleKey = (e: KeyboardEvent) => {
@@ -41,7 +42,7 @@ export default function Minimap({ sceneRef, cameraRef, controlsRef, sceneBoundsR
         e.preventDefault();
         setVisible((v) => {
           const next = !v;
-          localStorage.setItem("helscoop-minimap-visible", String(next));
+          safeSetLocalStorageItem("helscoop-minimap-visible", String(next));
           return next;
         });
       }

--- a/web/src/components/OnboardingTour.tsx
+++ b/web/src/components/OnboardingTour.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import { hasAuthSession } from "@/lib/api";
+import { safeGetLocalStorageItem, safeRemoveLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 const STORAGE_KEY = "helscoop_onboarding_completed";
@@ -100,15 +101,15 @@ function computeTooltipPosition(
 
 export function isOnboardingCompleted(): boolean {
   if (typeof window === "undefined") return true;
-  return localStorage.getItem(STORAGE_KEY) === "true";
+  return safeGetLocalStorageItem(STORAGE_KEY) === "true";
 }
 
 export function resetOnboarding(): void {
-  localStorage.removeItem(STORAGE_KEY);
+  safeRemoveLocalStorageItem(STORAGE_KEY);
 }
 
 function completeOnboarding(): void {
-  localStorage.setItem(STORAGE_KEY, "true");
+  safeSetLocalStorageItem(STORAGE_KEY, "true");
 }
 
 /** Welcome modal shown on first visit */

--- a/web/src/components/ThemeProvider.tsx
+++ b/web/src/components/ThemeProvider.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   type ReactNode,
 } from "react";
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 
 type ThemeChoice = "dark" | "light" | "auto";
 export type DarkMood = "warm" | "cool" | "black";
@@ -50,11 +51,11 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [prefersDark, setPrefersDark] = useState(true);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY) as ThemeChoice | null;
+    const stored = safeGetLocalStorageItem(STORAGE_KEY) as ThemeChoice | null;
     if (stored && CYCLE.includes(stored)) {
       setThemeState(stored);
     }
-    const storedMood = localStorage.getItem(MOOD_KEY) as DarkMood | null;
+    const storedMood = safeGetLocalStorageItem(MOOD_KEY) as DarkMood | null;
     if (storedMood && DARK_MOODS.includes(storedMood)) {
       setMoodState(storedMood);
     }
@@ -79,19 +80,19 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   const setTheme = useCallback((t: ThemeChoice) => {
     setThemeState(t);
-    localStorage.setItem(STORAGE_KEY, t);
+    safeSetLocalStorageItem(STORAGE_KEY, t);
   }, []);
 
   const setMood = useCallback((m: DarkMood) => {
     setMoodState(m);
-    localStorage.setItem(MOOD_KEY, m);
+    safeSetLocalStorageItem(MOOD_KEY, m);
   }, []);
 
   const toggle = useCallback(() => {
     setThemeState((prev) => {
       const idx = CYCLE.indexOf(prev);
       const next = CYCLE[(idx + 1) % CYCLE.length];
-      localStorage.setItem(STORAGE_KEY, next);
+      safeSetLocalStorageItem(STORAGE_KEY, next);
       return next;
     });
   }, []);

--- a/web/src/hooks/useAmbientSound.ts
+++ b/web/src/hooks/useAmbientSound.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 import { playSound, type SoundName } from "@/lib/sounds";
 
 const STORAGE_KEY = "helscoop_ambient_sound";
@@ -8,19 +9,19 @@ const STORAGE_KEY = "helscoop_ambient_sound";
 function isEnabled(): boolean {
   if (typeof window === "undefined") return false;
   if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
-    const explicit = localStorage.getItem(STORAGE_KEY);
+    const explicit = safeGetLocalStorageItem(STORAGE_KEY);
     if (explicit !== "true") return false;
   }
-  return localStorage.getItem(STORAGE_KEY) === "true";
+  return safeGetLocalStorageItem(STORAGE_KEY) === "true";
 }
 
 export function getAmbientSoundEnabled(): boolean {
   if (typeof window === "undefined") return false;
-  return localStorage.getItem(STORAGE_KEY) === "true";
+  return safeGetLocalStorageItem(STORAGE_KEY) === "true";
 }
 
 export function setAmbientSoundEnabled(enabled: boolean): void {
-  localStorage.setItem(STORAGE_KEY, String(enabled));
+  safeSetLocalStorageItem(STORAGE_KEY, String(enabled));
 }
 
 export function useAmbientSound() {

--- a/web/src/lib/__tests__/api-client.test.ts
+++ b/web/src/lib/__tests__/api-client.test.ts
@@ -60,6 +60,24 @@ describe("setToken / getToken", () => {
     expect(localStorage.getItem("helscoop_token")).toBeNull();
     expect(localStorage.getItem("helscoop_token_expires_at")).toBeNull();
   });
+
+  it("keeps in-memory auth usable when localStorage is blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(() => setToken("memory-token", Math.floor(Date.now() / 1000) + 3600)).not.toThrow();
+    expect(getToken()).toBe("memory-token");
+    expect(hasAuthSession()).toBe(true);
+    expect(() => setToken(null)).not.toThrow();
+    expect(hasAuthSession()).toBe(false);
+  });
 });
 
 describe("blob-backed downloads", () => {

--- a/web/src/lib/__tests__/browser-storage.test.ts
+++ b/web/src/lib/__tests__/browser-storage.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  safeGetLocalStorageItem,
+  safeRemoveLocalStorageItem,
+  safeSetLocalStorageItem,
+} from "@/lib/browser-storage";
+
+describe("browser-storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reads, writes, and removes localStorage values", () => {
+    expect(safeSetLocalStorageItem("k", "v")).toBe(true);
+    expect(safeGetLocalStorageItem("k")).toBe("v");
+    expect(safeRemoveLocalStorageItem("k")).toBe(true);
+    expect(safeGetLocalStorageItem("k")).toBeNull();
+  });
+
+  it("returns null when localStorage reads are blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(safeGetLocalStorageItem("k")).toBeNull();
+  });
+
+  it("returns false instead of throwing when localStorage writes are blocked", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(safeSetLocalStorageItem("k", "v")).toBe(false);
+  });
+
+  it("returns false instead of throwing when localStorage removes are blocked", () => {
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new DOMException("localStorage blocked", "SecurityError");
+    });
+
+    expect(safeRemoveLocalStorageItem("k")).toBe(false);
+  });
+});

--- a/web/src/lib/__tests__/i18n.test.ts
+++ b/web/src/lib/__tests__/i18n.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { getTranslation, detectLocale, persistLocale } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
 
@@ -25,6 +25,10 @@ function mockLocalStorage(data: Record<string, string> = {}) {
     key: vi.fn((i: number) => Object.keys(store)[i] ?? null),
   };
 }
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // ---------------------------------------------------------------------------
 // 1. Locale detection
@@ -102,18 +106,19 @@ describe("detectLocale", () => {
 // ---------------------------------------------------------------------------
 
 describe("persistLocale", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("stores locale in localStorage", () => {
-    const ls = mockLocalStorage();
-    vi.stubGlobal("localStorage", ls);
     persistLocale("en");
-    expect(ls.setItem).toHaveBeenCalledWith("helscoop_locale", "en");
+    expect(localStorage.getItem("helscoop_locale")).toBe("en");
   });
 
   it("overwrites previous locale", () => {
-    const ls = mockLocalStorage({ helscoop_locale: "fi" });
-    vi.stubGlobal("localStorage", ls);
+    localStorage.setItem("helscoop_locale", "fi");
     persistLocale("en");
-    expect(ls.setItem).toHaveBeenCalledWith("helscoop_locale", "en");
+    expect(localStorage.getItem("helscoop_locale")).toBe("en");
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,7 @@ import type {
   Template,
   SharePreviewState,
 } from "@/types";
+import { safeGetLocalStorageItem, safeRemoveLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 const SESSION_ACTIVE_KEY = "helscoop_session_active";
@@ -62,46 +63,33 @@ let tokenExpiresAt: number | null = null;
 // Background refresh timer handle — see scheduleProactiveRefresh() below.
 let _refreshTimerId: ReturnType<typeof setTimeout> | null = null;
 
-function hasStorage(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return typeof window.localStorage !== "undefined";
-  } catch {
-    return false;
-  }
-}
-
 function clearLegacyTokenStorage(): void {
-  if (!hasStorage()) return;
-  localStorage.removeItem(LEGACY_TOKEN_KEY);
-  localStorage.removeItem(LEGACY_TOKEN_EXPIRES_KEY);
+  safeRemoveLocalStorageItem(LEGACY_TOKEN_KEY);
+  safeRemoveLocalStorageItem(LEGACY_TOKEN_EXPIRES_KEY);
 }
 
 function persistSessionHint(expiresAt?: number | null): void {
-  if (!hasStorage()) return;
   clearLegacyTokenStorage();
-  localStorage.setItem(SESSION_ACTIVE_KEY, "true");
+  safeSetLocalStorageItem(SESSION_ACTIVE_KEY, "true");
   if (expiresAt) {
-    localStorage.setItem(SESSION_EXPIRES_KEY, String(expiresAt));
+    safeSetLocalStorageItem(SESSION_EXPIRES_KEY, String(expiresAt));
   } else {
-    localStorage.removeItem(SESSION_EXPIRES_KEY);
+    safeRemoveLocalStorageItem(SESSION_EXPIRES_KEY);
   }
 }
 
 function clearSessionHint(): void {
-  if (!hasStorage()) return;
   clearLegacyTokenStorage();
-  localStorage.removeItem(SESSION_ACTIVE_KEY);
-  localStorage.removeItem(SESSION_EXPIRES_KEY);
+  safeRemoveLocalStorageItem(SESSION_ACTIVE_KEY);
+  safeRemoveLocalStorageItem(SESSION_EXPIRES_KEY);
 }
 
 function loadSessionExpiryHint(): number | null {
-  if (!hasStorage()) return tokenExpiresAt;
-  const raw = localStorage.getItem(SESSION_EXPIRES_KEY);
+  const raw = safeGetLocalStorageItem(SESSION_EXPIRES_KEY);
   if (!raw) return tokenExpiresAt;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed)) {
-    localStorage.removeItem(SESSION_EXPIRES_KEY);
+    safeRemoveLocalStorageItem(SESSION_EXPIRES_KEY);
     return tokenExpiresAt;
   }
   tokenExpiresAt = parsed;
@@ -127,9 +115,8 @@ export function getToken(): string | null {
 
 export function hasAuthSession(): boolean {
   if (token) return true;
-  if (!hasStorage()) return false;
   clearLegacyTokenStorage();
-  if (localStorage.getItem(SESSION_ACTIVE_KEY) !== "true") return false;
+  if (safeGetLocalStorageItem(SESSION_ACTIVE_KEY) !== "true") return false;
   const expiresAt = loadSessionExpiryHint();
   if (expiresAt && expiresAt <= Math.floor(Date.now() / 1000)) {
     clearSessionHint();

--- a/web/src/lib/browser-storage.ts
+++ b/web/src/lib/browser-storage.ts
@@ -1,0 +1,28 @@
+export function safeGetLocalStorageItem(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function safeSetLocalStorageItem(key: string, value: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function safeRemoveLocalStorageItem(key: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1,3 +1,5 @@
+import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
+
 export type Locale = 'fi' | 'en' | 'sv';
 
 const translations = {
@@ -5966,7 +5968,7 @@ export function getTranslation(locale: Locale) {
 
 export function detectLocale(): Locale {
   if (typeof window === 'undefined') return 'fi';
-  const stored = localStorage.getItem('helscoop_locale');
+  const stored = safeGetLocalStorageItem('helscoop_locale');
   if (stored === 'fi' || stored === 'en' || stored === 'sv') return stored;
   const browserLang = navigator.language.toLowerCase();
   if (browserLang.startsWith('en')) return 'en';
@@ -5975,5 +5977,5 @@ export function detectLocale(): Locale {
 }
 
 export function persistLocale(locale: Locale) {
-  localStorage.setItem('helscoop_locale', locale);
+  safeSetLocalStorageItem('helscoop_locale', locale);
 }


### PR DESCRIPTION
## Summary
- Add safe localStorage helpers that degrade gracefully when browser storage is blocked or throws.
- Use the safe helpers in critical client startup/session paths: locale detection, theme/mood, onboarding, ambient sound, auth session hints, minimap visibility, and BOM panel width persistence.
- Ignore corrupt persisted BOM panel widths instead of letting `NaN` leak into layout state.
- Add regression coverage for blocked localStorage reads/writes/removes.

## Validation
- `cd web && npm test -- src/lib/__tests__/browser-storage.test.ts src/__tests__/i18n.test.ts src/__tests__/theme-provider.test.tsx src/__tests__/ambient-sound.test.ts src/__tests__/OnboardingTour.test.tsx src/lib/__tests__/api-client.test.ts`
- `cd web && npm test` (168 files, 2134 tests)
- `cd web && npm run build`
- `cd api && npm test` (1515 passed, 23 skipped in existing env-gated file)
- `cd api && npm run build`
- `cd scraper && npm test`
- `cd scraper && npm run typecheck`
- `cd e2e && E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@localhost:55434/helscoop E2E_API_PORT=3251 E2E_WEB_PORT=3252 TEST_API_URL=http://localhost:3251 TEST_WEB_URL=http://localhost:3252 npm run test:local` (170 passed)

Note: local E2E used an isolated local Postgres instance because the local Docker control plane has recently timed out before Playwright. GitHub Docker CI remains the merge gate.