### PR TITLE
Harden collaboration websocket messages

### DIFF
--- a/web/src/hooks/__tests__/useProjectCollaboration.test.ts
+++ b/web/src/hooks/__tests__/useProjectCollaboration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { parseIncomingCollaborationMessage } from "@/hooks/useProjectCollaboration";
+
+const peer = {
+  clientId: "client-1",
+  name: "Matti",
+  color: "#8bc48b",
+  cursor: null,
+  connectedAt: "2026-04-26T18:00:00.000Z",
+};
+
+describe("parseIncomingCollaborationMessage", () => {
+  it("accepts a valid welcome message", () => {
+    expect(parseIncomingCollaborationMessage(JSON.stringify({
+      type: "welcome",
+      self: peer,
+      peers: [{ ...peer, clientId: "client-2" }],
+    }))).toEqual({
+      type: "welcome",
+      self: peer,
+      peers: [{ ...peer, clientId: "client-2" }],
+    });
+  });
+
+  it("accepts peer updates with validated cursor data", () => {
+    expect(parseIncomingCollaborationMessage(JSON.stringify({
+      type: "cursor:update",
+      peer: {
+        ...peer,
+        cursor: { line: 12, column: 4, selectionStart: 120, selectionEnd: 140 },
+      },
+    }))).toEqual({
+      type: "cursor:update",
+      peer: {
+        ...peer,
+        cursor: { line: 12, column: 4, selectionStart: 120, selectionEnd: 140 },
+      },
+    });
+  });
+
+  it("accepts project and BOM update messages", () => {
+    expect(parseIncomingCollaborationMessage(JSON.stringify({
+      type: "project:update",
+      projectId: "project-1",
+      patch: { name: "Updated" },
+      updated_at: "2026-04-26T18:01:00.000Z",
+      sourceClientId: "client-2",
+      sourceName: "Laura",
+    }))).toEqual({
+      type: "project:update",
+      projectId: "project-1",
+      patch: { name: "Updated" },
+      updated_at: "2026-04-26T18:01:00.000Z",
+      sourceClientId: "client-2",
+      sourceName: "Laura",
+    });
+
+    expect(parseIncomingCollaborationMessage(JSON.stringify({
+      type: "bom:update",
+      projectId: "project-1",
+      count: 1,
+      items: [{ material_id: "timber", quantity: 3, unit: "m" }],
+    }))).toEqual({
+      type: "bom:update",
+      projectId: "project-1",
+      count: 1,
+      items: [{ material_id: "timber", quantity: 3, unit: "m" }],
+      sourceClientId: undefined,
+      sourceName: undefined,
+    });
+  });
+
+  it("accepts server error messages", () => {
+    expect(parseIncomingCollaborationMessage(JSON.stringify({
+      type: "error",
+      error: "permission denied",
+    }))).toEqual({ type: "error", error: "permission denied" });
+  });
+
+  it("rejects malformed JSON, binary payloads, and unknown message types", () => {
+    expect(parseIncomingCollaborationMessage("{not valid")).toBeNull();
+    expect(parseIncomingCollaborationMessage(new ArrayBuffer(8))).toBeNull();
+    expect(parseIncomingCollaborationMessage(JSON.stringify({ type: "future:event" }))).toBeNull();
+  });
+
+  it("rejects messages that would otherwise throw in the websocket handler", () => {
+    expect(parseIncomingCollaborationMessage(JSON.stringify({ type: "welcome", peers: [] }))).toBeNull();
+    expect(parseIncomingCollaborationMessage(JSON.stringify({ type: "presence:update" }))).toBeNull();
+    expect(parseIncomingCollaborationMessage(JSON.stringify({ type: "presence:leave", clientId: 42 }))).toBeNull();
+    expect(parseIncomingCollaborationMessage(JSON.stringify({ type: "project:update", projectId: "p1", patch: [] }))).toBeNull();
+    expect(parseIncomingCollaborationMessage(JSON.stringify({
+      type: "bom:update",
+      projectId: "p1",
+      count: 1,
+      items: [{ material_id: "timber", quantity: Number.NaN, unit: "m" }],
+    }))).toBeNull();
+  });
+});

