### PR TITLE
Harden collaboration websocket server

### DIFF
--- a/api/src/__tests__/collaboration.test.ts
+++ b/api/src/__tests__/collaboration.test.ts
@@ -149,4 +149,76 @@ describe("collaboration websocket server", () => {
       sourceName: "Alice",
     });
   });
+
+  it("rejects malformed non-object messages without breaking the room", async () => {
+    const alice = await connectClient(port, "project-1", "Alice");
+    const bob = await connectClient(port, "project-1", "Bob");
+    sockets.push(alice.socket, bob.socket);
+
+    const bobSeesInvalidPayload = waitForMessage<{ type: string; error: string }>(
+      bob.socket,
+      (message) => message.type === "error",
+    );
+
+    bob.socket.send("null");
+
+    await expect(bobSeesInvalidPayload).resolves.toMatchObject({
+      type: "error",
+      error: "Invalid collaboration message",
+    });
+
+    const bobSeesInvalidType = waitForMessage<{ type: string; error: string }>(
+      bob.socket,
+      (message) => message.type === "error",
+    );
+
+    bob.socket.send(JSON.stringify({ type: 42 }));
+
+    await expect(bobSeesInvalidType).resolves.toMatchObject({
+      type: "error",
+      error: "Invalid collaboration message type",
+    });
+
+    const aliceSeesCursor = waitForMessage<{ type: string; peer: { name: string; cursor: { line: number; column: number } } }>(
+      alice.socket,
+      (message) => message.type === "cursor:update",
+    );
+
+    bob.socket.send(JSON.stringify({ type: "cursor:update", cursor: { line: 7, column: 4 } }));
+
+    await expect(aliceSeesCursor).resolves.toMatchObject({
+      type: "cursor:update",
+      peer: { name: "Bob", cursor: { line: 7, column: 4 } },
+    });
+  });
+
+  it("rejects oversized frames before parsing and keeps the client connected", async () => {
+    const alice = await connectClient(port, "project-1", "Alice");
+    const bob = await connectClient(port, "project-1", "Bob");
+    sockets.push(alice.socket, bob.socket);
+
+    const bobSeesOversized = waitForMessage<{ type: string; error: string }>(
+      bob.socket,
+      (message) => message.type === "error",
+    );
+
+    bob.socket.send("x".repeat(529 * 1024));
+
+    await expect(bobSeesOversized).resolves.toMatchObject({
+      type: "error",
+      error: "Collaboration message exceeds maximum size of 528 KB",
+    });
+
+    const aliceSeesPresence = waitForMessage<{ type: string; peer: { name: string } }>(
+      alice.socket,
+      (message) => message.type === "presence:update",
+    );
+
+    bob.socket.send(JSON.stringify({ type: "presence:update", name: "Bobby" }));
+
+    await expect(aliceSeesPresence).resolves.toMatchObject({
+      type: "presence:update",
+      peer: { name: "Bobby" },
+    });
+  });
 });

--- a/api/src/collaboration.ts
+++ b/api/src/collaboration.ts
@@ -9,6 +9,7 @@ import { getAuthCookieToken } from "./session-cookie";
 
 const COLORS = ["#e5a04b", "#7ab3e0", "#8bc48b", "#d4a0e0", "#f0b86a", "#e07a7a"];
 const MAX_SCENE_BYTES = 512 * 1024;
