### PR TITLE
Harden async route error handling

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,6 +13,7 @@
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "express-async-errors": "^3.1.1",
         "express-rate-limit": "^8.3.2",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -4699,6 +4700,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-async-errors": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+      "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+      "license": "ISC",
+      "peerDependencies": {
+        "express": "^4.16.2"
       }
     },
     "node_modules/express-rate-limit": {

--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^8.3.2",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/api/src/__tests__/error-propagation.test.ts
+++ b/api/src/__tests__/error-propagation.test.ts
@@ -116,10 +116,24 @@ beforeEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// 1. Database failure handling in routes with try/catch
+// 1. Database failure handling in explicit and generic route error paths
 // ---------------------------------------------------------------------------
 
-describe("database failure in routes with explicit error handling", () => {
+describe("database failure handling", () => {
+  it("GET /projects forwards async DB failures to the generic error handler", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("connection pool exhausted at pg:5432"));
+
+    const res = await makeRequest("GET", "/projects", {
+      headers: AUTH,
+    });
+
+    expect(res.status).toBe(500);
+    const body = res.body as { error: string };
+    expect(body.error).toBe("Internal server error");
+    expect(body.error).not.toContain("pool");
+    expect(body.error).not.toContain("5432");
+  });
+
   it("PUT /auth/password returns 500 with generic message on DB failure", async () => {
     // First query (user lookup) fails
     mockQuery.mockRejectedValueOnce(new Error("connection pool exhausted at pg:5432"));

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,3 +1,4 @@
+import "express-async-errors";
 import * as Sentry from "@sentry/node";
 import http from "http";
 import express from "express";


### PR DESCRIPTION
Closes #1061

## Summary
- Load `express-async-errors` before API route registration so rejected async Express 4 handlers reach the generic error middleware.
- Add regression coverage for `GET /projects` returning a sanitized JSON 500 when the database query rejects.
- Preserve existing explicit route error handling while preventing ordinary async route failures from becoming hung requests or unhandled rejections.

## Validation
- `cd api && npm test -- src/__tests__/error-propagation.test.ts` — 48 passed
- `cd api && npm test` — 71 files passed, 1 skipped; 1521 passed, 23 skipped
- `cd api && npm audit --audit-level=moderate && npm run build`
- `cd web && npm test` — 172 files passed; 2158 tests passed
- `cd web && npm run build`
- `cd scraper && npm test && npm run typecheck`
- `cd e2e && E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@127.0.0.1:55445/helscoop E2E_API_PORT=3373 E2E_WEB_PORT=3374 TEST_API_URL=http://localhost:3373 TEST_WEB_URL=http://localhost:3374 npm run test:local` — 170 passed