--- a/web/src/hooks/useProjectCollaboration.ts
+++ b/web/src/hooks/useProjectCollaboration.ts
@@ -55,6 +55,123 @@ interface UseProjectCollaborationOptions {
   onBomUpdate?: (event: CollaborationBomUpdateEvent) => void;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isCursor(value: unknown): value is CollaborationCursor {
+  if (!isRecord(value)) return false;
+  return (
+    isFiniteNumber(value.line) &&
+    isFiniteNumber(value.column) &&
+    (value.selectionStart === undefined || isFiniteNumber(value.selectionStart)) &&
+    (value.selectionEnd === undefined || isFiniteNumber(value.selectionEnd))
+  );
+}
+
+function isPeer(value: unknown): value is CollaborationPeer {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.clientId === "string" &&
+    typeof value.name === "string" &&
+    typeof value.color === "string" &&
+    typeof value.connectedAt === "string" &&
+    (value.cursor === null || isCursor(value.cursor))
+  );
+}
+
+function isBomItem(value: unknown): value is CollaborationBomUpdateEvent["items"][number] {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.material_id === "string" &&
+    isFiniteNumber(value.quantity) &&
+    typeof value.unit === "string"
+  );
+}
+
+export function parseIncomingCollaborationMessage(raw: unknown): IncomingMessage | null {
+  if (typeof raw !== "string") return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed) || typeof parsed.type !== "string") return null;
+
+  switch (parsed.type) {
+    case "welcome":
+      if (!isPeer(parsed.self) || !Array.isArray(parsed.peers) || !parsed.peers.every(isPeer)) return null;
+      return { type: "welcome", self: parsed.self, peers: parsed.peers };
+
+    case "presence:join":
+    case "presence:update":
+    case "cursor:update":
+      if (!isPeer(parsed.peer)) return null;
+      return { type: parsed.type, peer: parsed.peer };
+
+    case "presence:leave":
+      if (typeof parsed.clientId !== "string") return null;
+      return { type: "presence:leave", clientId: parsed.clientId };
+
+    case "project:update":
+      if (
+        typeof parsed.projectId !== "string" ||
+        !isRecord(parsed.patch) ||
+        !isOptionalString(parsed.updated_at) ||
+        !isOptionalString(parsed.sourceClientId) ||
+        !isOptionalString(parsed.sourceName)
+      ) {
+        return null;
+      }
+      return {
+        type: "project:update",
+        projectId: parsed.projectId,
+        patch: parsed.patch,
+        updated_at: parsed.updated_at,
+        sourceClientId: parsed.sourceClientId,
+        sourceName: parsed.sourceName,
+      };
+
+    case "bom:update":
+      if (
+        typeof parsed.projectId !== "string" ||
+        !Array.isArray(parsed.items) ||
+        !parsed.items.every(isBomItem) ||
+        !isFiniteNumber(parsed.count) ||
+        !isOptionalString(parsed.sourceClientId) ||
+        !isOptionalString(parsed.sourceName)
+      ) {
+        return null;
+      }
+      return {
+        type: "bom:update",
+        projectId: parsed.projectId,
+        items: parsed.items,
+        count: parsed.count,
+        sourceClientId: parsed.sourceClientId,
+        sourceName: parsed.sourceName,
+      };
+
+    case "error":
+      if (!isOptionalString(parsed.error)) return null;
+      return { type: "error", error: parsed.error };
+
+    default:
+      return null;
+  }
+}
+
 function buildWebSocketUrl(projectId: string, token: string | null, shareToken: string | null, displayName: string | null): string {
   const url = new URL(API_URL, typeof window === "undefined" ? "http://localhost" : window.location.origin);
   url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
@@ -103,8 +220,13 @@ export function useProjectCollaboration({
   const sendMessage = useCallback((payload: Record<string, unknown>) => {
     const socket = socketRef.current;
     if (!socket || socket.readyState !== WebSocket.OPEN) return false;
-    socket.send(JSON.stringify(payload));
-    return true;
+    try {
+      socket.send(JSON.stringify(payload));
+      return true;
+    } catch {
+      setStatus("error");
+      return false;
+    }
   }, []);
 
   const flushCursor = useCallback(() => {
@@ -159,12 +281,8 @@ export function useProjectCollaboration({
       socket.onopen = () => setStatus("connected");
       socket.onerror = () => setStatus("error");
       socket.onmessage = (event) => {
-        let message: IncomingMessage;
-        try {
-          message = JSON.parse(event.data) as IncomingMessage;
-        } catch {
-          return;
-        }
+        const message = parseIncomingCollaborationMessage(event.data);
+        if (!message) return;
 
         if (message.type === "welcome") {
           clientIdRef.current = message.self.clientId;
@@ -194,6 +312,11 @@ export function useProjectCollaboration({
         if (message.type === "bom:update") {
           if (message.sourceClientId === clientIdRef.current) return;
           onBomUpdateRef.current?.(message);
+          return;
+        }
+
+        if (message.type === "error") {
+          setStatus("error");
         }
       };
 


### PR DESCRIPTION
## Summary
- validate collaboration websocket payloads before editor handlers dereference them
- ignore malformed, binary, or unknown realtime messages instead of throwing inside onmessage
- surface server-side collaboration error messages as an error state
- guard outbound websocket sends so transient socket failures do not throw through editor callbacks

## Validation
- web: npm test -- src/hooks/__tests__/useProjectCollaboration.test.ts
- web: npm test
- web: npm run build
- api: npm test
- api: npm run build
- scraper: npm test && npm run typecheck
- e2e: E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@localhost:55441/helscoop E2E_API_PORT=3365 E2E_WEB_PORT=3366 TEST_API_URL=http://localhost:3365 TEST_WEB_URL=http://localhost:3366 npm run test:local (170 passed)

Note: an earlier E2E attempt reached 169/170 and failed only because Playwright could not write screenshots due to ENOSPC. After cleaning generated dependency/artifact caches, the full suite passed.