+const MAX_MESSAGE_BYTES = MAX_SCENE_BYTES + 16 * 1024;
 
 interface AuthPayload {
   id?: string;
@@ -70,6 +71,10 @@ function safeName(value: unknown, fallback: string): string {
   return cleaned || fallback;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 function tokenDisplayName(payload: AuthPayload | null, suppliedName: string | null): string {
   if (suppliedName) return suppliedName;
   if (payload?.email) return payload.email.split("@")[0] || "Helscoop user";
@@ -118,7 +123,11 @@ function toPeer(client: CollaborationClient): CollaborationPeer {
 
 function sendJson(socket: WebSocket, payload: object): void {
   if (socket.readyState !== WebSocket.OPEN) return;
-  socket.send(JSON.stringify({ ...payload, sentAt: new Date().toISOString() }));
+  try {
+    socket.send(JSON.stringify({ ...payload, sentAt: new Date().toISOString() }));
+  } catch (err) {
+    logger.warn({ err }, "Failed to send collaboration message");
+  }
 }
 
 function broadcastToRoom(projectId: string, payload: object, exceptClientId?: string): void {
@@ -143,6 +152,19 @@ function removeClient(client: CollaborationClient): void {
     projectId: client.projectId,
     clientId: client.clientId,
   });
+}
+
+function rawDataByteLength(raw: RawData): number {
+  if (Array.isArray(raw)) return raw.reduce((total, chunk) => total + chunk.byteLength, 0);
+  if (typeof raw === "string") return Buffer.byteLength(raw);
+  return raw.byteLength;
+}
+
+function rawDataToString(raw: RawData): string {
+  if (Array.isArray(raw)) return Buffer.concat(raw).toString("utf8");
+  if (typeof raw === "string") return raw;
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString("utf8");
+  return raw.toString("utf8");
 }
 
 async function authorizeProjectAccess(projectId: string, token: string | null, shareToken: string | null) {
@@ -180,11 +202,27 @@ async function authorizeProjectAccess(projectId: string, token: string | null, s
 }
 
 function handleClientMessage(client: CollaborationClient, raw: RawData): void {
-  let message: Record<string, unknown>;
+  if (rawDataByteLength(raw) > MAX_MESSAGE_BYTES) {
+    sendJson(client.socket, { type: "error", error: "Collaboration message exceeds maximum size of 528 KB" });
+    return;
+  }
+
+  let parsed: unknown;
   try {
-    message = JSON.parse(raw.toString()) as Record<string, unknown>;
+    parsed = JSON.parse(rawDataToString(raw));
   } catch {
     sendJson(client.socket, { type: "error", error: "Invalid collaboration message" });
+    return;
+  }
+
+  if (!isRecord(parsed)) {
+    sendJson(client.socket, { type: "error", error: "Invalid collaboration message" });
+    return;
+  }
+
+  const message = parsed;
+  if (typeof message.type !== "string") {
+    sendJson(client.socket, { type: "error", error: "Invalid collaboration message type" });
     return;
   }
 
@@ -281,7 +319,14 @@ async function handleConnection(socket: WebSocket, req: http.IncomingMessage): P
     peer: toPeer(client),
   }, clientId);
 
-  socket.on("message", (raw) => handleClientMessage(client, raw));
+  socket.on("message", (raw) => {
+    try {
+      handleClientMessage(client, raw);
+    } catch (err) {
+      logger.warn({ err, projectId }, "Failed to handle collaboration message");
+      sendJson(socket, { type: "error", error: "Collaboration message failed" });
+    }
+  });
   socket.on("close", () => removeClient(client));
   socket.on("error", (err) => {
     logger.warn({ err, projectId }, "Collaboration socket error");


### PR DESCRIPTION
## Summary
- Closes #1055.
- Reject malformed non-object collaboration websocket frames instead of dereferencing them.
- Reject oversized collaboration frames before JSON parsing.
- Guard outbound websocket sends and message handlers so a bad frame/socket cannot crash the collaboration room.
- Add regression coverage for malformed payloads, invalid message types, oversized frames, and room liveness after rejection.

## Validation
- `cd api && npm test -- src/__tests__/collaboration.test.ts`
- `cd api && npm run build`
- `cd api && npm test`
- `cd web && npm test`
- `cd web && npm run build`
- `cd scraper && npm test && npm run typecheck`
- `cd e2e && E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@127.0.0.1:55442/helscoop E2E_API_PORT=3367 E2E_WEB_PORT=3368 TEST_API_URL=http://localhost:3367 TEST_WEB_URL=http://localhost:3368 npm run test:local`