### PR TITLE
Normalize BOM aggregate building areas

### DIFF
--- a/api/src/__tests__/bom-aggregate.test.ts
+++ b/api/src/__tests__/bom-aggregate.test.ts
@@ -215,4 +215,86 @@ describe("POST /bom/aggregate", () => {
       { project_id: "p1", project_name: "Sauna", quantity: 40, total: 110 },
     ]);
   });
+
+  it("uses shared building area fallbacks for legacy and Finnish project metadata", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "p1",
+            name: "Legacy area",
+            building_info: { area: 125 },
+            estimated_cost: "250",
+            bom_rows: 0,
+          },
+          {
+            id: "p2",
+            name: "Floor area",
+            building_info: JSON.stringify({ floorAreaM2: "80,5" }),
+            estimated_cost: "161",
+            bom_rows: 0,
+          },
+          {
+            id: "p3",
+            name: "Finnish area",
+            building_info: { kerrosala: 50 },
+            estimated_cost: "75",
+            bom_rows: 0,
+          },
+        ],
+      } as never)
+      .mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("POST", "/bom/aggregate", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { project_ids: ["p1", "p2", "p3"] },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      projects: Array<{ id: string; area_m2: number | null; cost_per_m2: number | null }>;
+    };
+    expect(body.projects).toEqual([
+      expect.objectContaining({ id: "p1", area_m2: 125, cost_per_m2: 2 }),
+      expect.objectContaining({ id: "p2", area_m2: 80.5, cost_per_m2: 2 }),
+      expect.objectContaining({ id: "p3", area_m2: 50, cost_per_m2: 1.5 }),
+    ]);
+  });
+
+  it("keeps aggregate summaries available when stored building_info is malformed", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "p1",
+            name: "Bad Metadata",
+            building_info: "{not valid json",
+            estimated_cost: "250",
+            bom_rows: 0,
+          },
+          {
+            id: "p2",
+            name: "Missing Metadata",
+            building_info: null,
+            estimated_cost: "180",
+            bom_rows: 0,
+          },
+        ],
+      } as never)
+      .mockResolvedValueOnce({ rows: [] } as never);
+
+    const res = await makeRequest("POST", "/bom/aggregate", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: { project_ids: ["p1", "p2"] },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      projects: Array<{ id: string; area_m2: number | null; cost_per_m2: number | null }>;
+    };
+    expect(body.projects).toEqual([
+      expect.objectContaining({ id: "p1", area_m2: null, cost_per_m2: null }),
+      expect.objectContaining({ id: "p2", area_m2: null, cost_per_m2: null }),
+    ]);
+  });
 });

--- a/api/src/routes/bom.ts
+++ b/api/src/routes/bom.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { query } from "../db";
 import { requireAuth } from "../auth";
 import { requirePermission } from "../permissions";
+import { extractBuildingAreaM2, parseBuildingInfo } from "../building-info";
 
 const router = Router();
 
@@ -43,20 +44,6 @@ interface AggregatedItem {
     estimated_savings_eur: number;
     note: string;
   } | null;
-}
-
-function extractAreaM2(buildingInfo: unknown): number | null {
-  if (typeof buildingInfo === "string") {
-    try {
-      return extractAreaM2(JSON.parse(buildingInfo));
-    } catch {
-      return null;
-    }
-  }
-  if (!buildingInfo || typeof buildingInfo !== "object") return null;
-  const rawArea = (buildingInfo as { area_m2?: unknown }).area_m2;
-  const area = Number(rawArea);
-  return Number.isFinite(area) && area > 0 ? area : null;
 }
 
 function normalizeProjectIds(input: unknown): string[] {
@@ -203,7 +190,7 @@ router.post("/aggregate", requireAuth, requirePermission("project:read_own"), as
     bom_rows: string | number;
   }) => {
     const estimatedCost = roundMoney(Number(project.estimated_cost) || 0);
-    const areaM2 = extractAreaM2(project.building_info);
+    const areaM2 = extractBuildingAreaM2(parseBuildingInfo(project.building_info)) ?? null;
     return {
       id: project.id,
       name: project.name,


### PR DESCRIPTION
## Summary
- closes #1063
- reuse the shared building-info parser for BOM aggregate project summaries
- cover legacy area, floorAreaM2, Finnish kerrosala, comma decimals, null, and malformed metadata

## Validation
- api: npm test -- src/__tests__/bom-aggregate.test.ts
- api: npm run build
- api: npm audit --audit-level=moderate
- api: npm test
- web: npm test
- web: npm run build
- scraper: npm test
- scraper: npm run typecheck
- e2e: npm run test:local with isolated Postgres, 170 passed