### PR TITLE
Harden project reloads and viewport stability

### DIFF
--- a/api/src/__tests__/quantity-takeoff.test.ts
+++ b/api/src/__tests__/quantity-takeoff.test.ts
@@ -189,4 +189,37 @@ describe("POST /quantity-takeoff/projects/:projectId/analyze", () => {
       bomLineCount: body.bom_suggestions.length,
     }));
   });
+
+  it("infers drawing scale from shared building area fallbacks", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "proj-1",
+          name: "Legacy metadata project",
+          building_info: JSON.stringify({ floorAreaM2: "160,5", floors: "2", type: "omakotitalo" }),
+        }],
+      } as never)
+      .mockResolvedValueOnce({ rows: materialRows } as never);
+
+    const res = await makeRequest("POST", "/quantity-takeoff/projects/proj-1/analyze", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: {
+        drawings: [drawing],
+        options: {
+          floor_label: "1. kerros",
+          notes: "no explicit dimensions provided",
+        },
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      drawing_context: { floor_area_m2: number; scale_source: string };
+      bom_suggestions: { quantity: number }[];
+    };
+    expect(body.drawing_context.scale_source).toBe("building_area");
+    expect(body.drawing_context.floor_area_m2).toBeGreaterThan(79);
+    expect(body.drawing_context.floor_area_m2).toBeLessThan(81);
+    expect(body.bom_suggestions.every((item) => item.quantity > 0)).toBe(true);
+  });
 });

--- a/api/src/__tests__/room-scan.test.ts
+++ b/api/src/__tests__/room-scan.test.ts
@@ -135,6 +135,10 @@ function scanDataUrl(text: string) {
   return `data:model/vnd.usd;base64,${Buffer.from(text).toString("base64")}`;
 }
 
+function jsonScanDataUrl(value: unknown) {
+  return `data:application/json;base64,${Buffer.from(JSON.stringify(value)).toString("base64")}`;
+}
+
 async function usdzDataUrl(text: string) {
   const zip = new JSZip();
   zip.file("RoomPlanExport.usda", text);
@@ -265,5 +269,42 @@ describe("POST /room-scan/projects/:projectId/import", () => {
     expect(body.source_detail).toContain("RoomPlanExport.usda");
     expect(body.quality.parser).toBe("roomplan_text");
     expect(body.rooms).toHaveLength(2);
+  });
+
+  it("uses shared building area fallbacks when exact scan geometry is unavailable", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "proj-1",
+          name: "Fallback scan",
+          building_info: { kerrosala: "96,5", floors: 1, type: "omakotitalo" },
+        }],
+      } as never)
+      .mockResolvedValueOnce({ rows: materialRows } as never);
+
+    const res = await makeRequest("POST", "/room-scan/projects/proj-1/import", {
+      headers: { Authorization: `Bearer ${authToken()}` },
+      body: {
+        scans: [{
+          name: "fallback-roomplan.json",
+          mime_type: "application/json",
+          size: 200,
+          data_url: jsonScanDataUrl({ rooms: [], walls: [], openings: [] }),
+        }],
+      },
+    });
+
+    expect(res.status).toBe(200);
+    const body = res.body as {
+      floor_area_m2: number;
+      quality: { parser: string; warnings: string[] };
+      bom_suggestions: { material_id: string; quantity: number }[];
+    };
+    expect(body.quality.parser).toBe("fallback");
+    expect(body.quality.warnings.join(" ")).toContain("building area");
+    expect(body.floor_area_m2).toBeGreaterThan(95);
+    expect(body.floor_area_m2).toBeLessThan(98);
+    expect(body.bom_suggestions.map((item) => item.material_id)).toContain("osb_18mm");
+    expect(body.bom_suggestions.every((item) => item.quantity > 0)).toBe(true);
   });
 });

--- a/api/src/routes/quantity-takeoff.ts
+++ b/api/src/routes/quantity-takeoff.ts
@@ -9,6 +9,7 @@ import {
   deductCreditsForFeature,
   type InsufficientCreditsBody,
 } from "../entitlements";
+import { extractBuildingAreaM2, parseBuildingInfo as parseSharedBuildingInfo } from "../building-info";
 
 const router = Router();
 
