### PR TITLE
Harden chat and draft storage recovery

### DIFF
--- a/web/src/__tests__/ChatPanel.test.tsx
+++ b/web/src/__tests__/ChatPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
@@ -75,6 +75,11 @@ beforeEach(() => {
   mockToast.mockReset();
   mockTrack.mockReset();
   mockChat.mockReset();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
   localStorage.clear();
 });
 
@@ -426,6 +431,58 @@ describe("ChatPanel — localStorage persistence", () => {
     render(<ChatPanel {...defaultProps} projectId="proj-2" />);
     expect(screen.getByText("hello")).toBeInTheDocument();
     expect(screen.getByText("world")).toBeInTheDocument();
+  });
+
+  it("ignores and clears invalid stored messages instead of crashing", () => {
+    localStorage.setItem("helscoop-chat-broken", JSON.stringify({ role: "user", content: "not an array" }));
+
+    render(<ChatPanel {...defaultProps} projectId="broken" />);
+
+    expect(screen.getByLabelText("editor.chatInputLabel")).toBeInTheDocument();
+    expect(localStorage.getItem("helscoop-chat-broken")).toBeNull();
+  });
+
+  it("filters malformed stored message entries", () => {
+    localStorage.setItem(
+      "helscoop-chat-partial",
+      JSON.stringify([
+        { role: "user", content: "keep me" },
+        { role: "assistant", content: 42 },
+        { role: "system", content: "drop me" },
+      ]),
+    );
+
+    render(<ChatPanel {...defaultProps} projectId="partial" />);
+
+    expect(screen.getByText("keep me")).toBeInTheDocument();
+    expect(screen.queryByText("drop me")).not.toBeInTheDocument();
+    expect(JSON.parse(localStorage.getItem("helscoop-chat-partial")!)).toEqual([{ role: "user", content: "keep me" }]);
+  });
+
+  it("survives unavailable localStorage", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    render(<ChatPanel {...defaultProps} projectId="blocked" />);
+
+    expect(screen.getByLabelText("editor.chatInputLabel")).toBeInTheDocument();
+  });
+
+  it("reloads chat history when projectId changes without leaking the previous project", async () => {
+    localStorage.setItem("helscoop-chat-proj-a", JSON.stringify([{ role: "user", content: "project a" }]));
+    localStorage.setItem("helscoop-chat-proj-b", JSON.stringify([{ role: "assistant", content: "project b" }]));
+
+    const { rerender } = render(<ChatPanel {...defaultProps} projectId="proj-a" />);
+    expect(screen.getByText("project a")).toBeInTheDocument();
+
+    rerender(<ChatPanel {...defaultProps} projectId="proj-b" />);
+
+    await waitFor(() => {
+      expect(screen.queryByText("project a")).not.toBeInTheDocument();
+      expect(screen.getByText("project b")).toBeInTheDocument();
+    });
+    expect(JSON.parse(localStorage.getItem("helscoop-chat-proj-b")!)).toEqual([{ role: "assistant", content: "project b" }]);
   });
 
   it("does not persist when projectId is not set", async () => {

--- a/web/src/__tests__/useDraftRecovery.test.ts
+++ b/web/src/__tests__/useDraftRecovery.test.ts
@@ -31,6 +31,7 @@ describe("useDraftRecovery", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     localStorage.clear();
   });
 
@@ -68,6 +69,19 @@ describe("useDraftRecovery", () => {
     const { result } = renderHook(() =>
       useDraftRecovery(null, SAVED, SAVED, onRestore)
     );
+    expect(result.current.hasDraft).toBe(false);
+  });
+
+  it("continues when localStorage reads are blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    const onRestore = vi.fn();
+    const { result } = renderHook(() =>
+      useDraftRecovery(PROJECT_ID, SAVED, SAVED, onRestore)
+    );
+
     expect(result.current.hasDraft).toBe(false);
   });
 
@@ -195,6 +209,31 @@ describe("useDraftRecovery", () => {
     expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
   });
 
