### PR TITLE
Harden clipboard flows and E2E session seeding

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -46,8 +46,10 @@ export async function setAuthToken(page: Page, token: string): Promise<void> {
     localStorage.setItem("helscoop_onboarding_completed", "true");
   };
   await page.addInitScript(seedSession, token);
-  await page.goto("/", { waitUntil: "domcontentloaded" });
-  await page.waitForTimeout(1500);
+  await page.goto("/", { waitUntil: "commit" });
+  await page
+    .waitForFunction(() => document.readyState !== "loading", undefined, { timeout: 10_000 })
+    .catch(() => {});
 
   const isLoggedIn = await page
     .getByText(/omat projektit|my projects/i)
@@ -61,8 +63,10 @@ export async function setAuthToken(page: Page, token: string): Promise<void> {
       .catch(() => false);
     if (hasLoginForm) {
       await page.evaluate(seedSession, token);
-      await page.goto("/", { waitUntil: "domcontentloaded" });
-      await page.waitForTimeout(1500);
+      await page.goto("/", { waitUntil: "commit" });
+      await page
+        .waitForFunction(() => document.readyState !== "loading", undefined, { timeout: 10_000 })
+        .catch(() => {});
     }
   }
 }

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/lib/scene-geometry-bom";
 import { replaceSceneMaterialReferences } from "@/lib/scene-materials";
 import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { countSceneAddCalls } from "@/lib/scene-a11y";
 import {
   calculateSurfaceAnnualHeatLossKwh,
@@ -3743,14 +3744,14 @@ export default function ProjectPage() {
             <button
               className="btn btn-ghost save-failure-btn"
               onClick={async () => {
-                try {
-                  await navigator.clipboard.writeText(sceneJs);
+                const copiedToClipboard = await copyTextToClipboard(sceneJs);
+                if (copiedToClipboard) {
                   setClipboardCopied(true);
                   toast(t('editor.saveFailedCopied'), "success");
                   setTimeout(() => setClipboardCopied(false), 2000);
-                } catch {
-                  toast(t('toast.copyFailed'), "error");
+                  return;
                 }
+                toast(t('toast.copyFailed'), "error");
               }}
             >
               {clipboardCopied ? t('editor.saveFailedCopied') : t('editor.saveFailedCopy')}
@@ -5421,14 +5422,14 @@ export default function ProjectPage() {
                 className="btn btn-primary"
                 onClick={async () => {
                   const url = `${window.location.origin}/shared/${shareToken}`;
-                  try {
-                    await navigator.clipboard.writeText(url);
+                  const copiedToClipboard = await copyTextToClipboard(url);
+                  if (copiedToClipboard) {
                     setShareCopied(true);
                     toast(t('toast.linkCopied'), "success");
                     setTimeout(() => setShareCopied(false), 2000);
-                  } catch {
-                    toast(t('toast.copyFailed'), "error");
+                    return;
                   }
+                  toast(t('toast.copyFailed'), "error");
                 }}
                 style={{ padding: "10px 16px", fontSize: 13, fontWeight: 600, flexShrink: 0 }}
               >

--- a/web/src/components/BeforeAfterSharePanel.tsx
+++ b/web/src/components/BeforeAfterSharePanel.tsx
@@ -11,6 +11,7 @@ import {
   sanitizePresentationFilename,
   type PresentationPresetId,
 } from "@/lib/presentation-export";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type { ViewportPresentationApi } from "@/components/Viewport3D";
 import type { SharePreviewState } from "@/types";
 
@@ -227,15 +228,15 @@ export default function BeforeAfterSharePanel({
     const saved = savedPreview ? { preview: savedPreview, token: shareToken } : await generateAndSavePreview();
     if (!saved) return;
     const url = buildBeforeAfterShareUrl(window.location.origin, saved.token);
-    try {
-      await navigator.clipboard.writeText(url);
+    const copiedToClipboard = await copyTextToClipboard(url);
+    if (copiedToClipboard) {
       setCopied(true);
       onCopySuccess();
       track("before_after_share_link_copied", { project_id: projectId });
       window.setTimeout(() => setCopied(false), 1800);
-    } catch {
-      onCopyError();
+      return;
     }
+    onCopyError();
   }
 
   async function downloadComparison() {

--- a/web/src/components/BlueprintToScenePanel.tsx
+++ b/web/src/components/BlueprintToScenePanel.tsx
@@ -9,6 +9,7 @@ import {
   recognizeBlueprintFromMetadata,
   type BlueprintRecognitionResult,
 } from "@/lib/blueprint-to-scene";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type { BuildingInfo } from "@/types";
 
 const COPY = {
@@ -153,7 +154,7 @@ export default function BlueprintToScenePanel({
   projectName?: string;
   onApplyScene?: (sceneJs: string) => void;
 }) {
-  const { locale } = useTranslation();
+  const { locale, t } = useTranslation();
   const { toast } = useToast();
   const { track } = useAnalytics();
   const inputId = useId();
@@ -212,15 +213,23 @@ export default function BlueprintToScenePanel({
   }
 
   async function copyScene() {
-    if (!result || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(result.sceneJs);
+    if (!result) return;
+    const copiedToClipboard = await copyTextToClipboard(result.sceneJs);
+    if (!copiedToClipboard) {
+      toast(t("toast.copyFailed"), "error");
+      return;
+    }
     setCopied("scene");
     toast(labels.copied, "success");
   }
 
   async function copyHandoff() {
-    if (!result || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(formatBlueprintHandoff(result));
+    if (!result) return;
+    const copiedToClipboard = await copyTextToClipboard(formatBlueprintHandoff(result));
+    if (!copiedToClipboard) {
+      toast(t("toast.copyFailed"), "error");
+      return;
+    }
     setCopied("handoff");
     toast(labels.handoffCopied, "success");
   }

--- a/web/src/components/KrautaProPartnerPanel.tsx
+++ b/web/src/components/KrautaProPartnerPanel.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import { api } from "@/lib/api";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import {
   buildKrautaProPackage,
   formatKrautaProPackage,
@@ -124,9 +125,8 @@ export default function KrautaProPartnerPanel({
 
   const copyPackage = async () => {
     const text = formatKrautaProPackage(plan, projectName, activeLocale === "fi" ? "fi" : "en");
-    if (typeof navigator !== "undefined" && navigator.clipboard) {
-      await navigator.clipboard.writeText(text);
-    }
+    const copiedToClipboard = await copyTextToClipboard(text);
+    if (!copiedToClipboard) return;
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1600);
   };

--- a/web/src/components/PhasedRenovationPlannerPanel.tsx
+++ b/web/src/components/PhasedRenovationPlannerPanel.tsx
@@ -9,6 +9,7 @@ import {
   type PhasedRenovationPhase,
   type PhasedRenovationYear,
 } from "@/lib/phased-renovation";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type { BomItem, BuildingInfo, Material } from "@/types";
 
 interface PhasedRenovationPlannerPanelProps {
@@ -206,9 +207,8 @@ export default function PhasedRenovationPlannerPanel({
 
   const copyHandoff = async () => {
     const text = formatPhasedRenovationPlan(plan, activeLocale === "sv" ? "en" : activeLocale);
-    if (typeof navigator !== "undefined" && navigator.clipboard) {
-      await navigator.clipboard.writeText(text);
-    }
+    const copiedToClipboard = await copyTextToClipboard(text);
+    if (!copiedToClipboard) return;
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1600);
   };

--- a/web/src/components/RenovationRoadmapPanel.tsx
+++ b/web/src/components/RenovationRoadmapPanel.tsx
@@ -7,6 +7,7 @@ import {
   formatRoadmapHandoff,
   type RoadmapPhase,
 } from "@/lib/renovation-roadmap";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type { BomItem, BuildingInfo, Material } from "@/types";
 import type { LocalizedText } from "@/lib/permit-checker";
 
@@ -139,7 +140,8 @@ export default function RenovationRoadmapPanel({
   if (bom.length === 0) return null;
 
   const copyHandoff = async () => {
-    await navigator.clipboard.writeText(formatRoadmapHandoff(roadmap, roadmapLocale === "sv" ? "en" : roadmapLocale));
+    const copiedToClipboard = await copyTextToClipboard(formatRoadmapHandoff(roadmap, roadmapLocale === "sv" ? "en" : roadmapLocale));
+    if (!copiedToClipboard) return;
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1600);
   };

--- a/web/src/components/SceneApiReference.tsx
+++ b/web/src/components/SceneApiReference.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
+import { copyTextToClipboard } from "@/lib/clipboard";
 
 /* ── DSL function definitions ──────────────────────────────── */
 
@@ -266,11 +267,11 @@ export default function SceneApiReference({
   const [activeSection, setActiveSection] = useState<Section>("primitives");
   const { t } = useTranslation();
 
-  const copyToClipboard = (code: string) => {
+  const copyToClipboard = async (code: string) => {
     if (onInsertCode) {
       onInsertCode(code);
     } else {
-      navigator.clipboard.writeText(code);
+      await copyTextToClipboard(code);
     }
   };
 

--- a/web/src/components/ScreenshotPopover.tsx
+++ b/web/src/components/ScreenshotPopover.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import { useToast } from "@/components/ToastProvider";
+import { copyImageBlobToClipboard, copyTextToClipboard } from "@/lib/clipboard";
 
 interface ScreenshotPopoverProps {
   /** Base64 data URL of the captured screenshot */
@@ -73,24 +74,25 @@ export default function ScreenshotPopover({
   const handleCopyToClipboard = useCallback(async () => {
     if (!imageDataUrl) return;
     try {
-      // Convert data URL to blob
       const res = await fetch(imageDataUrl);
       const blob = await res.blob();
-      await navigator.clipboard.write([
-        new ClipboardItem({ "image/png": blob }),
-      ]);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback: try to copy as text (some browsers don't support ClipboardItem)
-      try {
-        await navigator.clipboard.writeText(imageDataUrl);
+      const copiedImage = await copyImageBlobToClipboard(blob);
+      if (copiedImage) {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
-      } catch {
-        toast(t('toast.copyFailed'), "error");
+        return;
       }
+    } catch {
+      // Fall through to the text fallback below.
     }
+
+    const copiedDataUrl = await copyTextToClipboard(imageDataUrl);
+    if (copiedDataUrl) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      return;
+    }
+    toast(t('toast.copyFailed'), "error");
   }, [imageDataUrl, toast, t]);
 
   if (!imageDataUrl) return null;

--- a/web/src/components/SharePresentationPanel.tsx
+++ b/web/src/components/SharePresentationPanel.tsx
@@ -11,6 +11,7 @@ import {
   sanitizePresentationFilename,
   type PresentationPresetId,
 } from "@/lib/presentation-export";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type { BomItem } from "@/types";
 import type { ViewportPresentationApi } from "@/components/Viewport3D";
 
@@ -53,15 +54,15 @@ export default function SharePresentationPanel({
 
   const copyPresentationUrl = async () => {
     if (!presentationUrl) return;
-    try {
-      await navigator.clipboard.writeText(presentationUrl);
+    const copiedToClipboard = await copyTextToClipboard(presentationUrl);
+    if (copiedToClipboard) {
       setCopied(true);
       onCopySuccess();
       track("presentation_link_copied", { preset: selectedPreset });
       window.setTimeout(() => setCopied(false), 1800);
-    } catch {
-      onCopyError();
+      return;
     }
+    onCopyError();
   };
 
   const downloadRender = () => {

--- a/web/src/components/ShoppingListModal.tsx
+++ b/web/src/components/ShoppingListModal.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useCallback, useRef } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type { BomItem, Material } from "@/types";
 
 interface ShoppingListModalProps {
@@ -69,7 +70,7 @@ export default function ShoppingListModal({
     [localeTag],
   );
 
-  const handleCopy = useCallback(() => {
+  const handleCopy = useCallback(async () => {
     const lines: string[] = [];
     if (projectName) lines.push(projectName);
     lines.push("─".repeat(40));
@@ -83,7 +84,7 @@ export default function ShoppingListModal({
     }
     lines.push("");
     lines.push(`${t("shoppingList.grandTotal")}: ${formatPrice(grandTotal)}`);
-    navigator.clipboard.writeText(lines.join("\n"));
+    await copyTextToClipboard(lines.join("\n"));
   }, [supplierGroups, grandTotal, projectName, formatPrice, t]);
 
   const handlePrint = useCallback(() => {

--- a/web/src/lib/__tests__/clipboard.test.ts
+++ b/web/src/lib/__tests__/clipboard.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyImageBlobToClipboard, copyTextToClipboard } from "@/lib/clipboard";
+
+function setClipboard(value: Partial<Clipboard> | undefined) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value,
+  });
+}
+
+function setExecCommand(value: ((command: string) => boolean) | undefined) {
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setClipboard(undefined);
+  setExecCommand(undefined);
+  vi.stubGlobal("ClipboardItem", undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("clipboard helpers", () => {
+  it("uses the async Clipboard API when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText } as Partial<Clipboard>);
+
+    await expect(copyTextToClipboard("hello")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to a temporary textarea when writeText is blocked", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    const execCommand = vi.fn().mockReturnValue(true);
+    setClipboard({ writeText } as Partial<Clipboard>);
+    setExecCommand(execCommand);
+
+    await expect(copyTextToClipboard("fallback")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("fallback");
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("returns false when no clipboard path is available", async () => {
+    await expect(copyTextToClipboard("no api")).resolves.toBe(false);
+  });
+
+  it("copies image blobs when ClipboardItem and clipboard.write are available", async () => {
+    class TestClipboardItem {
+      constructor(readonly items: Record<string, Blob>) {}
+    }
+    const write = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("ClipboardItem", TestClipboardItem);
+    setClipboard({ write } as Partial<Clipboard>);
+
+    const blob = new Blob(["png"], { type: "image/png" });
+    await expect(copyImageBlobToClipboard(blob)).resolves.toBe(true);
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0][0][0]).toBeInstanceOf(TestClipboardItem);
+  });
+});

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -1,0 +1,100 @@
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  const clipboard = getNavigatorClipboard();
+
+  if (clipboard && typeof clipboard.writeText === "function") {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the textarea fallback below.
+    }
+  }
+
+  return copyTextWithTextarea(text);
+}
+
+export async function copyImageBlobToClipboard(blob: Blob): Promise<boolean> {
+  const clipboard = getNavigatorClipboard();
+
+  if (
+    !clipboard ||
+    typeof clipboard.write !== "function" ||
+    typeof ClipboardItem === "undefined"
+  ) {
+    return false;
+  }
+
+  try {
+    await clipboard.write([
+      new ClipboardItem({ [blob.type || "image/png"]: blob }),
+    ]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getNavigatorClipboard(): Clipboard | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  try {
+    return navigator.clipboard;
+  } catch {
+    return undefined;
+  }
+}
+
+function copyTextWithTextarea(text: string): boolean {
+  if (
+    typeof document === "undefined" ||
+    !document.body ||
+    typeof document.execCommand !== "function"
+  ) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  textarea.style.opacity = "0";
+
+  const activeElement = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
+  const selection = typeof window !== "undefined" ? window.getSelection() : null;
+  const selectedRanges = selection
+    ? Array.from({ length: selection.rangeCount }, (_, index) => selection.getRangeAt(index))
+    : [];
+
+  document.body.appendChild(textarea);
+  focusWithoutScroll(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+    try {
+      if (selection) {
+        selection.removeAllRanges();
+        selectedRanges.forEach((range) => selection.addRange(range));
+      }
+    } catch {
+      // Restoring a stale selection can fail if the original node was removed.
+    }
+    if (activeElement) focusWithoutScroll(activeElement);
+  }
+}
+
+function focusWithoutScroll(element: HTMLElement): void {
+  try {
+    element.focus({ preventScroll: true });
+  } catch {
+    element.focus();
+  }
+}


### PR DESCRIPTION
## Summary
- Add safe clipboard helpers with async Clipboard API handling, textarea fallback, and image blob support.
- Route copy/share/export handoff flows through the safe helper so failed clipboard permissions do not create unhandled rejections or false success states.
- Make E2E session seeding less flaky by waiting for navigation commit plus readyState instead of depending on a brittle DOMContentLoaded wait.

## Validation
- web: npm test (2138 passed)
- web: npm run build
- api: npm test (1515 passed, 23 skipped)
- api: npm run build
- scraper: npm test (5 passed)
- scraper: npm run typecheck
- e2e: npm run test:local -- tests/bom-interactions.spec.ts (20 passed)
- e2e: fresh-db npm run test:local (170 passed)