### PR TITLE
Harden BOM and chat E2E readiness

### DIFF
--- a/e2e/tests/ai-chat.spec.ts
+++ b/e2e/tests/ai-chat.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { registerUser, loginViaUI, createProjectViaAPI, expectMainViewportVisible } from "./helpers";
+import { registerUser, loginViaUI, createProjectViaAPI, expectObjectCount, openProjectEditor } from "./helpers";
 
 test.describe("AI Chat — message, response, and apply flow", () => {
   let user: { email: string; password: string; name: string; token: string };
@@ -18,10 +18,8 @@ test.describe("AI Chat — message, response, and apply flow", () => {
   test("send message, receive response with code, apply to scene", async ({ page }) => {
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openProjectEditor(page, projectId);
+    await expectObjectCount(page, 1);
 
     // 1. Verify chat input is visible
     const chatInput = page.locator(".chat-input, textarea[aria-label]").last();
@@ -35,62 +33,46 @@ test.describe("AI Chat — message, response, and apply flow", () => {
     // 3. Verify user message appears in chat
     await expect(page.getByText("Add a pitched roof to the building")).toBeVisible({ timeout: 5_000 });
 
-    // 4. Wait for AI response (shimmer bar should appear, then response)
-    await page.waitForTimeout(5000);
-
-    // 5. Verify AI response with code
+    // 4. Verify AI response with code and apply it.
     const aiResponse = page.locator(".chat-msg-ai .chat-msg-content").last();
     await expect(aiResponse).toBeVisible({ timeout: 30_000 });
-    const responseText = await aiResponse.textContent();
-    expect(responseText).toBeTruthy();
+    await expect(aiResponse).toContainText(/roof|katto|scene\.add/i, { timeout: 30_000 });
 
-    // 6. Look for Apply button
     const applyBtn = page.locator(".chat-apply-btn").first();
-    if (await applyBtn.isVisible({ timeout: 10_000 }).catch(() => false)) {
-      await applyBtn.click();
+    await expect(applyBtn).toBeVisible({ timeout: 10_000 });
+    await applyBtn.click();
 
-      // Handle confirmation dialog if it appears
-      const confirmDialog = page.locator('[role="dialog"]');
-      if (await confirmDialog.isVisible({ timeout: 3_000 }).catch(() => false)) {
-        const confirmBtn = confirmDialog.getByRole("button", { name: /apply|käytä/i });
-        if (await confirmBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
-          await confirmBtn.click();
-        }
-      }
-
-      await page.waitForTimeout(2000);
+    const confirmDialog = page.locator('[role="dialog"]');
+    if (await confirmDialog.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await confirmDialog.getByRole("button", { name: /apply|aseta|käytä|tillämpa/i }).click();
     }
 
+    await expectObjectCount(page, 3, 20_000);
     await page.screenshot({ path: "test-results/ai-chat-response.png" });
   });
 
   test("suggestion chips populate chat input", async ({ page }) => {
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openProjectEditor(page, projectId);
 
     // Find suggestion chips
     const chips = page.locator(".chat-suggestion-chip");
-    const chipCount = await chips.count().catch(() => 0);
+    await expect(chips.first()).toBeVisible({ timeout: 10_000 });
 
-    if (chipCount > 0) {
-      const chipText = await chips.first().textContent();
-      expect(chipText).toBeTruthy();
+    const chipText = await chips.first().textContent();
+    expect(chipText).toBeTruthy();
 
-      // Click the chip
-      await chips.first().click();
+    // Click the chip
+    await chips.first().click();
 
-      // Verify input is populated
-      const chatInput = page.locator(".chat-input, textarea[aria-label]").last();
-      const inputValue = await chatInput.inputValue();
-      expect(inputValue).toBe(chipText);
+    // Verify input is populated
+    const chatInput = page.locator(".chat-input, textarea[aria-label]").last();
+    const inputValue = await chatInput.inputValue();
+    expect(inputValue).toBe(chipText);
 
-      // Input should be focused
-      await expect(chatInput).toBeFocused();
-    }
+    // Input should be focused
+    await expect(chatInput).toBeFocused();
 
     await page.screenshot({ path: "test-results/ai-chat-chips.png" });
   });
@@ -98,10 +80,7 @@ test.describe("AI Chat — message, response, and apply flow", () => {
   test("chat error shows error message", async ({ page }) => {
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openProjectEditor(page, projectId);
 
     // Intercept the chat API to simulate failure
     await page.route("**/chat", (route) => {
@@ -113,12 +92,10 @@ test.describe("AI Chat — message, response, and apply flow", () => {
     const sendBtn = page.locator('.chat-send-btn, button[aria-label*="lähetä" i], button[aria-label*="send" i]').last();
     await sendBtn.click();
 
-    // Wait for error response
-    await page.waitForTimeout(3000);
-
     // Check for error toast or error message in chat
     const errorIndicator = page.locator('[role="alert"], .chat-msg-ai .chat-msg-content, [class*="toast"]').last();
     await expect(errorIndicator).toBeVisible({ timeout: 10_000 });
+    await expect(errorIndicator).toContainText(/wrong|error|virhe|pieleen|failed/i);
 
     await page.screenshot({ path: "test-results/ai-chat-error.png" });
   });
@@ -126,30 +103,22 @@ test.describe("AI Chat — message, response, and apply flow", () => {
   test("chat message history persists across page navigation", async ({ page }) => {
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openProjectEditor(page, projectId);
 
     // Send a message
     const chatInput = page.locator(".chat-input, textarea[aria-label]").last();
     await chatInput.fill("Add a window to the wall");
     const sendBtn = page.locator('.chat-send-btn, button[aria-label*="lähetä" i], button[aria-label*="send" i]').last();
     await sendBtn.click();
-    await page.waitForTimeout(5000);
+    await expect(page.getByText("Add a window to the wall")).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator(".chat-msg-ai .chat-msg-content").last()).toBeVisible({ timeout: 30_000 });
 
     // Navigate away and back
     await page.goto("/");
-    await page.waitForTimeout(1000);
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
+    await openProjectEditor(page, projectId);
 
     // Verify previous messages are still visible
-    const previousMsg = page.getByText("Add a window to the wall");
-    if (await previousMsg.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      expect(true).toBe(true);
-    }
+    await expect(page.getByText("Add a window to the wall")).toBeVisible({ timeout: 10_000 });
 
     await page.screenshot({ path: "test-results/ai-chat-persistence.png" });
   });

--- a/e2e/tests/bom-crud.spec.ts
+++ b/e2e/tests/bom-crud.spec.ts
@@ -1,128 +1,152 @@
-import { test, expect } from "@playwright/test";
-import { registerUser, loginViaUI, apiUrl, expectMainViewportVisible } from "./helpers";
+import { test, expect, type Page } from "@playwright/test";
+import {
+  createProjectViaAPI,
+  expectBomPanelVisible,
+  loginViaUI,
+  openProjectEditor,
+  registerUser,
+  saveBomViaAPI,
+} from "./helpers";
+
+const SCENE_JS = 'scene.add(box(6,0.2,4), {material:"foundation"});';
+
+async function createProject(page: Page, token: string, name: string): Promise<string> {
+  return createProjectViaAPI(page, token, { name, scene_js: SCENE_JS });
+}
+
+function bomSave(page: Page, projectId: string) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === "PUT" &&
+      response.url().includes(`/projects/${projectId}/bom`) &&
+      response.ok(),
+    { timeout: 15_000 },
+  );
+}
+
+function bomRow(page: Page, material: RegExp) {
+  return page.locator(".bom-item-card").filter({ hasText: material }).first();
+}
+
+async function openBomProject(page: Page, projectId: string) {
+  await openProjectEditor(page, projectId);
+  await expectBomPanelVisible(page);
+}
 
 test.describe("BOM Panel — Item CRUD", () => {
   let user: { email: string; password: string; name: string; token: string };
-  let projectId: string;
 
   test.beforeAll(async ({ browser }) => {
     const page = await browser.newPage();
     user = await registerUser(page, `bom-crud-${Date.now()}`);
-
-    const res = await page.request.post(apiUrl("/projects"), {
-      headers: { Authorization: `Bearer ${user.token}` },
-      data: {
-        name: "BOM CRUD Test",
-        scene_js: 'scene.add(box(6,0.2,4), {material:"foundation"});',
-      },
-    });
-    projectId = (await res.json()).id;
     await page.close();
   });
 
-  test("add a material to the BOM from the material search", async ({ page }) => {
+  test("adds a material to the BOM from the material catalog", async ({ page }) => {
+    const projectId = await createProject(page, user.token, "BOM Add Test");
     await loginViaUI(page, user.email, user.password);
-    await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openBomProject(page, projectId);
 
-    const addBtn = page.getByRole("button", { name: /lisää|add material/i });
-    if (await addBtn.isVisible({ timeout: 10_000 }).catch(() => false)) {
-      await addBtn.click();
+    const materialCard = page.locator(".material-browse-card").filter({ hasText: /48x148/i }).first();
+    await materialCard.scrollIntoViewIfNeeded();
+    await expect(materialCard).toBeVisible({ timeout: 10_000 });
+    await materialCard.click();
 
-      const searchInput = page.getByPlaceholder(/hae materiaali|search material/i);
-      if (await searchInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-        await searchInput.fill("48x98");
-        await page.waitForTimeout(500);
+    const quantityInput = materialCard.locator('input[type="number"]');
+    await expect(quantityInput).toBeVisible({ timeout: 5_000 });
+    await quantityInput.fill("3");
 
-        const result = page.getByText(/48x98/i).first();
-        if (await result.isVisible({ timeout: 5000 }).catch(() => false)) {
-          await result.click();
-          await page.waitForTimeout(500);
+    const save = bomSave(page, projectId);
+    await materialCard.locator("button", { hasText: /lisää|add/i }).click();
+    await save;
 
-          await expect(page.getByText(/48x98/i).first()).toBeVisible({ timeout: 5000 });
-        }
-      }
-    }
-
-    await page.screenshot({ path: "test-results/bom-add-material.png" });
+    const row = bomRow(page, /48x148/i);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row.locator(".bom-item-qty-input")).toHaveValue("3");
   });
 
-  test("edit BOM item quantity inline", async ({ page }) => {
+  test("edits BOM item quantity inline and persists the change", async ({ page }) => {
+    const projectId = await createProject(page, user.token, "BOM Quantity Test");
+    await saveBomViaAPI(page, user.token, projectId, [
+      { material_id: "pine_48x98_c24", quantity: 10, unit: "jm" },
+    ]);
+
     await loginViaUI(page, user.email, user.password);
-    await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openBomProject(page, projectId);
 
-    const qtyInput = page.locator('input[type="number"]').first();
-    if (await qtyInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-      const before = await qtyInput.inputValue();
-      const newQty = String(parseInt(before || "1") + 15);
-      await qtyInput.fill(newQty);
-      await qtyInput.press("Tab");
-      await page.waitForTimeout(1000);
+    const row = bomRow(page, /48\s*x?\s*98|runkopuu|framing timber/i);
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    const quantityInput = row.locator(".bom-item-qty-input");
+    const totalBefore = await row.locator(".bom-item-total").textContent();
 
-      const qtyAfter = page.locator('input[type="number"]').first();
-      await expect(qtyAfter).toHaveValue(newQty, { timeout: 5000 });
-    }
+    const save = bomSave(page, projectId);
+    await quantityInput.fill("25");
+    await quantityInput.blur();
+    await save;
 
-    await page.screenshot({ path: "test-results/bom-edit-qty.png" });
+    await expect(quantityInput).toHaveValue("25");
+    await expect(row.locator(".bom-item-total")).not.toHaveText(totalBefore || "", { timeout: 5_000 });
   });
 
-  test("remove a BOM item and verify it disappears", async ({ page }) => {
+  test("removes a BOM item and leaves the remaining items intact", async ({ page }) => {
+    const projectId = await createProject(page, user.token, "BOM Remove Test");
+    await saveBomViaAPI(page, user.token, projectId, [
+      { material_id: "pine_48x98_c24", quantity: 10, unit: "jm" },
+      { material_id: "osb_9mm", quantity: 5, unit: "m2" },
+    ]);
+
     await loginViaUI(page, user.email, user.password);
-    await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openBomProject(page, projectId);
 
-    const bomItems = page.locator('[data-testid="bom-item"], [class*="bom-row"], [class*="bom-item"]');
-    const countBefore = await bomItems.count().catch(() => 0);
+    const framingRow = bomRow(page, /48\s*x?\s*98|runkopuu|framing timber/i);
+    const osbRow = bomRow(page, /osb/i);
+    await expect(framingRow).toBeVisible({ timeout: 10_000 });
+    await expect(osbRow).toBeVisible({ timeout: 10_000 });
 
-    if (countBefore > 0) {
-      const removeBtn = page.locator('button[aria-label*="poista" i], button[aria-label*="remove" i], button[aria-label*="delete" i]').first();
-      if (await removeBtn.isVisible({ timeout: 5000 }).catch(() => false)) {
-        await removeBtn.click();
-        await page.waitForTimeout(1500);
-
-        const countAfter = await bomItems.count().catch(() => 0);
-        expect(countAfter).toBeLessThan(countBefore);
-      }
+    await framingRow.scrollIntoViewIfNeeded();
+    await framingRow.hover();
+    const removeButton = framingRow.locator(".bom-remove-btn");
+    await expect(removeButton).toBeVisible({ timeout: 5_000 });
+    const save = bomSave(page, projectId);
+    await removeButton.click();
+    const confirmButton = page.locator("button").filter({
+      hasText: /delete|poista|remove|radera|kyllä|yes|vahvista|confirm/i,
+    });
+    if (await confirmButton.first().isVisible({ timeout: 1_500 }).catch(() => false)) {
+      await confirmButton.first().click();
     }
+    await expect(framingRow).not.toBeVisible({ timeout: 5_000 });
+    await expect(osbRow).toBeVisible({ timeout: 5_000 });
+    await save;
 
-    await page.screenshot({ path: "test-results/bom-remove-item.png" });
+    await openBomProject(page, projectId);
+    await expect(bomRow(page, /48\s*x?\s*98|runkopuu|framing timber/i)).not.toBeVisible({ timeout: 5_000 });
+    await expect(bomRow(page, /osb/i)).toBeVisible({ timeout: 5_000 });
   });
 
-  test("BOM total cost updates after quantity change", async ({ page }) => {
+  test("updates visible item and panel totals after quantity change", async ({ page }) => {
+    const projectId = await createProject(page, user.token, "BOM Total Test");
+    await saveBomViaAPI(page, user.token, projectId, [
+      { material_id: "pine_48x148_c24", quantity: 2, unit: "jm" },
+    ]);
+
     await loginViaUI(page, user.email, user.password);
-    await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForTimeout(2000);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openBomProject(page, projectId);
 
-    const totalEl = page.getByText(/yhteensä|total/i).first();
-    const initialTotal = await totalEl.textContent().catch(() => null);
+    const row = bomRow(page, /48\s*x?\s*148/i);
+    await expect(row).toBeVisible({ timeout: 10_000 });
 
-    const qtyInput = page.locator('input[type="number"]').first();
-    if (await qtyInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-      const current = await qtyInput.inputValue();
-      const newQty = String(parseInt(current || "1") + 10);
-      await qtyInput.fill(newQty);
-      await qtyInput.press("Tab");
-      await page.waitForTimeout(1500);
+    const itemTotal = row.locator(".bom-item-total");
+    const itemTotalBefore = await itemTotal.textContent();
+    const panelTextBefore = await page.locator(".editor-bom-panel").textContent();
 
-      const updatedTotal = await totalEl.textContent().catch(() => null);
-      if (initialTotal && updatedTotal) {
-        expect(updatedTotal).not.toBe(initialTotal);
-      }
-    }
+    const save = bomSave(page, projectId);
+    await row.locator(".bom-item-qty-input").fill("20");
+    await row.locator(".bom-item-qty-input").blur();
+    await save;
 
-    await page.screenshot({ path: "test-results/bom-total-update.png" });
+    await expect(itemTotal).not.toHaveText(itemTotalBefore || "", { timeout: 5_000 });
+    const panelTextAfter = await page.locator(".editor-bom-panel").textContent();
+    expect(panelTextAfter).not.toBe(panelTextBefore);
   });
 });

--- a/e2e/tests/bom-interactions.spec.ts
+++ b/e2e/tests/bom-interactions.spec.ts
@@ -5,6 +5,7 @@ import {
   setAuthToken,
   createProjectViaAPI,
   deleteProjectViaAPI,
+  openProjectEditor,
 } from "./helpers";
 
 /**
@@ -25,15 +26,7 @@ async function loginAndNavigateToProject(
 ): Promise<void> {
   const token = await loginUser(page, email, password);
   await setAuthToken(page, token);
-  await page.goto(`/project/${projectId}`);
-  await page.waitForLoadState("networkidle");
-  // Wait for the editor layout to be ready (canvas or BOM panel)
-  await page
-    .locator(".editor-bom-panel, canvas[data-engine^='three.js'][aria-hidden='true']")
-    .first()
-    .waitFor({ state: "visible", timeout: 20_000 });
-  // Extra settle time for React hydration and material fetches
-  await page.waitForTimeout(1500);
+  await openProjectEditor(page, projectId, 20_000);
 }
 
 /** Ensure the BOM panel is visible — toggle it on if needed. */

--- a/e2e/tests/bom-undo.spec.ts
+++ b/e2e/tests/bom-undo.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { registerUser, loginViaUI, createProjectViaAPI, saveBomViaAPI } from "./helpers";
+import { registerUser, loginViaUI, createProjectViaAPI, openProjectEditor, saveBomViaAPI } from "./helpers";
 
 const framingMaterialPattern = /48\s*x?\s*98|framing timber|runkopuu/i;
 const osbMaterialPattern = /osb.*9\s*mm/i;
@@ -26,9 +26,7 @@ test.describe("BOM item removal — undo toast flow", () => {
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(2000);
+    await openProjectEditor(page, projectId);
 
     // Open BOM panel if not visible
     const bomToggle = page.locator('button[aria-label*="BOM" i], button[aria-label*="materiaali" i], button[data-tooltip*="BOM" i]');
@@ -66,7 +64,6 @@ test.describe("BOM item removal — undo toast flow", () => {
 
     // Click undo
     await undoButton.first().click();
-    await page.waitForTimeout(500);
 
     // Verify the item is restored — both items should be visible again
     await expect(page.locator(".bom-item-card").filter({ hasText: framingMaterialPattern }).first()).toBeVisible({ timeout: 5_000 });
@@ -85,9 +82,7 @@ test.describe("BOM item removal — undo toast flow", () => {
 
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15_000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(2000);
+    await openProjectEditor(page, projectId);
 
     // Open BOM panel
     const bomToggle = page.locator('button[aria-label*="BOM" i], button[aria-label*="materiaali" i], button[data-tooltip*="BOM" i]');

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -135,6 +135,18 @@ export async function expectMainViewportVisible(page: Page, timeout = 30_000): P
   await expect(mainViewportCanvas(page)).toBeVisible({ timeout });
 }
 
+export async function openProjectEditor(page: Page, projectId: string, timeout = 30_000): Promise<void> {
+  await page.goto(`/project/${projectId}`, { waitUntil: "domcontentloaded" });
+  await expect(page.getByLabel(/project name/i)).toBeVisible({ timeout });
+  await expectMainViewportVisible(page, timeout);
+}
+
+export async function expectBomPanelVisible(page: Page, timeout = 15_000): Promise<Locator> {
+  const panel = page.locator('[data-testid="bom-panel"], .editor-bom-panel').first();
+  await expect(panel).toBeVisible({ timeout });
+  return panel;
+}
+
 export function objectCountStatus(page: Page, pattern: RegExp = /[1-9]\d*\s*(objects|objektia)/i): Locator {
   return page.locator(".viewport-status, .editor-status-segment").filter({ hasText: pattern }).first();
 }

--- a/e2e/tests/pdf-export.spec.ts
+++ b/e2e/tests/pdf-export.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { apiUrl, createProjectViaAPI, loginViaUI, registerUser, saveBomViaAPI, expectMainViewportVisible } from "./helpers";
+import { apiUrl, createProjectViaAPI, loginViaUI, openProjectEditor, registerUser, saveBomViaAPI } from "./helpers";
 
 test.describe("PDF Export", () => {
   let user: { email: string; password: string; name: string; token: string };
@@ -44,9 +44,7 @@ test.describe("PDF Export", () => {
   test("PDF export button triggers download in editor", async ({ page }) => {
     await loginViaUI(page, user.email, user.password);
     await page.getByText(/omat projektit|my projects/i).waitFor({ state: "visible", timeout: 15000 });
-    await page.goto(`/project/${projectId}`);
-    await page.waitForLoadState("networkidle");
-    await expectMainViewportVisible(page);
+    await openProjectEditor(page, projectId);
 
     const exportTrigger = page.locator('[data-tour="export-btn"] button').first();
     await expect(exportTrigger).toBeEnabled({ timeout: 15_000 });


### PR DESCRIPTION
## Summary
- add shared editor/BOM readiness helpers for E2E navigation
- make BOM CRUD tests deterministic with isolated projects, API-seeded fixtures, save-response waits, and persistence assertions
- harden AI chat, BOM undo/interactions, and PDF export specs by removing fixed sleeps and soft-pass branches

Closes #1069

## Validation
- `cd web && npm test`
- `cd web && npm run build`
- `cd api && npm test`
- `cd api && npm run build`
- `cd scraper && npm test`
- `cd scraper && npm run typecheck`
- focused local E2E: `tests/bom-crud.spec.ts tests/bom-interactions.spec.ts tests/bom-undo.spec.ts tests/ai-chat.spec.ts tests/pdf-export.spec.ts` => 32 passed
- full local E2E on fresh Postgres: `170 passed (21.6m)`