+  it("continues when localStorage writes are blocked", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    const onRestore = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ current, saved }) =>
+        useDraftRecovery(PROJECT_ID, current, saved, onRestore),
+      { initialProps: { current: SAVED, saved: SAVED } }
+    );
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    rerender({ current: EDITED, saved: SAVED });
+
+    await act(async () => {
+      vi.advanceTimersByTime(DRAFT_DEBOUNCE_MS + 100);
+    });
+
+    expect(onRestore).not.toHaveBeenCalled();
+  });
+
   it("clears localStorage immediately (no debounce) when currentScript reverts to savedScript", async () => {
     localStorage.setItem(DRAFT_KEY, EDITED);
     const onRestore = vi.fn();
@@ -215,6 +254,24 @@ describe("useDraftRecovery", () => {
 
     // The removal should happen synchronously (no timer advance needed)
     expect(localStorage.getItem(DRAFT_KEY)).toBeNull();
+  });
+
+  it("continues when localStorage removals are blocked", () => {
+    localStorage.setItem(DRAFT_KEY, EDITED);
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+    const onRestore = vi.fn();
+    const { result } = renderHook(() =>
+      useDraftRecovery(PROJECT_ID, SAVED, SAVED, onRestore)
+    );
+
+    act(() => {
+      result.current.discard();
+      result.current.clearDraft();
+    });
+
+    expect(result.current.hasDraft).toBe(false);
   });
 
   // ── projectId change ──────────────────────────────────────────────────────

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -9,6 +9,7 @@ import { useCursorGlow } from "@/hooks/useCursorGlow";
 import { useAmbientSound } from "@/hooks/useAmbientSound";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import { buildSavingsRecommendations } from "@/lib/bom-savings";
+import { safeGetLocalStorageItem, safeRemoveLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 import { countSceneAddCalls } from "@/lib/scene-a11y";
 import { interpretScene } from "@/lib/scene-interpreter";
 import type { ChatMessage, BomItem, Material, ProjectImage } from "@/types";
@@ -80,6 +81,42 @@ function computeSimpleDiff(oldText: string, newText: string): DiffLine[] {
   return result;
 }
 
+function isStoredChatMessage(value: unknown): value is ChatMessage {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<ChatMessage>;
+  return (
+    (candidate.role === "user" || candidate.role === "assistant") &&
+    typeof candidate.content === "string"
+  );
+}
+
+function loadStoredChatMessages(storageKey: string | null): ChatMessage[] {
+  if (!storageKey) return [];
+  const stored = safeGetLocalStorageItem(storageKey);
+  if (!stored) return [];
+
+  try {
+    const parsed = JSON.parse(stored) as unknown;
+    if (!Array.isArray(parsed)) {
+      safeRemoveLocalStorageItem(storageKey);
+      return [];
+    }
+
+    const messages = parsed.filter(isStoredChatMessage);
+    if (messages.length !== parsed.length) {
+      if (messages.length > 0) {
+        safeSetLocalStorageItem(storageKey, JSON.stringify(messages.slice(-50)));
+      } else {
+        safeRemoveLocalStorageItem(storageKey);
+      }
+    }
+    return messages.slice(-50);
+  } catch {
+    safeRemoveLocalStorageItem(storageKey);
+    return [];
+  }
+}
+
 export default function ChatPanel({
   projectId,
   sceneJs,
@@ -107,16 +144,24 @@ export default function ChatPanel({
 }) {
   const glow = useCursorGlow();
   const chatStorageKey = projectId ? `helscoop-chat-${projectId}` : null;
-  const [messages, setMessages] = useState<ChatMessage[]>(() => {
-    if (typeof window === "undefined" || !chatStorageKey) return [];
-    try {
-      const stored = localStorage.getItem(chatStorageKey);
-      return stored ? JSON.parse(stored) : [];
-    } catch { return []; }
-  });
+  const [messages, setMessages] = useState<ChatMessage[]>(() => loadStoredChatMessages(chatStorageKey));
+  const loadedChatStorageKeyRef = useRef(chatStorageKey);
+  const skipNextPersistRef = useRef(false);
+
   useEffect(() => {
+    if (loadedChatStorageKeyRef.current === chatStorageKey) return;
+    loadedChatStorageKeyRef.current = chatStorageKey;
+    skipNextPersistRef.current = true;
+    setMessages(loadStoredChatMessages(chatStorageKey));
+  }, [chatStorageKey]);
+
+  useEffect(() => {
+    if (skipNextPersistRef.current) {
+      skipNextPersistRef.current = false;
+      return;
+    }
     if (!chatStorageKey || messages.length === 0) return;
-    try { localStorage.setItem(chatStorageKey, JSON.stringify(messages.slice(-50))); } catch {}
+    safeSetLocalStorageItem(chatStorageKey, JSON.stringify(messages.slice(-50)));
   }, [messages, chatStorageKey]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);

--- a/web/src/hooks/useDraftRecovery.ts
+++ b/web/src/hooks/useDraftRecovery.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
+import { safeGetLocalStorageItem, safeRemoveLocalStorageItem, safeSetLocalStorageItem } from "@/lib/browser-storage";
 
 const DRAFT_DEBOUNCE_MS = 2000;
 
@@ -41,17 +42,13 @@ export function useDraftRecovery(
     if (!projectId) return;
     initialCheckDoneRef.current = false;
 
-    try {
-      const stored = localStorage.getItem(draftKey(projectId));
-      if (stored && stored !== savedScript) {
-        draftContentRef.current = stored;
-        setHasDraft(true);
-      } else {
-        draftContentRef.current = null;
-        setHasDraft(false);
-      }
-    } catch {
-      // localStorage may be unavailable (private browsing, quota, etc.)
+    const stored = safeGetLocalStorageItem(draftKey(projectId));
+    if (stored && stored !== savedScript) {
+      draftContentRef.current = stored;
+      setHasDraft(true);
+    } else {
+      draftContentRef.current = null;
+      setHasDraft(false);
     }
 
     // Mark initial check as done after a tick so the debounced save
@@ -69,21 +66,13 @@ export function useDraftRecovery(
     // If the current script matches the saved version, clear the draft
     if (currentScript === savedScript) {
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      try {
-        localStorage.removeItem(draftKey(projectId));
-      } catch {
-        // ignore
-      }
+      safeRemoveLocalStorageItem(draftKey(projectId));
       return;
     }
 
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      try {
-        localStorage.setItem(draftKey(projectId), currentScript);
-      } catch {
-        // quota exceeded or unavailable — silently ignore
-      }
+      safeSetLocalStorageItem(draftKey(projectId), currentScript);
     }, DRAFT_DEBOUNCE_MS);
 
     return () => {
@@ -101,11 +90,7 @@ export function useDraftRecovery(
 
   const discard = useCallback(() => {
     if (projectId) {
-      try {
-        localStorage.removeItem(draftKey(projectId));
-      } catch {
-        // ignore
-      }
+      safeRemoveLocalStorageItem(draftKey(projectId));
     }
     draftContentRef.current = null;
     setHasDraft(false);
@@ -113,11 +98,7 @@ export function useDraftRecovery(
 
   const clearDraft = useCallback(() => {
     if (projectId) {
-      try {
-        localStorage.removeItem(draftKey(projectId));
-      } catch {
-        // ignore
-      }
+      safeRemoveLocalStorageItem(draftKey(projectId));
     }
     draftContentRef.current = null;
     setHasDraft(false);


### PR DESCRIPTION
## Summary
- validate restored chat history before rendering it
- clear malformed chat storage and avoid carrying messages across project switches
- route draft recovery through safe localStorage helpers so blocked/quota storage does not break editing
- add regression coverage for corrupt, malformed, unavailable, and project-switch storage cases

## Validation
- web: npm test -- src/__tests__/ChatPanel.test.tsx src/__tests__/useDraftRecovery.test.ts src/lib/__tests__/browser-storage.test.ts
- web: npm test
- web: npm run build
- api: npm test
- api: npm run build
- scraper: npm test && npm run typecheck
- e2e: E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@localhost:55439/helscoop E2E_API_PORT=3361 E2E_WEB_PORT=3362 TEST_API_URL=http://localhost:3361 TEST_WEB_URL=http://localhost:3362 npm run test:local (170 passed)