### PR TITLE
Harden building info parsing in estimate routes

### DIFF
--- a/api/src/__tests__/ara-grant.test.ts
+++ b/api/src/__tests__/ara-grant.test.ts
@@ -417,4 +417,26 @@ describe("GET /ara-grant/package — package generation", () => {
     expect(body.costEstimate.totalWithVat).toBe(0);
     expect(body.eligibility).toBe(false);
   });
+
+  it("uses safe defaults when building_info JSON is malformed", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "proj-1", building_info: "{not valid json" }],
+    } as never);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/ara-grant/package?projectId=proj-1", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+    });
+    expect(res.status).toBe(200);
+
+    const body = res.body as {
+      energyClassBefore: string;
+      costEstimate: { items: unknown[]; totalWithoutVat: number };
+      eligibility: boolean;
+    };
+    expect(body.energyClassBefore).toBe("E");
+    expect(body.costEstimate.items).toEqual([]);
+    expect(body.costEstimate.totalWithoutVat).toBe(0);
+    expect(body.eligibility).toBe(false);
+  });
 });

--- a/api/src/__tests__/carbon.test.ts
+++ b/api/src/__tests__/carbon.test.ts
@@ -350,6 +350,20 @@ describe("GET /carbon/calculate — building area", () => {
     expect(body.limitKg).toBe(68000);
   });
 
+  it("uses default area when stringified building_info is malformed", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "proj-1", building_info: "{not valid json" }],
+    } as never);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/carbon/calculate?projectId=proj-1", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+    });
+    expect(res.status).toBe(200);
+    const body = res.body as { limitKg: number };
+    expect(body.limitKg).toBe(96000);
+  });
+
   it("falls back to legacy 'area' field when area_m2 is absent", async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{ id: "proj-1", building_info: { area: 150 } }],

--- a/api/src/__tests__/huoltokirja.test.ts
+++ b/api/src/__tests__/huoltokirja.test.ts
@@ -235,6 +235,27 @@ describe("GET /huoltokirja/generate", () => {
     expect(doc.buildingInfo).toEqual({});
   });
 
