### PR TITLE
Harden browser download flows

### DIFF
--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -45,6 +45,7 @@ import {
 import { replaceSceneMaterialReferences } from "@/lib/scene-materials";
 import { safeGetLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { downloadBlob, downloadDataUrl } from "@/lib/download";
 import { countSceneAddCalls } from "@/lib/scene-a11y";
 import {
   calculateSurfaceAnnualHeatLossKwh,
@@ -570,10 +571,7 @@ export default function ProjectPage() {
     }
     try {
       const dataUrl = await composePhotoOverlayExport(modelFrame, photoOverlay);
-      const link = document.createElement("a");
-      link.href = dataUrl;
-      link.download = `${projectName.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_-]/g, "_") || "helscoop"}_photo_overlay.png`;
-      link.click();
+      downloadDataUrl(dataUrl, `${projectName.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_-]/g, "_") || "helscoop"}_photo_overlay.png`);
       toast(t("photoOverlay.exported"), "success");
       track("project_exported", { format: "photo_overlay_png" });
       playSound("exportDone");
@@ -2441,12 +2439,7 @@ export default function ProjectPage() {
               exportedAt: new Date().toISOString(),
             };
             const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement("a");
-            a.href = url;
-            a.download = `${projectName.replace(/\s+/g, '_')}.helscoop`;
-            a.click();
-            URL.revokeObjectURL(url);
+            downloadBlob(blob, `${projectName.replace(/\s+/g, '_')}.helscoop`);
             toast(t("toast.projectExported"), "success");
             playSound("exportDone");
           } catch (err) {
@@ -3575,12 +3568,7 @@ export default function ProjectPage() {
                       track("bom_exported", { format: "json" });
                       const res = await api.exportBOM(projectId);
                       const blob = new Blob([JSON.stringify(res, null, 2)], { type: "application/json" });
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement("a");
-                      a.href = url;
-                      a.download = `bom_${projectId}.json`;
-                      a.click();
-                      URL.revokeObjectURL(url);
+                      downloadBlob(blob, `bom_${projectId}.json`);
                       toast(t('toast.bomExported'), "success");
                       playSound("exportDone");
                     } catch (err) {
@@ -3633,12 +3621,7 @@ export default function ProjectPage() {
                         exportedAt: new Date().toISOString(),
                       };
                       const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: "application/json" });
-                      const url = URL.createObjectURL(blob);
-                      const a = document.createElement("a");
-                      a.href = url;
-                      a.download = `${projectName.replace(/\s+/g, '_')}.helscoop`;
-                      a.click();
-                      URL.revokeObjectURL(url);
+                      downloadBlob(blob, `${projectName.replace(/\s+/g, '_')}.helscoop`);
                       toast(t('toast.projectExported'), "success");
                       playSound("exportDone");
                     } catch (err) {

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -10,6 +10,7 @@ import { useTheme, DARK_MOODS, type DarkMood } from "@/components/ThemeProvider"
 import ConfirmDialog from "@/components/ConfirmDialog";
 import { resetOnboarding } from "@/components/OnboardingTour";
 import { getAmbientSoundEnabled, setAmbientSoundEnabled } from "@/hooks/useAmbientSound";
+import { downloadBlob } from "@/lib/download";
 import { playSound } from "@/lib/sounds";
 import { Skeleton, SkeletonBlock } from "@/components/Skeleton";
 import Link from "next/link";
@@ -158,13 +159,8 @@ export default function SettingsPage() {
     try {
       const data = await api.exportData();
       const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
       const date = new Date().toISOString().split("T")[0];
-      a.download = `helscoop_data_export_${date}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
+      downloadBlob(blob, `helscoop_data_export_${date}.json`);
       toast(t("settings.dataExported"), "success");
     } catch (err) {
       toast(

--- a/web/src/app/shared/[token]/SharedProjectContent.tsx
+++ b/web/src/app/shared/[token]/SharedProjectContent.tsx
@@ -8,6 +8,7 @@ import { api, ApiError } from "@/lib/api";
 import { useTranslation } from "@/components/LocaleProvider";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { getPresentationPreset } from "@/lib/presentation-export";
+import { downloadBlob } from "@/lib/download";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import BeforeAfterComparison from "@/components/BeforeAfterComparison";
 import type { BomItem, Project, SharedProjectComment } from "@/types";
@@ -45,13 +46,8 @@ function exportBomCsv(
 
   const csv = '\uFEFF' + headers.map((h) => escapeCsvField(h, sep)).join(sep) + '\n' + rows.join('\n') + '\n';
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
   const safe = projectName.replace(/[^a-zA-Z0-9_-]/g, '_').substring(0, 40);
-  a.download = `helscoop-bom-${safe}-${new Date().toISOString().slice(0, 10)}.csv`;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, `helscoop-bom-${safe}-${new Date().toISOString().slice(0, 10)}.csv`);
 }
 
 function Viewport3DLoading() {

--- a/web/src/components/ArCameraOverlay.tsx
+++ b/web/src/components/ArCameraOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
+import { downloadDataUrl } from "@/lib/download";
 import type { ViewportPresentationApi } from "@/components/Viewport3D";
 
 export interface ArModification {
@@ -34,13 +35,6 @@ function safeFileName(name: string): string {
     .replace(/\s+/g, "-")
     .replace(/[^a-zA-Z0-9_-]/g, "")
     .toLowerCase() || "helscoop-ar";
-}
-
-function downloadDataUrl(dataUrl: string, filename: string) {
-  const link = document.createElement("a");
-  link.href = dataUrl;
-  link.download = filename;
-  link.click();
 }
 
 function drawCover(

--- a/web/src/components/BeforeAfterSharePanel.tsx
+++ b/web/src/components/BeforeAfterSharePanel.tsx
@@ -12,6 +12,7 @@ import {
   type PresentationPresetId,
 } from "@/lib/presentation-export";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { downloadDataUrl } from "@/lib/download";
 import type { ViewportPresentationApi } from "@/components/Viewport3D";
 import type { SharePreviewState } from "@/types";
 
@@ -39,13 +40,6 @@ function nextFrame(): Promise<void> {
     }
     setTimeout(resolve, 0);
   });
-}
-
-function downloadDataUrl(dataUrl: string, filename: string) {
-  const link = document.createElement("a");
-  link.download = filename;
-  link.href = dataUrl;
-  link.click();
 }
 
 function loadImage(dataUrl: string): Promise<HTMLImageElement> {

--- a/web/src/components/BomPanel.tsx
+++ b/web/src/components/BomPanel.tsx
@@ -29,6 +29,7 @@ import RoomScanImportPanel from "@/components/RoomScanImportPanel";
 import PermitCheckerPanel from "@/components/PermitCheckerPanel";
 import ShoppingListModal from "@/components/ShoppingListModal";
 import { api } from "@/lib/api";
+import { downloadBlob } from "@/lib/download";
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { interpretScene, extractSceneMaterials } from "@/lib/scene-interpreter";
 import { detectHeatingGrantOpportunity } from "@/lib/heating-grant-context";
@@ -1943,12 +1944,7 @@ function generateBomCsv(
 /** Trigger a browser download of a CSV string */
 function downloadCsv(csv: string, filename: string): void {
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, filename);
 }
 
 export default function BomPanel({

--- a/web/src/components/ConstructionTimelapsePanel.tsx
+++ b/web/src/components/ConstructionTimelapsePanel.tsx
@@ -12,6 +12,7 @@ import {
   type TimelapseCameraMode,
   type TimelapseSpeed,
 } from "@/lib/construction-timelapse";
+import { downloadBlob } from "@/lib/download";
 import type { AssemblyGuide } from "@/lib/assembly-guide";
 
 interface ConstructionTimelapsePanelProps {
@@ -46,15 +47,7 @@ function fileSafe(value: string): string {
 
 function downloadTextFile(text: string, filename: string, mimeType: string) {
   const blob = new Blob([text], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  link.style.display = "none";
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
+  downloadBlob(blob, filename);
 }
 
 function cameraModeLabel(mode: TimelapseCameraMode): string {

--- a/web/src/components/DaylightPanel.tsx
+++ b/web/src/components/DaylightPanel.tsx
@@ -11,6 +11,7 @@ import {
   SEASON_PRESETS,
   sunPositionToLightDirection,
 } from "@/lib/sun-position";
+import { downloadBlob } from "@/lib/download";
 import type { SeasonalLighting, ShadowStudy } from "@/lib/sun-position";
 
 export interface DaylightViewportShadowStudy {
@@ -53,12 +54,7 @@ function parseDateValue(value: string): { year: number; month: number; day: numb
 
 function downloadSvg(filename: string, svg: string) {
   const blob = new Blob([svg], { type: "image/svg+xml;charset=utf-8" });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement("a");
-  anchor.href = url;
-  anchor.download = filename;
-  anchor.click();
-  URL.revokeObjectURL(url);
+  downloadBlob(blob, filename);
 }
 
 export default function DaylightPanel({

--- a/web/src/components/ProjectList.tsx
+++ b/web/src/components/ProjectList.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { api, logout } from "@/lib/api";
+import { downloadBlob } from "@/lib/download";
 import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectCard, SkeletonBlock } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
@@ -405,14 +406,7 @@ export default function ProjectList({
     ];
     const csv = rows.map((row) => row.map(escape).join(",")).join("\n");
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `helscoop_combined_bom_${new Date().toISOString().slice(0, 10)}.csv`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-    window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
+    downloadBlob(blob, `helscoop_combined_bom_${new Date().toISOString().slice(0, 10)}.csv`);
     toast(t("bomAggregate.exported"), "success");
   }
 

--- a/web/src/components/ScenarioRenderPanel.tsx
+++ b/web/src/components/ScenarioRenderPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "rea
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { useToast } from "@/components/ToastProvider";
 import { useTranslation } from "@/components/LocaleProvider";
+import { downloadDataUrl } from "@/lib/download";
 import {
   PRESENTATION_PRESETS,
   sanitizePresentationFilename,
@@ -130,13 +131,6 @@ function nextFrame(): Promise<void> {
     }
     setTimeout(resolve, 0);
   });
-}
-
-function downloadDataUrl(dataUrl: string, filename: string) {
-  const link = document.createElement("a");
-  link.download = filename;
-  link.href = dataUrl;
-  link.click();
 }
 
 function loadImage(dataUrl: string): Promise<HTMLImageElement> {

--- a/web/src/components/ScreenshotPopover.tsx
+++ b/web/src/components/ScreenshotPopover.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "@/components/LocaleProvider";
 import { useToast } from "@/components/ToastProvider";
 import { copyImageBlobToClipboard, copyTextToClipboard } from "@/lib/clipboard";
+import { downloadDataUrl } from "@/lib/download";
 
 interface ScreenshotPopoverProps {
   /** Base64 data URL of the captured screenshot */
@@ -65,10 +66,7 @@ export default function ScreenshotPopover({
     if (!imageDataUrl) return;
     const safeName = (projectName || "screenshot").replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_-]/g, "");
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-    const link = document.createElement("a");
-    link.download = `helscoop-${safeName}-${timestamp}.png`;
-    link.href = imageDataUrl;
-    link.click();
+    downloadDataUrl(imageDataUrl, `helscoop-${safeName}-${timestamp}.png`);
   }, [imageDataUrl, projectName]);
 
   const handleCopyToClipboard = useCallback(async () => {

--- a/web/src/components/SharePresentationPanel.tsx
+++ b/web/src/components/SharePresentationPanel.tsx
@@ -12,6 +12,7 @@ import {
   type PresentationPresetId,
 } from "@/lib/presentation-export";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { downloadDataUrl } from "@/lib/download";
 import type { BomItem } from "@/types";
 import type { ViewportPresentationApi } from "@/components/Viewport3D";
 
@@ -22,13 +23,6 @@ interface SharePresentationPanelProps {
   captureApiRef: React.MutableRefObject<ViewportPresentationApi | null>;
   onCopySuccess: () => void;
   onCopyError: () => void;
-}
-
-function downloadDataUrl(dataUrl: string, filename: string) {
-  const link = document.createElement("a");
-  link.download = filename;
-  link.href = dataUrl;
-  link.click();
 }
 
 export default function SharePresentationPanel({

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -14,6 +14,7 @@ import ViewportContextMenu, { type ContextMenuItem } from "@/components/Viewport
 import ScreenshotPopover from "@/components/ScreenshotPopover";
 import { shortcutLabel } from "@/lib/shortcut-label";
 import { getPresentationPreset, type PresentationPresetId } from "@/lib/presentation-export";
+import { downloadDataUrl } from "@/lib/download";
 import { useAmbientSound } from "@/hooks/useAmbientSound";
 import ViewCube from "@/components/ViewCube";
 import Minimap from "@/components/Minimap";
@@ -2799,10 +2800,7 @@ export default function Viewport3D({
     ctx.textAlign = "right";
     ctx.textBaseline = "bottom";
     ctx.fillText("helscoop.fi", canvas.width - fontSize, canvas.height - fontSize * 0.6);
-    const link = document.createElement("a");
-    link.download = "helscoop-screenshot.png";
-    link.href = offscreen.toDataURL("image/png");
-    link.click();
+    downloadDataUrl(offscreen.toDataURL("image/png"), "helscoop-screenshot.png");
   }, []);
 
   const contextMenuItems: ContextMenuItem[] = [

--- a/web/src/lib/__tests__/download.test.ts
+++ b/web/src/lib/__tests__/download.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { downloadBlob, downloadDataUrl } from "@/lib/download";
+
+describe("download helpers", () => {
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: originalCreateObjectUrl,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: originalRevokeObjectUrl,
+    });
+    document.body.innerHTML = "";
+  });
+
+  it("downloads data URLs with a temporary attached anchor", () => {
+    let clickedAnchor: HTMLAnchorElement | null = null;
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (this: HTMLAnchorElement) {
+      clickedAnchor = this;
+    });
+
+    expect(downloadDataUrl("data:image/png;base64,abc", "scene.png")).toBe(true);
+
+    expect(clickedAnchor).not.toBeNull();
+    const anchor = clickedAnchor as unknown as HTMLAnchorElement;
+    expect(anchor.download).toBe("scene.png");
+    expect(anchor.href).toBe("data:image/png;base64,abc");
+    expect(document.querySelector("a[download]")).toBeNull();
+  });
+
+  it("keeps blob URLs alive long enough for browser download managers", () => {
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:download"),
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    expect(downloadBlob(new Blob(["csv"], { type: "text/csv" }), "bom.csv")).toBe(true);
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(29_999);
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:download");
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -47,6 +47,7 @@ import type {
   SharePreviewState,
 } from "@/types";
 import { safeGetLocalStorageItem, safeRemoveLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
+import { downloadBlob } from "@/lib/download";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
 const SESSION_ACTIVE_KEY = "helscoop_session_active";
@@ -123,21 +124,6 @@ export function hasAuthSession(): boolean {
     return false;
   }
   return true;
-}
-
-function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  a.style.display = "none";
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-
-  // Keep the object URL alive long enough for browser download managers and
-  // Playwright's download observer to resolve the blob-backed navigation.
-  window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
 }
 
 function authHeaders(extra?: Record<string, string>): Record<string, string> {

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -1,0 +1,50 @@
+const OBJECT_URL_REVOKE_DELAY_MS = 30_000;
+
+export function downloadDataUrl(dataUrl: string, filename: string): boolean {
+  return clickDownloadLink(dataUrl, filename);
+}
+
+export function downloadBlob(blob: Blob, filename: string): boolean {
+  if (typeof URL === "undefined" || typeof URL.createObjectURL !== "function") {
+    return false;
+  }
+
+  let url: string;
+  try {
+    url = URL.createObjectURL(blob);
+  } catch {
+    return false;
+  }
+  const started = clickDownloadLink(url, filename);
+
+  if (typeof URL.revokeObjectURL === "function") {
+    const revoke = () => URL.revokeObjectURL(url);
+    if (typeof window !== "undefined" && typeof window.setTimeout === "function") {
+      window.setTimeout(revoke, OBJECT_URL_REVOKE_DELAY_MS);
+    } else {
+      setTimeout(revoke, OBJECT_URL_REVOKE_DELAY_MS);
+    }
+  }
+
+  return started;
+}
+
+function clickDownloadLink(href: string, filename: string): boolean {
+  if (typeof document === "undefined" || !document.body) return false;
+
+  const link = document.createElement("a");
+  link.href = href;
+  link.download = filename;
+  link.rel = "noopener";
+  link.style.display = "none";
+
+  document.body.appendChild(link);
+  try {
+    link.click();
+    return true;
+  } catch {
+    return false;
+  } finally {
+    link.remove();
+  }
+}


### PR DESCRIPTION
## Summary
- add shared browser download helpers that append temporary anchors before clicking
- keep blob object URLs alive briefly before revocation so browser download managers and Playwright observers can resolve reliably
- replace scattered one-off download code across exports, screenshots, share panels, BOM, settings, and shared views

## Validation
- web: npm test
- web: npm run build
- api: npm test
- api: npm run build
- scraper: npm test && npm run typecheck
- e2e: E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@localhost:55438/helscoop E2E_API_PORT=3359 E2E_WEB_PORT=3360 TEST_API_URL=http://localhost:3359 TEST_WEB_URL=http://localhost:3360 npm run test:local (170 passed)