### PR TITLE
Harden service worker runtime paths

### DIFF
--- a/web/public/push-sw.js
+++ b/web/public/push-sw.js
@@ -1,3 +1,15 @@
+function safeNotificationPath(value) {
+  if (typeof value !== "string" || !value.trim()) return "/";
+
+  try {
+    const url = new URL(value, self.location.origin);
+    if (url.origin !== self.location.origin) return "/";
+    return `${url.pathname}${url.search}${url.hash}` || "/";
+  } catch {
+    return "/";
+  }
+}
+
 self.addEventListener("push", (event) => {
   let payload = {};
   try {
@@ -20,11 +32,12 @@ self.addEventListener("push", (event) => {
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const url = event.notification.data?.url || "/";
+  const url = safeNotificationPath(event.notification.data?.url);
   event.waitUntil(
     clients.matchAll({ type: "window", includeUncontrolled: true }).then((clientList) => {
       for (const client of clientList) {
-        if ("focus" in client && client.url.endsWith(url)) return client.focus();
+        const clientPath = safeNotificationPath(client.url);
+        if ("focus" in client && clientPath === url) return client.focus();
       }
       return clients.openWindow(url);
     }),

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -7,19 +7,46 @@ const STATIC_ASSETS = [
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS))
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(STATIC_ASSETS))
+      .catch(() => undefined)
   );
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+      )
+      .catch(() => undefined)
   );
   self.clients.claim();
 });