+  it("uses empty building info when stored building_info JSON is malformed", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ id: "p-bad-info", name: "Bad Metadata", building_info: "{not valid json" }],
+    } as never);
+    mockQuery.mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("GET", "/huoltokirja/generate?projectId=p-bad-info", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+    });
+    expect(res.status).toBe(200);
+
+    const doc = res.body as {
+      projectName: string;
+      buildingInfo: Record<string, unknown>;
+      components: unknown[];
+    };
+    expect(doc.projectName).toBe("Bad Metadata");
+    expect(doc.buildingInfo).toEqual({});
+    expect(doc.components).toEqual([]);
+  });
+
   it("parses Finnish-keyed building_info correctly", async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [{

--- a/api/src/building-info.ts
+++ b/api/src/building-info.ts
@@ -1,0 +1,31 @@
+export function parseBuildingInfo(input: unknown): Record<string, unknown> {
+  if (!input) return {};
+  if (typeof input === "object" && !Array.isArray(input)) {
+    return input as Record<string, unknown>;
+  }
+  if (typeof input !== "string") return {};
+
+  try {
+    const parsed = JSON.parse(input);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+export function positiveNumber(value: unknown): number | undefined {
+  const parsed = typeof value === "number" ? value : Number(String(value ?? "").replace(",", "."));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+export function cleanString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  return cleaned || undefined;
+}
+
+export function extractBuildingAreaM2(info: Record<string, unknown>): number | undefined {
+  return positiveNumber(info.area_m2 ?? info.area ?? info.floorAreaM2 ?? info.kerrosala);
+}

--- a/api/src/routes/ara-grant.ts
+++ b/api/src/routes/ara-grant.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { query } from "../db";
 import { requireAuth } from "../auth";
 import { calculateEnergyClass } from "../energy-class";
+import { cleanString, extractBuildingAreaM2, parseBuildingInfo, positiveNumber } from "../building-info";
 
 const router = Router();
 
@@ -76,14 +77,7 @@ router.get("/package", async (req, res) => {
 
   const project = projectResult.rows[0];
 
-  // Parse building info
-  let buildingInfo: Record<string, unknown> = {};
-  if (project.building_info) {
-    buildingInfo =
-      typeof project.building_info === "string"
-        ? JSON.parse(project.building_info)
-        : project.building_info;
-  }
+  const buildingInfo = parseBuildingInfo(project.building_info);
 
   // Fetch BOM items with pricing
   const bomResult = await query(
@@ -143,10 +137,10 @@ router.get("/package", async (req, res) => {
 
   const energyResult = calculateEnergyClass(
     {
-      year_built: buildingInfo.year_built as number | undefined,
-      heating: buildingInfo.heating as string | undefined,
-      area_m2: (buildingInfo.area_m2 ?? buildingInfo.area) as number | undefined,
-      type: buildingInfo.type as string | undefined,
+      year_built: positiveNumber(buildingInfo.year_built ?? buildingInfo.yearBuilt),
+      heating: cleanString(buildingInfo.heating),
+      area_m2: extractBuildingAreaM2(buildingInfo),
+      type: cleanString(buildingInfo.type),
     },
     bom,
   );

--- a/api/src/routes/carbon.ts
+++ b/api/src/routes/carbon.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { query } from "../db";
 import { requireAuth } from "../auth";
+import { extractBuildingAreaM2, parseBuildingInfo } from "../building-info";
 
 const router = Router();
 
@@ -58,20 +59,10 @@ router.get("/calculate", async (req, res) => {
 
   const project = projectResult.rows[0];
 
-  // Extract building area from building_info if available
+  // Extract building area from building_info, preferring schema key area_m2.
   let buildingAreaM2 = 120; // default for typical Finnish single-family
-  if (project.building_info) {
-    const info =
-      typeof project.building_info === "string"
-        ? JSON.parse(project.building_info)
-        : project.building_info;
-    // building_info stores area as area_m2 (see building.ts BuildingInfo interface).
-    // Fall back to legacy "area" field for old projects.
-    const rawArea = info.area_m2 ?? info.area;
-    if (rawArea != null && typeof rawArea === "number" && Number.isFinite(rawArea) && rawArea > 0) {
-      buildingAreaM2 = rawArea;
-    }
-  }
+  const areaFromProject = extractBuildingAreaM2(parseBuildingInfo(project.building_info));
+  if (areaFromProject) buildingAreaM2 = areaFromProject;
 
   // Fetch BOM items with CO₂ factors
   const bomResult = await query(

--- a/api/src/routes/huoltokirja.ts
+++ b/api/src/routes/huoltokirja.ts
@@ -11,6 +11,7 @@
 import { Router } from "express";
 import { query } from "../db";
 import { requireAuth } from "../auth";
+import { cleanString, extractBuildingAreaM2, parseBuildingInfo, positiveNumber } from "../building-info";
 import {
   getScheduleForCategory,
   type MaintenanceSchedule,
@@ -145,20 +146,13 @@ router.get("/generate", async (req, res) => {
       [projectId],
     );
 
-    // Parse building_info (stored as JSONB in the database)
-    let buildingInfo: HuoltokirjaBuildingInfo = {};
-    if (project.building_info) {
-      const raw =
-        typeof project.building_info === "string"
-          ? JSON.parse(project.building_info)
-          : project.building_info;
-      buildingInfo = {
-        address: raw.address ?? raw.osoite ?? undefined,
-        buildingType: raw.buildingType ?? raw.kayttotarkoitus ?? undefined,
-        yearBuilt: raw.yearBuilt ?? raw.valmistumisvuosi ?? undefined,
-        area: raw.area ?? raw.kerrosala ?? undefined,
-      };
-    }
+    const rawBuildingInfo = parseBuildingInfo(project.building_info);
+    const buildingInfo: HuoltokirjaBuildingInfo = {
+      address: cleanString(rawBuildingInfo.address ?? rawBuildingInfo.osoite),
+      buildingType: cleanString(rawBuildingInfo.buildingType ?? rawBuildingInfo.kayttotarkoitus),
+      yearBuilt: positiveNumber(rawBuildingInfo.yearBuilt ?? rawBuildingInfo.year_built ?? rawBuildingInfo.valmistumisvuosi),
+      area: extractBuildingAreaM2(rawBuildingInfo),
+    };
 
     // Map BOM rows to huoltokirja components
     const components: HuoltokirjaComponent[] = bomResult.rows.map((row) => {


### PR DESCRIPTION
Closes #1059

## Summary
- Add a shared `building_info` parser that safely handles malformed JSON, non-object JSON, and legacy area field names.
- Use safe defaults in carbon, ARA grant package, and huoltokirja generation routes instead of throwing on bad persisted metadata.
- Add regression tests for malformed stringified `building_info` in all affected routes.

## Validation
- `cd api && npm test -- src/__tests__/carbon.test.ts src/__tests__/ara-grant.test.ts src/__tests__/huoltokirja.test.ts`
- `cd api && npm run build`
- `cd api && npm test -- src/__tests__/route-audit.test.ts`
- `cd api && npm test` — 71 files passed, 1 skipped; 1520 passed, 23 skipped
- `cd web && npm test` — 172 files passed; 2158 tests passed
- `cd web && npm run build`
- `cd scraper && npm test && npm run typecheck`
- `cd e2e && E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@127.0.0.1:55444/helscoop E2E_API_PORT=3371 E2E_WEB_PORT=3372 TEST_API_URL=http://localhost:3371 TEST_WEB_URL=http://localhost:3372 npm run test:local` — 170 passed