@@ -104,15 +105,13 @@ function positiveNumber(value: unknown): number | undefined {
 }
 
 function parseBuildingInfo(value: unknown): BuildingContext {
-  if (typeof value === "string") {
-    try {
-      return parseBuildingInfo(JSON.parse(value));
-    } catch {
-      return {};
-    }
-  }
-  if (!value || typeof value !== "object") return {};
-  return value as BuildingContext;
+  const parsed = parseSharedBuildingInfo(value);
+  const normalized = { ...parsed } as BuildingContext;
+  const areaM2 = extractBuildingAreaM2(parsed);
+  if (areaM2 !== undefined) normalized.area_m2 = areaM2;
+  const floors = positiveNumber(parsed.floors);
+  if (floors !== undefined) normalized.floors = floors;
+  return normalized;
 }
 
 function normalizeText(value: string): string {

--- a/api/src/routes/room-scan.ts
+++ b/api/src/routes/room-scan.ts
@@ -16,6 +16,7 @@ import {
   type RoomScanFileInput,
   type RoomScanImportOptions,
 } from "../room-scan-parser";
+import { extractBuildingAreaM2, parseBuildingInfo as parseSharedBuildingInfo } from "../building-info";
 
 const router = Router();
 
@@ -52,15 +53,13 @@ function positiveNumber(value: unknown): number | undefined {
 }
 
 function parseBuildingInfo(value: unknown): RoomScanBuildingContext {
-  if (typeof value === "string") {
-    try {
-      return parseBuildingInfo(JSON.parse(value));
-    } catch {
-      return {};
-    }
-  }
-  if (!value || typeof value !== "object") return {};
-  return value as RoomScanBuildingContext;
+  const parsed = parseSharedBuildingInfo(value);
+  const normalized = { ...parsed } as RoomScanBuildingContext;
+  const areaM2 = extractBuildingAreaM2(parsed);
+  if (areaM2 !== undefined) normalized.area_m2 = areaM2;
+  const floors = positiveNumber(parsed.floors);
+  if (floors !== undefined) normalized.floors = floors;
+  return normalized;
 }
 
 function normalizeScans(input: unknown): RoomScanFileInput[] {

--- a/e2e/tests/viewport-rendering.spec.ts
+++ b/e2e/tests/viewport-rendering.spec.ts
@@ -152,13 +152,12 @@ scene.add(roof2, { material: "roofing", color: [0.35, 0.32, 0.30] });
     });
     const project = await res.json();
 