+
+function fallbackResponse(request) {
+  return caches
+    .match(request)
+    .then((cached) => cached || caches.match("/"))
+    .then((cached) => cached || Response.error());
+}
+
+function fetchAndRefreshCache(request) {
+  return fetch(request)
+    .then((response) => {
+      if (response.ok) {
+        caches
+          .open(CACHE_NAME)
+          .then((cache) => cache.put(request, response.clone()))
+          .catch(() => undefined);
+      }
+      return response;
+    })
+    .catch(() => fallbackResponse(request));
+}
 
 self.addEventListener("fetch", (event) => {
   const { request } = event;
@@ -32,20 +59,20 @@ self.addEventListener("fetch", (event) => {
 
   if (url.pathname.match(/\.(js|css|woff2?|svg|png|jpg|ico)$/)) {
     event.respondWith(
-      caches.open(CACHE_NAME).then((cache) =>
-        cache.match(request).then((cached) => {
-          const fetched = fetch(request).then((response) => {
-            if (response.ok) cache.put(request, response.clone());
-            return response;
-          });
-          return cached || fetched;
-        })
-      )
+      caches
+        .open(CACHE_NAME)
+        .then((cache) =>
+          cache.match(request).then((cached) => {
+            const refreshed = fetchAndRefreshCache(request);
+            return cached || refreshed;
+          })
+        )
+        .catch(() => fetchAndRefreshCache(request))
     );
     return;
   }
 
   event.respondWith(
-    fetch(request).catch(() => caches.match(request))
+    fetch(request).catch(() => fallbackResponse(request))
   );
 });

--- a/web/src/__tests__/service-workers.test.ts
+++ b/web/src/__tests__/service-workers.test.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import * as vm from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+
+type WorkerHandler = (event: Record<string, unknown>) => void;
+
+interface WorkerHarness {
+  listeners: Record<string, WorkerHandler[]>;
+  self: {
+    skipWaiting: ReturnType<typeof vi.fn>;
+    clients: {
+      claim: ReturnType<typeof vi.fn>;
+      matchAll: ReturnType<typeof vi.fn>;
+      openWindow: ReturnType<typeof vi.fn>;
+    };
+    registration: {
+      showNotification: ReturnType<typeof vi.fn>;
+    };
+    location: {
+      origin: string;
+    };
+  };
+}
+
+function loadWorkerScript(
+  filename: "sw.js" | "push-sw.js",
+  overrides: Record<string, unknown> = {},
+): WorkerHarness {
+  const listeners: Record<string, WorkerHandler[]> = {};
+  const clients = {
+    claim: vi.fn(),
+    matchAll: vi.fn().mockResolvedValue([]),
+    openWindow: vi.fn().mockResolvedValue(undefined),
+  };
+  const self = {
+    skipWaiting: vi.fn(),
+    clients,
+    registration: {
+      showNotification: vi.fn().mockResolvedValue(undefined),
+    },
+    location: {
+      origin: "https://app.test",
+    },
+    addEventListener: vi.fn((type: string, handler: WorkerHandler) => {
+      listeners[type] = [...(listeners[type] || []), handler];
+    }),
+  };
+
+  const source = readFileSync(path.join(process.cwd(), "public", filename), "utf8");
+  vm.runInNewContext(source, {
+    self,
+    clients,
+    caches: {
+      open: vi.fn(),
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
+      match: vi.fn().mockResolvedValue(undefined),
+    },
+    fetch: vi.fn(),
+    URL,
+    Response,
+    Promise,
+    console,
+    ...overrides,
+  });
+
+  return { listeners, self };
+}
+
+describe("service workers", () => {
+  it("does not reject install when static precache writes fail", async () => {
+    const addAll = vi.fn().mockRejectedValue(new Error("cache write failed"));
+    const caches = {
+      open: vi.fn().mockResolvedValue({ addAll }),
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
+      match: vi.fn().mockResolvedValue(undefined),
+    };
+    const { listeners, self } = loadWorkerScript("sw.js", { caches });
+    const pending: Promise<unknown>[] = [];
+
+    listeners.install[0]({
+      waitUntil: (promise: Promise<unknown>) => pending.push(promise),
+    });
+
+    await expect(Promise.all(pending)).resolves.toEqual([undefined]);
+    expect(addAll).toHaveBeenCalledWith(["/", "/manifest.json", "/icon.svg"]);
+    expect(self.skipWaiting).toHaveBeenCalled();
+  });
+
+  it("serves cached static assets when background refresh fails", async () => {
+    const cachedResponse = new Response("cached asset", { status: 200 });
+    const cache = {
+      match: vi.fn().mockResolvedValue(cachedResponse),
+      put: vi.fn().mockRejectedValue(new Error("quota exceeded")),
+    };
+    const caches = {
+      open: vi.fn().mockResolvedValue(cache),
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
+      match: vi.fn().mockResolvedValue(undefined),
+    };
+    const fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    const { listeners } = loadWorkerScript("sw.js", { caches, fetch });
+    let responsePromise: Promise<Response> | null = null;
+
+    listeners.fetch[0]({
+      request: {
+        method: "GET",
+        url: "https://app.test/_next/static/chunks/app.js",
+      },
+      respondWith: (promise: Promise<Response>) => {
+        responsePromise = promise;
+      },
+    });
+
+    await expect(responsePromise).resolves.toBe(cachedResponse);
+    expect(fetch).toHaveBeenCalled();
+  });
+
+  it("keeps app shell registration failures out of unhandled promise paths", () => {
+    const layoutSource = readFileSync(path.join(process.cwd(), "src/app/layout.tsx"), "utf8");
+
+    expect(layoutSource).toContain('navigator.serviceWorker.register("/sw.js").catch(function(){})');
+  });
+
+  it("normalizes external push notification click targets to the app root", async () => {
+    const clients = {
+      claim: vi.fn(),
+      matchAll: vi.fn().mockResolvedValue([]),
+      openWindow: vi.fn().mockResolvedValue(undefined),
+    };
+    const { listeners } = loadWorkerScript("push-sw.js", { clients });
+    const pending: Promise<unknown>[] = [];
+    const close = vi.fn();
+
+    listeners.notificationclick[0]({
+      notification: {
+        close,
+        data: { url: "https://evil.test/phish" },
+      },
+      waitUntil: (promise: Promise<unknown>) => pending.push(promise),
+    });
+
+    await Promise.all(pending);
+    expect(close).toHaveBeenCalled();
+    expect(clients.openWindow).toHaveBeenCalledWith("/");
+  });
+
+  it("focuses an existing same-origin push notification target", async () => {
+    const focus = vi.fn().mockResolvedValue(undefined);
+    const clients = {
+      claim: vi.fn(),
+      matchAll: vi.fn().mockResolvedValue([
+        { url: "https://app.test/project/project-1?tab=bom", focus },
+      ]),
+      openWindow: vi.fn().mockResolvedValue(undefined),
+    };
+    const { listeners } = loadWorkerScript("push-sw.js", { clients });
+    const pending: Promise<unknown>[] = [];
+
+    listeners.notificationclick[0]({
+      notification: {
+        close: vi.fn(),
+        data: { url: "/project/project-1?tab=bom" },
+      },
+      waitUntil: (promise: Promise<unknown>) => pending.push(promise),
+    });
+
+    await Promise.all(pending);
+    expect(focus).toHaveBeenCalled();
+    expect(clients.openWindow).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -104,7 +104,7 @@ export default function RootLayout({
         />
         <script
           dangerouslySetInnerHTML={{
-            __html: `if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js")})}`
+            __html: `if("serviceWorker"in navigator){window.addEventListener("load",function(){navigator.serviceWorker.register("/sw.js").catch(function(){})})}`
           }}
         />
         {/* Google Identity Services — for Google Sign-In */}


### PR DESCRIPTION
## Summary
- Closes #1057.
- Keep `/sw.js` install, activate, runtime cache refresh, and offline fallback paths from surfacing unhandled promise rejections.
- Catch app-shell service worker registration failures in `RootLayout`.
- Normalize push notification click URLs to safe same-origin paths before focusing/opening windows.
- Add VM-based regression tests for service worker install/cache failures and push click target normalization.

## Validation
- `cd web && npm test -- src/__tests__/service-workers.test.ts`
- `cd web && npm test`
- `cd web && npm run build`
- `cd api && npm run build && npm test`
- `cd scraper && npm test && npm run typecheck`
- `cd e2e && E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@127.0.0.1:55443/helscoop E2E_API_PORT=3369 E2E_WEB_PORT=3370 TEST_API_URL=http://localhost:3369 TEST_WEB_URL=http://localhost:3370 npm run test:local`