-    await page.goto(`/project/${project.id}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
+    await page.goto(`/project/${project.id}`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByLabel(/project name/i)).toHaveValue("Error Test", { timeout: 15_000 });
 
     // Should show error indicator
     await expect(
       page.getByText(/virhe|error/i).first()
-    ).toBeVisible({ timeout: 10_000 });
+    ).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/e2e/tests/visual-regression.spec.ts
+++ b/e2e/tests/visual-regression.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Locator } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import { inflateSync } from "node:zlib";
 import { registerUser, loginViaUI, createProjectViaAPI, mainViewportCanvas } from "./helpers";
 
@@ -113,7 +113,7 @@ function decodePng(buffer: Buffer): DecodedPng {
 }
 
 async function expectCanvasToHaveRenderedContent(canvas: Locator) {
-  const image = decodePng(await canvas.screenshot());
+  const image = decodePng(await captureCanvasPng(canvas));
   const totalPixels = image.width * image.height;
   const stride = Math.max(1, Math.floor(totalPixels / 10_000));
   const quantizedColors = new Set<string>();
@@ -144,6 +144,26 @@ async function expectCanvasToHaveRenderedContent(canvas: Locator) {
   expect(maxLuma - minLuma).toBeGreaterThan(10);
 }
 
+async function captureCanvasPng(canvas: Locator): Promise<Buffer> {
+  const dataUrl = await canvas.evaluate(async (node) => {
+    const target = node as HTMLCanvasElement;
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+    return target.toDataURL("image/png");
+  });
+  expect(dataUrl.startsWith("data:image/png;base64,")).toBe(true);
+  return Buffer.from(dataUrl.replace(/^data:image\/png;base64,/, ""), "base64");
+}
+
+async function openProjectViewport(page: Page, projectId: string, renderDelayMs = 1_000): Promise<Locator> {
+  await page.goto(`/project/${projectId}`, { waitUntil: "domcontentloaded" });
+  const canvas = mainViewportCanvas(page);
+  await expect(canvas).toBeVisible({ timeout: 20_000 });
+  await page.waitForTimeout(renderDelayMs);
+  return canvas;
+}
+
 test.describe("3D Viewport — Visual Regression", () => {
   let user: { email: string; password: string; name: string; token: string };
 
@@ -161,12 +181,7 @@ test.describe("3D Viewport — Visual Regression", () => {
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(3000);
-    await page.waitForLoadState("networkidle");
-
-    const canvas = mainViewportCanvas(page);
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
+    const canvas = await openProjectViewport(page, projectId, 1_500);
 
     const box = await canvas.boundingBox();
     expect(box).toBeTruthy();
@@ -202,12 +217,7 @@ scene.add(wall4, { material: "lumber" });
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(4000);
-    await page.waitForLoadState("networkidle");
-
-    const canvas = mainViewportCanvas(page);
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
+    const canvas = await openProjectViewport(page, projectId, 1_500);
     await page.screenshot({ path: "test-results/vr-complex-scene.png" });
     await expectCanvasToHaveRenderedContent(canvas);
   });
@@ -220,15 +230,10 @@ scene.add(wall4, { material: "lumber" });
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(3000);
-    await page.waitForLoadState("networkidle");
-
-    const canvas = mainViewportCanvas(page);
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
+    const canvas = await openProjectViewport(page, projectId, 1_500);
 
     // Take solid-mode baseline
-    const solidScreenshot = await canvas.screenshot();
+    const solidScreenshot = await captureCanvasPng(canvas);
 
     // Toggle wireframe mode
     const wireframeBtn = page.locator('button[aria-label*="wireframe" i], button[aria-label*="rautalanka" i], button[data-tooltip*="wireframe" i]');
@@ -237,7 +242,7 @@ scene.add(wall4, { material: "lumber" });
       await page.waitForTimeout(1500);
 
       // Take wireframe screenshot
-      const wireframeScreenshot = await canvas.screenshot();
+      const wireframeScreenshot = await captureCanvasPng(canvas);
 
       // Compare — wireframe should look different
       expect(Buffer.compare(solidScreenshot, wireframeScreenshot)).not.toBe(0);
@@ -254,15 +259,10 @@ scene.add(wall4, { material: "lumber" });
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(3000);
-    await page.waitForLoadState("networkidle");
-
-    const canvas = mainViewportCanvas(page);
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
+    const canvas = await openProjectViewport(page, projectId, 1_500);
 
     // Take default angle baseline
-    const defaultScreenshot = await canvas.screenshot();
+    const defaultScreenshot = await captureCanvasPng(canvas);
 
     // Try camera preset buttons (front, side, top)
     const cameraPresets = page.locator('button[aria-label*="camera" i], button[data-tooltip*="front" i], button[data-tooltip*="edestä" i]');
@@ -270,7 +270,7 @@ scene.add(wall4, { material: "lumber" });
       await cameraPresets.first().click();
       await page.waitForTimeout(1500);
 
-      const presetScreenshot = await canvas.screenshot();
+      const presetScreenshot = await captureCanvasPng(canvas);
       expect(Buffer.compare(defaultScreenshot, presetScreenshot)).not.toBe(0);
     }
 
@@ -292,12 +292,7 @@ scene.add(result, { material: "lumber" });
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(4000);
-    await page.waitForLoadState("networkidle");
-
-    const canvas = mainViewportCanvas(page);
-    await expect(canvas).toBeVisible({ timeout: 15_000 });
+    const canvas = await openProjectViewport(page, projectId, 1_500);
     await page.screenshot({ path: "test-results/vr-boolean-ops.png" });
     await expectCanvasToHaveRenderedContent(canvas);
   });

--- a/web/src/__tests__/api-token-refresh.test.ts
+++ b/web/src/__tests__/api-token-refresh.test.ts
@@ -198,6 +198,42 @@ describe("refresh endpoint returns 401", () => {
   });
 });
 
+describe("cookie-backed refresh without local session hint", () => {
+  it("attempts refresh after 401 even when the in-memory token and local hint are absent", async () => {
+    setToken(null);
+    const now = Math.floor(Date.now() / 1000);
+    let refreshAttempts = 0;
+
+    fetchMock.mockImplementation(async (url: string, opts?: RequestInit) => {
+      const urlStr = url.toString();
+      const authHeader = (opts?.headers as Record<string, string>)?.Authorization || "";
+
+      if (urlStr.includes("/auth/refresh")) {
+        refreshAttempts++;
+        expect(authHeader).toBe("");
+        return jsonResponse(200, {
+          token: "cookie-refreshed-token",
+          token_expires_at: now + 900,
+        });
+      }
+
+      if (urlStr.includes("/projects") && authHeader.includes("cookie-refreshed-token")) {
+        return jsonResponse(200, [{ id: "p1", name: "Recovered" }]);
+      }
+
+      if (urlStr.includes("/projects")) {
+        return jsonResponse(401, { error: "Cookie token expired" }, "Unauthorized");
+      }
+
+      return jsonResponse(500, { error: "Unexpected" });
+    });
+
+    await expect(api.getProjects()).resolves.toEqual([{ id: "p1", name: "Recovered" }]);
+    expect(refreshAttempts).toBe(1);
+    expect(getToken()).toBe("cookie-refreshed-token");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // 4. Proactive refresh when token is about to expire
 // ---------------------------------------------------------------------------

--- a/web/src/app/project/[id]/page.tsx
+++ b/web/src/app/project/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo, type CSSProperties } from "react";
 import dynamic from "next/dynamic";
 import { useParams, useRouter } from "next/navigation";
-import { api, hasAuthSession, setToken } from "@/lib/api";
+import { api, setToken } from "@/lib/api";
 import { useToast } from "@/components/ToastProvider";
 import { SkeletonProjectEditor } from "@/components/Skeleton";
 import { useTranslation } from "@/components/LocaleProvider";
@@ -636,10 +636,6 @@ export default function ProjectPage() {
   }, [queueSceneAnnouncement, toast, t]);
 
   useEffect(() => {
-    if (!hasAuthSession()) {
-      router.push("/");
-      return;
-    }
     Promise.all([api.getProject(projectId), api.getMaterials()])
       .then(([proj, mats]) => {
         setProject(proj);
@@ -708,7 +704,6 @@ export default function ProjectPage() {
   }, [projectId, router, toast, t]);
 
   useEffect(() => {
-    if (!hasAuthSession()) return;
     let cancelled = false;
     api.getProjectImages(projectId)
       .then((result) => {
@@ -723,7 +718,6 @@ export default function ProjectPage() {
   }, [projectId]);
 
   useEffect(() => {
-    if (!hasAuthSession()) return;
     let cancelled = false;
     api.getProjectPriceChange(projectId)
       .then((summary) => {

--- a/web/src/components/Viewport3D.tsx
+++ b/web/src/components/Viewport3D.tsx
@@ -1625,10 +1625,15 @@ export default function Viewport3D({
       fillLightRef.current = null;
       groundMeshRef.current = null;
 
+      scene.clear();
+      renderer.setAnimationLoop(null);
       renderer.dispose();
-      if (container.contains(renderer.domElement)) {
-        container.removeChild(renderer.domElement);
+      renderer.forceContextLoss();
+      if (renderer.domElement.parentElement) {
+        renderer.domElement.parentElement.removeChild(renderer.domElement);
       }
+      renderer.domElement.width = 0;
+      renderer.domElement.height = 0;
 
       rendererRef.current = null;
       sceneRef.current = null;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -208,7 +208,6 @@ let refreshPromise: Promise<boolean> | null = null;
  */
 async function refreshAccessToken(): Promise<boolean> {
   const t = getToken();
-  if (!t && !hasAuthSession()) return false;
   try {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -336,7 +335,7 @@ async function apiFetch(path: string, opts?: RequestInit) {
 
     // On 401 for a non-auth endpoint, attempt a single token refresh
     if (res.status === 401 && !isAuthEndpoint) {
-      const refreshed = hasAuthSession() ? await refreshOnce() : false;
+      const refreshed = await refreshOnce();
       if (refreshed) {
         // Retry the original request with the new token
         const retryHeaders: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Normalize project `building_info` before quantity takeoff and RoomPlan import so legacy/shared area keys like `floorAreaM2` and `kerrosala` drive scale fallbacks.
- Let protected project loads recover from HTTP-only cookie sessions by attempting refresh on 401 even when local storage hints are missing.
- Release 3D viewport WebGL resources on unmount and harden visual E2E checks against late-suite canvas screenshot/network-idle stalls.

Closes #1065
Closes #1066
Closes #1067

## Validation
- `cd api && npm test` — 1525 passed, 23 skipped
- `cd api && npm run build`
- `cd web && npm test` — 2159 passed
- `cd web && npm run build`
- `cd scraper && npm test` — 5 passed
- `cd scraper && npm run typecheck`
- `cd e2e && env E2E_SKIP_DOCKER=1 E2E_DATABASE_URL=postgres://danielzautner@127.0.0.1:55447/helscoop E2E_API_PORT=3377 E2E_WEB_PORT=3378 TEST_API_URL=http://localhost:3377 TEST_WEB_URL=http://localhost:3378 npm run test:local` — 170 passed from a fresh local Postgres database
- `git diff --check`